### PR TITLE
Fix: Use Sun - Sat weeks for NALD

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const Good = require('good');
 const GoodWinston = require('good-winston');
 const Hapi = require('hapi');
 const HapiAuthJwt2 = require('hapi-auth-jwt2');
+const moment = require('moment');
+moment.locale('en-gb');
 
 // -------------- Require project code -----------------
 const config = require('./config');

--- a/src/lib/nald-dates.js
+++ b/src/lib/nald-dates.js
@@ -1,0 +1,21 @@
+const moment = require('moment');
+
+const withNaldLocale = date => moment(date).locale('en');
+const getFirstDayOfWeek = day => withNaldLocale(day).startOf('week');
+const getLastDayOfWeek = day => withNaldLocale(day).endOf('week');
+
+/**
+ * Gets the start and end days of a week relative to the passed day
+ * in NALD terms, where the week is deemed to start on a sunday, and
+ * end on the saturday.
+ */
+const getWeek = day => {
+  return {
+    start: getFirstDayOfWeek(day),
+    end: getLastDayOfWeek(day)
+  };
+};
+
+module.exports = {
+  getWeek
+};

--- a/src/modules/returns/lib/generate-nil-lines.js
+++ b/src/modules/returns/lib/generate-nil-lines.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const { pick, mapValues } = require('lodash');
+const naldDates = require('../../../lib/nald-dates');
 
 /**
  * Get required daily return lines
@@ -65,18 +66,18 @@ const getYears = (startDate, endDate) => {
  * @return {Array} list of required return lines
  */
 const getWeeks = (startDate, endDate) => {
-  const datePtr = moment(startDate);
+  let datePtr = naldDates.getWeek(startDate);
   const lines = [];
-  datePtr.startOf('week');
+
   do {
     lines.push({
-      startDate: datePtr.startOf('week').format('YYYY-MM-DD'),
-      endDate: datePtr.endOf('week').format('YYYY-MM-DD'),
+      startDate: datePtr.start.format('YYYY-MM-DD'),
+      endDate: datePtr.end.format('YYYY-MM-DD'),
       timePeriod: 'week'
     });
-    datePtr.add(1, 'week');
+    datePtr = naldDates.getWeek(datePtr.start.add(1, 'week'));
   }
-  while (datePtr.isSameOrBefore(endDate, 'month'));
+  while (datePtr.end.isSameOrBefore(endDate, 'day'));
 
   return lines;
 };

--- a/test/lib/nald-dates.js
+++ b/test/lib/nald-dates.js
@@ -1,0 +1,215 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+const moment = require('moment');
+moment.locale('en-gb');
+
+const naldDates = require('../../src/lib/nald-dates');
+
+experiment('is the main locale', async () => {
+  test('in the context of the outer test suite the last day of the week is a sunday', async () => {
+    const sunday = moment('2018-10-28', 'YYYY-MM-DD').endOf('day');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    expect(monday.endOf('week').toString()).to.equal(sunday.toString());
+  });
+
+  test('in the context of the outer test suite the first day of the week is a monday', async () => {
+    const sunday = moment('2018-10-28', 'YYYY-MM-DD');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    expect(sunday.startOf('week').toString()).to.equal(monday.toString());
+  });
+});
+
+experiment('getWeek using moments', () => {
+  test('for a sunday the first day of the week is that sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(sunday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a sunday the last day of the week is the next saturday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(sunday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a monday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(monday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a monday the last day of the week is the next saturday', async () => {
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a tuesday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const tuesday = moment('2018-10-23', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a tuesday the last day of the week is the next saturday', async () => {
+    const tuesday = moment('2018-10-23', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a wednesday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const wednesday = moment('2018-10-24', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a wednesday the last day of the week is the next saturday', async () => {
+    const wednesday = moment('2018-10-24', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a thursday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const thursday = moment('2018-10-25', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(thursday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a thursday the last day of the week is the next saturday', async () => {
+    const thursday = moment('2018-10-25', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a friday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const friday = moment('2018-10-26', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(friday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a friday the last day of the week is the next saturday', async () => {
+    const friday = moment('2018-10-26', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a saturday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(saturday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a saturday the last day of the week is that saturday', async () => {
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(saturday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+});
+
+experiment('getWeek using strings', () => {
+  test('for a sunday the first day of the week is that sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const week = naldDates.getWeek('2018-10-21');
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a sunday the last day of the week is the next saturday', async () => {
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek('2018-10-21');
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a monday the first day of the week is the previous sunday', async () => {
+    const monday = '2018-10-22';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a monday the last day of the week is the next saturday', async () => {
+    const monday = '2018-10-22';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a tuesday the first day of the week is the previous sunday', async () => {
+    const tuesday = '2018-10-23';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a tuesday the last day of the week is the next saturday', async () => {
+    const tuesday = '2018-10-23';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a wednesday the first day of the week is the previous sunday', async () => {
+    const wednesday = '2018-10-24';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a wednesday the last day of the week is the next saturday', async () => {
+    const wednesday = '2018-10-24';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a thursday the first day of the week is the previous sunday', async () => {
+    const thursday = '2018-10-25';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a thursday the last day of the week is the next saturday', async () => {
+    const thursday = '2018-10-25';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a friday the first day of the week is the previous sunday', async () => {
+    const friday = '2018-10-26';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a friday the last day of the week is the next saturday', async () => {
+    const friday = '2018-10-26';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a saturday the first day of the week is the previous sunday', async () => {
+    const saturday = '2018-10-27';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(saturday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a saturday the last day of the week is that saturday', async () => {
+    const saturday = '2018-10-27';
+    const week = naldDates.getWeek(saturday);
+    expect(week.end.toString()).to.equal(moment(saturday).endOf('day').toString());
+  });
+});

--- a/test/modules/returns/lib/generate-nil-lines.js
+++ b/test/modules/returns/lib/generate-nil-lines.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const moment = require('moment');
+moment.locale('en-gb');
+
 const { experiment, it } = module.exports.lab = require('lab').script();
 const { expect } = require('code');
 const { uniq } = require('lodash');
@@ -148,6 +151,7 @@ experiment('getWeeks', () => {
   it('Should output `week` as the period', async () => {
     const days = getWeeks('2018-01-01', '2018-12-31');
     const periods = uniq(days.map(day => day.timePeriod));
+    expect(periods.length).to.equal(1);
     expect(periods).to.equal(['week']);
   });
 });


### PR DESCRIPTION
WATER-1632

Changes week calculations to us weeks that start on Sundays.

Sets the global moment locale to en-gb, but then adds a nald-dates
module for calculating the weeks, where a local locale of `en` is used
which treats weeks as running Sun - Sat.

Updates any existing code that used `startOf` or `endOf` and routes
through nald-dates.