### PR TITLE
Feat: Separate test tasks

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -4,10 +4,5 @@
 module.exports = {
   // This version global seems to be introduced by sinon.
   globals: 'version,payload',
-  coverage: true,
-  threshold: 55,
-  'coverage-exclude': ['src/lib/logger'],
-  reporter: ['lcov', 'console'],
-  output: ['lcov.info', 'stdout'],
   verbose: true
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - npm install
 script:
   - npm run lint
-  - npm run test
+  - npm run test:travis
   - npm run codecov
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "lab",
+    "test:travis": "lab -c -t 55 -m 0 -r lcov -o lcov.info -r console -o stdout",
     "lint": "eslint .",
     "codecov": "istanbul cover lab --report lcovonly  -- -l  && codecov"
   },


### PR DESCRIPTION
Changes the test tasks to cater for local dev and execution on Travis.

Locally only the lab tests are run. Therefore the code coverage is not
to provide a cleaner output whilst developing.

Travis then has a separate task which includes the code coverage.