### PR TITLE
Fix: Handle null quantities

### DIFF
--- a/src/modules/returns/lib/transformers.js
+++ b/src/modules/returns/lib/transformers.js
@@ -25,6 +25,10 @@ const transformReturn = returnData => {
 };
 
 const transformQuantity = (quantity = 0) => {
+  if (quantity === null || toUpper(quantity) === 'NULL') {
+    return null;
+  }
+
   const val = quantity.toString();
   return val.includes('.') ? parseFloat(val).toFixed(3) : val;
 };

--- a/test/modules/returns/lib/transformers.js
+++ b/test/modules/returns/lib/transformers.js
@@ -237,4 +237,15 @@ experiment('transformQuantity', () => {
     expect(transformers.transformQuantity(123.123456)).to.equal('123.123');
     expect(transformers.transformQuantity(123.129999)).to.equal('123.130');
   });
+
+  it('returns null if the quantity is null', async () => {
+    const val = transformers.transformQuantity(null);
+    expect(val).to.equal(null);
+  });
+
+  it('returns null if the quantity is a string representation of null', async () => {
+    expect(transformers.transformQuantity('null')).to.be.null();
+    expect(transformers.transformQuantity('NULL')).to.be.null();
+    expect(transformers.transformQuantity('Null')).to.be.null();
+  });
 });


### PR DESCRIPTION
Handles null quantities, returning null rather than continuing as if it
was a number.