### PR TITLE
Fixes issue where licences with null ORIG_EFF_DATE could not be imported

### DIFF
--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -1,7 +1,7 @@
 exports.getLicence = `
   SELECT *
   FROM import."NALD_ABS_LICENCES" l
-  WHERE l."LIC_NO"=$1 AND l."ORIG_EFF_DATE"<>'null';
+  WHERE l."LIC_NO"=$1;
 `;
 
 exports.getLicenceVersions = `
@@ -105,6 +105,5 @@ AND a."ID" =  any (string_to_array($2, ',')::text[])`;
 
 exports.getAllLicenceNumbers = `
   SELECT l."LIC_NO"
-  FROM import."NALD_ABS_LICENCES" l
-  WHERE l."ORIG_EFF_DATE"<>'null';
+  FROM import."NALD_ABS_LICENCES" l;
 `;

--- a/src/modules/licence-import/jobs/index.js
+++ b/src/modules/licence-import/jobs/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const IMPORT_COMPANIES_JOB = 'import.companies';
 const IMPORT_COMPANY_JOB = 'import.company';
 const IMPORT_LICENCES_JOB = 'import.licences';

--- a/src/modules/licence-import/transform/licence.js
+++ b/src/modules/licence-import/transform/licence.js
@@ -14,7 +14,7 @@ const mapContactData = data => ({
  */
 const transformLicence = licenceData => {
   // Get licence
-  const licence = mappers.licence.mapLicence(licenceData.licence);
+  const licence = mappers.licence.mapLicence(licenceData.licence, licenceData.versions);
   const purposes = licenceData.purposes.map(mappers.licencePurpose.mapLicencePurpose);
 
   // Get documents

--- a/src/modules/licence-import/transform/mappers/licence.js
+++ b/src/modules/licence-import/transform/mappers/licence.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const date = require('./date');
 const str = require('./str');
 const {
@@ -28,30 +30,56 @@ const getRegionData = licenceData => {
   return { historicalAreaCode, regionalChargeArea };
 };
 
-const mapLicence = data => {
+const isNotDraftLicenceVersion = licenceVersion => licenceVersion.STATUS !== 'DRAFT';
+
+const getLicenceVersionStartDate = licenceVersion => date.mapNaldDate(licenceVersion.EFF_ST_DATE);
+
+/**
+ * Maps the licence and licence versions to a start date.
+ * If the licence ORIG_EFF_DATE is not null, this is used.
+ * Otherwise the start date of the earliest non-draft licence
+ * version is used.
+ *
+ * @param {Object} licence
+ * @param {Object} licenceVersions
+ * @return {String} YYYY-MM-DD
+ */
+const mapStartDate = (licence, licenceVersions) => {
+  if (licence.ORIG_EFF_DATE !== 'null') {
+    return date.mapNaldDate(licence.ORIG_EFF_DATE);
+  }
+
+  return licenceVersions
+    .filter(isNotDraftLicenceVersion)
+    .map(getLicenceVersionStartDate)
+    .sort()
+    .shift();
+};
+
+const mapLicence = (licence, licenceVersions) => {
   const endDates = [
-    data.EXPIRY_DATE,
-    data.REV_DATE,
-    data.LAPSED_DATE
+    licence.EXPIRY_DATE,
+    licence.REV_DATE,
+    licence.LAPSED_DATE
   ]
     .map(str.mapNull)
     .filter(identity)
     .map(date.mapNaldDate);
 
   return {
-    licenceNumber: data.LIC_NO,
-    startDate: date.mapNaldDate(data.ORIG_EFF_DATE),
+    licenceNumber: licence.LIC_NO,
+    startDate: mapStartDate(licence, licenceVersions),
     endDate: date.getMinDate(endDates),
     documents: [],
     agreements: [],
-    externalId: `${data.FGAC_REGION_CODE}:${data.ID}`,
-    isWaterUndertaker: endsWith(data.AREP_EIUC_CODE, 'SWC'),
-    regions: getRegionData(data),
-    regionCode: parseInt(data.FGAC_REGION_CODE, 10),
-    expiredDate: date.mapNaldDate(data.EXPIRY_DATE),
-    lapsedDate: date.mapNaldDate(data.LAPSED_DATE),
-    revokedDate: date.mapNaldDate(data.REV_DATE),
-    _nald: data
+    externalId: `${licence.FGAC_REGION_CODE}:${licence.ID}`,
+    isWaterUndertaker: endsWith(licence.AREP_EIUC_CODE, 'SWC'),
+    regions: getRegionData(licence),
+    regionCode: parseInt(licence.FGAC_REGION_CODE, 10),
+    expiredDate: date.mapNaldDate(licence.EXPIRY_DATE),
+    lapsedDate: date.mapNaldDate(licence.LAPSED_DATE),
+    revokedDate: date.mapNaldDate(licence.REV_DATE),
+    _nald: licence
   };
 };
 

--- a/test/modules/licence-import/transform/mappers/licence.js
+++ b/test/modules/licence-import/transform/mappers/licence.js
@@ -15,10 +15,26 @@ experiment('modules/licence-import/transform/mappers/licence', () => {
       expect(mapped.licenceNumber).to.equal(licenceNumber);
     });
 
-    test('sets the startDate', async () => {
+    test('sets the startDate when the original effective date is not null', async () => {
       const input = { ORIG_EFF_DATE: '01/02/2003', AREP_EIUC_CODE: 'ANOTH' };
       const mapped = mapLicence(input);
       expect(mapped.startDate).to.equal('2003-02-01');
+    });
+
+    test('gets the start date from the earliest non-draft licence version if the original effective date is null', async () => {
+      const licence = { ORIG_EFF_DATE: 'null', AREP_EIUC_CODE: 'ANOTH' };
+      const licenceVersions = [{
+        STATUS: 'DRAFT',
+        EFF_ST_DATE: '01/01/2018'
+      }, {
+        STATUS: 'SUPER',
+        EFF_ST_DATE: '02/01/2018'
+      }, {
+        STATUS: 'CURR',
+        EFF_ST_DATE: '03/01/2018'
+      }];
+      const mapped = mapLicence(licence, licenceVersions);
+      expect(mapped.startDate).to.equal('2018-01-02');
     });
 
     test('sets the end date to the minimum date', async () => {


### PR DESCRIPTION
WATER-2844

Where a licence doesn't have an original effective date, the start date of the earliest non-draft licence version is used instead.