### PR TITLE
Fix: Update charging import schedule

### DIFF
--- a/src/modules/charging-import/plugin.js
+++ b/src/modules/charging-import/plugin.js
@@ -4,12 +4,14 @@ const jobs = require('./jobs');
 const chargingImport = require('./lib/import');
 const { createRegister } = require('../../lib/plugin');
 
+// run at 1000 Mon, Weds and Fri
+const cronSchedule = '0 10 * * 1,3,5';
+
 const registerSubscribers = async server => {
   // Import charging data
   await server.messageQueue.subscribe(jobs.IMPORT_CHARGING_DATA, chargingImport.importChargingData);
 
-  // Set up cron job to import charge data every other day at 3:00pm
-  cron.schedule('0 15 */2 * *', async () => {
+  cron.schedule(cronSchedule, async () => {
     await server.messageQueue.publish(jobs.importChargingData());
   });
 };

--- a/test/modules/charging-import/plugin.js
+++ b/test/modules/charging-import/plugin.js
@@ -1,6 +1,9 @@
+'use strict';
+
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
 const sandbox = require('sinon').createSandbox();
 const cron = require('node-cron');
+
 const { plugin } = require('../../../src/modules/charging-import/plugin');
 const jobs = require('../../../src/modules/charging-import/jobs');
 const chargingImport = require('../../../src/modules/charging-import/lib/import.js');
@@ -46,10 +49,9 @@ experiment('modules/charging-import/plugin.js', () => {
         )).to.be.true();
       });
 
-      test('schedules a cron job to run the import every other day at 3:00pm', async () => {
-        expect(cron.schedule.calledWith(
-          '0 15 */2 * *'
-        )).to.be.true();
+      test('schedules a cron job to run the import 1000 on Mon, Wed and Fri', async () => {
+        const [schedule] = cron.schedule.lastCall.args;
+        expect(schedule).to.equal('0 10 * * 1,3,5');
       });
     });
 


### PR DESCRIPTION
WATER-2690

Updates the cron schedule to run the charging import every Mon, Weds and
Friday so that if the environments are stopped/started the job execution
is consistent.