### PR TITLE
Fixes cleanup phase of charge version import

### DIFF
--- a/src/modules/charging-import/lib/import.js
+++ b/src/modules/charging-import/lib/import.js
@@ -18,7 +18,6 @@ const importQueries = [
   chargingQueries.importChargeVersions,
   chargingQueries.importChargeElements,
   chargingQueries.importChargeAgreements,
-  chargingQueries.cleanupChargeAgreements,
   chargingQueries.cleanupChargeElements,
   chargingQueries.cleanupChargeVersions,
   returnVersionQueries.importReturnVersions,

--- a/src/modules/charging-import/lib/queries/charging.js
+++ b/src/modules/charging-import/lib/queries/charging.js
@@ -83,7 +83,6 @@ const cleanupChargeVersions = `DELETE FROM water.charge_versions WHERE charge_ve
       and ncv."AABL_ID" is null
 );`;
 
-
 const importChargeElements = `INSERT INTO water.charge_elements
 (charge_element_id, charge_version_id, external_id, abstraction_period_start_day, abstraction_period_start_month,
 abstraction_period_end_day, abstraction_period_end_month, authorised_annual_quantity, season, season_derived,


### PR DESCRIPTION
WATER-2872
The cleanup phase of charge version imports removes charge versions/elements no longer present in NALD.

However these now may be referenced in billing tables, causing the deletes to fail.

This PR updates the queries to only delete charge versions/elements that haven't been involved in billing.