### PR TITLE
Feat: Extra data for NALD export resources

### DIFF
--- a/src/modules/returns/controller.js
+++ b/src/modules/returns/controller.js
@@ -27,7 +27,7 @@ const getVersions = async (request, h) => {
   }
 
   try {
-    const pagination = { perPage: 2000 };
+    const pagination = Object.assign({ perPage: 2000 }, request.query.pagination);
     const response = await versions.findMany(filter, {}, pagination);
 
     if (response.data.length) {

--- a/src/modules/returns/lib/transformers.js
+++ b/src/modules/returns/lib/transformers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const moment = require('moment');
-const { range, get, pick } = require('lodash');
+const { flow, toUpper, first, range, get, pick } = require('lodash');
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -9,16 +9,27 @@ const getFutureDate = (date, daysForward) => {
   return moment(date, DATE_FORMAT).add(daysForward, 'days').format(DATE_FORMAT);
 };
 
+const getNaldStyleDate = date => moment(date, DATE_FORMAT).format('YYYYMMDD000000');
+
 /**
  * Takes a WRLS return object and converts to a smaller object ready
  * for loading into NALD
  */
 const transformReturn = returnData => {
-  const transformed = pick(returnData, 'returns_frequency', 'licence_ref', 'start_date', 'end_date', 'status');
+  const transformed = pick(returnData, 'returns_frequency', 'licence_ref', 'start_date', 'end_date', 'status', 'received_date');
   transformed.regionCode = get(returnData, 'metadata.nald.regionCode');
   transformed.formatId = get(returnData, 'metadata.nald.formatId');
+  transformed.nald_date_from = getNaldStyleDate(transformed.start_date);
+  transformed.nald_ret_date = getNaldStyleDate(transformed.received_date);
   return transformed;
 };
+
+const transformQuantity = (quantity = 0) => {
+  const val = quantity.toString();
+  return val.includes('.') ? parseFloat(val).toFixed(3) : val;
+};
+
+const getUpperCasedFirstCharacter = flow(first, toUpper);
 
 /**
  * Takes a WRLS line object and converts to a smaller object ready
@@ -28,8 +39,12 @@ const transformLine = lineData => {
   if (lineData.time_period === 'week') {
     throw new Error('Please use transformWeeklyLine for weekly lines');
   }
-  const paths = ['quantity', 'start_date', 'end_date', 'time_period', 'reading_type', 'unit'];
-  return pick(lineData, paths);
+  const paths = ['start_date', 'end_date', 'time_period', 'reading_type', 'unit'];
+  const line = pick(lineData, paths);
+  line.quantity = transformQuantity(lineData.quantity);
+  line.nald_reading_type = getUpperCasedFirstCharacter(line.reading_type);
+  line.nald_time_period = getUpperCasedFirstCharacter(line.time_period);
+  return line;
 };
 
 /**
@@ -61,5 +76,6 @@ const transformWeeklyLine = lineData => {
 module.exports = {
   transformReturn,
   transformLine,
-  transformWeeklyLine
+  transformWeeklyLine,
+  transformQuantity
 };

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -11,7 +11,11 @@ const getVersions = {
     validate: {
       query: {
         start: Joi.string().isoDate().required(),
-        end: Joi.string().isoDate().optional()
+        end: Joi.string().isoDate().optional(),
+        pagination: Joi.object().keys({
+          page: Joi.number(),
+          perPage: Joi.number()
+        }).optional()
       }
     }
   },

--- a/test/modules/returns/responses/lineMonthly.json
+++ b/test/modules/returns/responses/lineMonthly.json
@@ -2,7 +2,7 @@
   "line_id": "test-line-id",
   "version_id": "test-version-id",
   "substance": "water",
-  "quantity": "11",
+  "quantity": "12.3456789",
   "unit": "m³",
   "start_date": "2017-11-01",
   "end_date": "2017-11-30",


### PR DESCRIPTION
 - Adds configurable pagination to the `/etl/versions` resource
 - Adds NALD formatted values to responses
 - Adds the received date to the returns object in the lines response.