### PR TITLE
Fix: Update airbrake js

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -3,6 +3,6 @@
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
   // This version global seems to be introduced by sinon.
-  globals: 'version,payload',
+  globals: 'version,payload,fetch,Response,Headers,Request',
   verbose: true
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,9 +102,12 @@
       }
     },
     "airbrake-js": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/airbrake-js/-/airbrake-js-1.4.6.tgz",
-      "integrity": "sha512-y8coA5sB8pTgkqg1BEu2x+85+Fpd/KYGsKcKxSs5wPVD0czIHCB52byzlTFXU5KFzJR86SPYbsp3VhmyeKt3mw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/airbrake-js/-/airbrake-js-1.5.0.tgz",
+      "integrity": "sha512-EjSNkgOvCxwhd264xaIdow6eCUZ4G+73odPLWIwBMgaNkVWV6/nnnHHGVdWKa7J5Xgi+8LactWhcvjcazqp5rg==",
+      "requires": {
+        "isomorphic-fetch": "^2.2.1"
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -812,6 +815,14 @@
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -1590,7 +1601,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1734,6 +1744,11 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1757,6 +1772,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2368,6 +2392,15 @@
       "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
       "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -3370,6 +3403,11 @@
           "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^6.0.0"
   },
   "dependencies": {
-    "airbrake-js": "^1.1.2",
+    "airbrake-js": "^1.5.0",
     "blipp": "^3.0.0",
     "boom": "^5.2.0",
     "code": "^5.2.0",


### PR DESCRIPTION
WATER-1557

Updates to a version that does not have a recursive function that can be
called in a way that never returns.