### PR TITLE
For weekly returns, output nulls on non-Saturdays.  For nil returns, …

### DIFF
--- a/src/modules/returns/lib/generate-nil-lines.js
+++ b/src/modules/returns/lib/generate-nil-lines.js
@@ -190,7 +190,7 @@ const getAbsPeriod = (returnData) => {
 const mapLine = (line, absPeriod) => {
   const { startDate, endDate, timePeriod } = line;
 
-  const isInPeriod = isDateWithinAbstractionPeriod(startDate, absPeriod) || isDateWithinAbstractionPeriod(endDate, absPeriod);
+  const isInPeriod = isDateWithinAbstractionPeriod(endDate, absPeriod);
 
   return {
     start_date: startDate,

--- a/src/modules/returns/lib/transformers.js
+++ b/src/modules/returns/lib/transformers.js
@@ -78,7 +78,7 @@ const transformWeeklyLine = lineData => {
 
   const dailies = range(7).reduce((lines, daysForward) => {
     const date = getFutureDate(lineData.start_date, daysForward);
-    const quantity = daysForward === 6 ? lineData.quantity : 0;
+    const quantity = daysForward === 6 ? lineData.quantity : null;
 
     const dailyLine = transformLine(Object.assign({}, lineData, {
       start_date: date,

--- a/test/modules/returns/lib/transformers.js
+++ b/test/modules/returns/lib/transformers.js
@@ -172,9 +172,9 @@ experiment('transformWeeklyLine', () => {
     expect(transformed[6].end_date).to.equal('2017-11-04');
   });
 
-  it('the first 6 days have a value of zero', async () => {
+  it('the first 6 days have a value of null', async () => {
     const firstSix = transformed.slice(0, 6);
-    const allZero = firstSix.every(line => line.quantity === '0');
+    const allZero = firstSix.every(line => line.quantity === null);
     expect(allZero).to.be.true();
   });
 


### PR DESCRIPTION
…only output 0s for weeks with end date inside abstraction period.