### PR TITLE
Fix: Delete documents from CRM when deleted from NALD

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -3,7 +3,8 @@
     {
       "name": "import",
       "ignore_watch": [
-        "node_modules"
+        "node_modules",
+        "temp"
       ],
       "env": {
         "watch": true

--- a/src/lib/connectors/import.js
+++ b/src/lib/connectors/import.js
@@ -7,9 +7,25 @@ const getLicenceNumbersQuery = `
   from import."NALD_ABS_LICENCES";
 `;
 
+const deleteCrmV1DocumentsQuery = `
+  update crm.document_header
+  set date_deleted = now()
+  where system_external_id not in (
+    select l."LIC_NO"
+    from import."NALD_ABS_LICENCES" l
+  )
+  and date_deleted is null
+  and regime_entity_id = '0434dc31-a34e-7158-5775-4694af7a60cf';
+`;
+
 const getLicenceNumbers = async () => {
   const response = await pool.query(getLicenceNumbersQuery);
   return response.rows || [];
 };
 
+const deleteRemovedDocuments = () => {
+  return pool.query(deleteCrmV1DocumentsQuery);
+};
+
 exports.getLicenceNumbers = getLicenceNumbers;
+exports.deleteRemovedDocuments = deleteRemovedDocuments;

--- a/src/lib/services/import.js
+++ b/src/lib/services/import.js
@@ -8,4 +8,9 @@ const getLicenceNumbers = async () => {
   return licenceNumbers.map(licenceNumber => licenceNumber.LIC_NO);
 };
 
+const deleteRemovedDocuments = async () => {
+  return importConnector.deleteRemovedDocuments();
+};
+
+exports.deleteRemovedDocuments = deleteRemovedDocuments;
 exports.getLicenceNumbers = getLicenceNumbers;

--- a/src/modules/licence-import/connectors/documents.js
+++ b/src/modules/licence-import/connectors/documents.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { pool } = require('../../../lib/connectors/db');
+const queries = require('./queries/documents');
+
+/**
+ * Mark any documents in crm_v2.documents as deleted if the licence
+ * numbers no longer exist in import.NALD_ABS_LICENCES
+ */
+const deleteRemovedDocuments = () => pool.query(queries.deleteCrmV2Documents);
+
+exports.deleteRemovedDocuments = deleteRemovedDocuments;

--- a/src/modules/licence-import/connectors/queries/documents.js
+++ b/src/modules/licence-import/connectors/queries/documents.js
@@ -1,0 +1,11 @@
+exports.deleteCrmV2Documents = `
+  update crm_v2.documents
+  set date_deleted = now()
+  where document_ref not in (
+    select l."LIC_NO"
+    from import."NALD_ABS_LICENCES" l
+  )
+  and date_deleted is null
+  and regime = 'water'
+  and document_type = 'abstraction_licence';
+`;

--- a/src/modules/licence-import/controller.js
+++ b/src/modules/licence-import/controller.js
@@ -21,7 +21,7 @@ const postImportHandler = async (request, h, jobCreator, errorMessage) => {
   };
 };
 
-const createImportJob = () => jobs.importCompanies();
+const createImportJob = () => jobs.deleteDocuments();
 const createImportCompanyJob = request => jobs.importCompany(request.query.regionCode, request.query.partyId);
 const createImportLicenceJob = request => jobs.importLicence(request.query.licenceNumber);
 

--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -65,14 +65,14 @@ AND ag."AFSA_CODE" IN ('S127', 'S130S', 'S130T', 'S130U', 'S130W')
 `;
 
 exports.getInvoiceAccounts = `
-select a."ACON_APAR_ID" AS licence_holder_party_id, p."NAME" AS licence_holder_party_name, 
+select a."ACON_APAR_ID" AS licence_holder_party_id, p."NAME" AS licence_holder_party_name,
 p2."NAME" AS invoice_account_party_name,
-i.* 
+i.*
 from import."NALD_LH_ACCS" a
 join import."NALD_PARTIES" p on a."ACON_APAR_ID"=p."ID" and a."FGAC_REGION_CODE"=p."FGAC_REGION_CODE"
-join import."NALD_IAS_INVOICE_ACCS" i 
-on 
-  a."ACC_NO"=i."ALHA_ACC_NO" 
+join import."NALD_IAS_INVOICE_ACCS" i
+on
+  a."ACC_NO"=i."ALHA_ACC_NO"
   and a."FGAC_REGION_CODE"=i."FGAC_REGION_CODE"
 join import."NALD_PARTIES" p2 on i."ACON_APAR_ID"=p2."ID" AND i."FGAC_REGION_CODE"=p2."FGAC_REGION_CODE"
 join (
@@ -80,7 +80,7 @@ join (
   from import."NALD_CHG_VERSIONS" cv
   where cv."STATUS"<>'DRAFT'
 ) cv
-on 
+on
   i."IAS_CUST_REF"=cv."AIIA_IAS_CUST_REF"
   and i."FGAC_REGION_CODE"=cv."FGAC_REGION_CODE"
   and i."ALHA_ACC_NO"=cv."AIIA_ALHA_ACC_NO"
@@ -110,8 +110,8 @@ exports.getAllLicenceNumbers = `
 
 exports.getLicenceRoles = `
 select * from import."NALD_LIC_ROLES" r
-where r."FGAC_REGION_CODE"=$1 and r."AABL_ID"=$2 
-order by to_date(r."EFF_ST_DATE", 'DD/MM/YYYY') 
+where r."FGAC_REGION_CODE"=$1 and r."AABL_ID"=$2
+order by to_date(r."EFF_ST_DATE", 'DD/MM/YYYY')
 `;
 
 exports.getPartyLicenceRoles = `

--- a/src/modules/licence-import/handlers/delete-documents.js
+++ b/src/modules/licence-import/handlers/delete-documents.js
@@ -1,0 +1,12 @@
+const { logger } = require('../../../logger');
+const documentsConnector = require('../connectors/documents');
+
+module.exports = async job => {
+  try {
+    logger.info('Deleting removed documents');
+    return documentsConnector.deleteRemovedDocuments();
+  } catch (err) {
+    logger.error('Failed to delete removed documents', err);
+    throw err;
+  }
+};

--- a/src/modules/licence-import/handlers/index.js
+++ b/src/modules/licence-import/handlers/index.js
@@ -1,9 +1,15 @@
 module.exports = {
+  deleteDocuments: require('./delete-documents'),
+  onCompleteDeleteDocuments: require('./on-complete-delete-documents'),
+
   importCompany: require('./import-company'),
   onCompleteImportCompany: require('./on-complete-import-company'),
+
   importCompanies: require('./import-companies'),
   onCompleteImportCompanies: require('./on-complete-import-companies'),
+
   importLicences: require('./import-licences'),
   onCompleteImportLicences: require('./on-complete-import-licences'),
+
   importLicence: require('./import-licence')
 };

--- a/src/modules/licence-import/handlers/on-complete-delete-documents.js
+++ b/src/modules/licence-import/handlers/on-complete-delete-documents.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const jobs = require('../jobs');
+
+module.exports = async (messageQueue, job) =>
+  messageQueue.publish(jobs.importCompanies());

--- a/src/modules/licence-import/jobs/index.js
+++ b/src/modules/licence-import/jobs/index.js
@@ -4,6 +4,7 @@ const IMPORT_COMPANIES_JOB = 'import.companies';
 const IMPORT_COMPANY_JOB = 'import.company';
 const IMPORT_LICENCES_JOB = 'import.licences';
 const IMPORT_LICENCE_JOB = 'import.licence';
+const DELETE_DOCUMENTS_JOB = 'import.delete-documents';
 
 /**
  * Formats arguments to publish a PG boss event to import all companies
@@ -65,12 +66,18 @@ const importLicence = licenceNumber => ({
   }
 });
 
+const deleteDocuments = () => ({
+  name: DELETE_DOCUMENTS_JOB
+});
+
 exports.IMPORT_COMPANIES_JOB = IMPORT_COMPANIES_JOB;
 exports.IMPORT_COMPANY_JOB = IMPORT_COMPANY_JOB;
 exports.IMPORT_LICENCES_JOB = IMPORT_LICENCES_JOB;
 exports.IMPORT_LICENCE_JOB = IMPORT_LICENCE_JOB;
+exports.DELETE_DOCUMENTS_JOB = DELETE_DOCUMENTS_JOB;
 
 exports.importCompanies = importCompanies;
 exports.importCompany = importCompany;
 exports.importLicences = importLicences;
 exports.importLicence = importLicence;
+exports.deleteDocuments = deleteDocuments;

--- a/src/modules/licence-import/load/connectors/queries.js
+++ b/src/modules/licence-import/load/connectors/queries.js
@@ -1,6 +1,14 @@
-exports.createDocument = `INSERT INTO crm_v2.documents (regime, document_type, document_ref, version_number, status, start_date, end_date, external_id, date_created, date_updated)
-VALUES ('water', 'abstraction_licence', $1, $2, $3, $4, $5, $6, NOW(), NOW()) ON CONFLICT (regime, document_type, version_number, document_ref) DO UPDATE SET start_date=EXCLUDED.start_date, end_date=EXCLUDED.end_date,
-  status=EXCLUDED.status, external_id=EXCLUDED.external_id, date_updated=EXCLUDED.date_updated;`;
+exports.createDocument = `
+  INSERT INTO crm_v2.documents (regime, document_type, document_ref, version_number, status, start_date, end_date, external_id, date_created, date_updated, date_deleted)
+  VALUES ('water', 'abstraction_licence', $1, $2, $3, $4, $5, $6, NOW(), NOW(), null)
+  ON CONFLICT (regime, document_type, version_number, document_ref)
+  DO UPDATE SET
+    start_date=EXCLUDED.start_date,
+    end_date=EXCLUDED.end_date,
+    status=EXCLUDED.status,
+    external_id=EXCLUDED.external_id,
+    date_updated=EXCLUDED.date_updated,
+    date_deleted=EXCLUDED.date_deleted;`;
 
 exports.createDocumentRole = `INSERT INTO crm_v2.document_roles (document_id, role_id, company_id, contact_id, address_id, start_date, end_date, date_created, date_updated, invoice_account_id)
 SELECT d.document_id, r.role_id, c.company_id, co.contact_id, a.address_id, $8, $9, NOW(), NOW(), ia.invoice_account_id
@@ -90,7 +98,7 @@ ON CONFLICT (company_id, address_id, role_id) DO UPDATE SET
 
 exports.createAgreement = `insert into water.licence_agreements (licence_ref, financial_agreement_type_id, start_date, end_date, date_created, date_updated)
   select $1, t.financial_agreement_type_id, $3, $4, NOW(), NOW()
-    from water.financial_agreement_types t 
+    from water.financial_agreement_types t
     where t.financial_agreement_code=$2 on conflict (licence_ref, financial_agreement_type_id, start_date)  do update set end_date=EXCLUDED.end_date, date_updated=EXCLUDED.date_updated;`;
 
 exports.createLicence = `insert into water.licences (region_id, licence_ref, is_water_undertaker, regions, start_date, expired_date, lapsed_date, revoked_date)

--- a/src/modules/nald-import/jobs/delete-removed-documents-complete.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents-complete.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const logger = require('./lib/logger');
+
+const populatePendingImportJob = require('./populate-pending-import');
+
+const deleteRemovedDocumentsComplete = async (job, messageQueue) => {
+  if (job.failed) {
+    return logger.logFailedJob(job);
+  }
+
+  logger.logHandlingOnCompleteJob(job);
+
+  try {
+    // Publish a new job to populate pending import table
+    await messageQueue.publish(populatePendingImportJob.createMessage());
+  } catch (err) {
+    logger.logHandlingOnCompleteError(job, err);
+    throw err;
+  }
+};
+
+module.exports = deleteRemovedDocumentsComplete;

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const logger = require('./lib/logger');
+
+const JOB_NAME = 'nald-import.delete-removed-documents';
+const importService = require('../../../lib/services/import');
+
+const createMessage = () => ({
+  name: JOB_NAME,
+  options: {
+    expireIn: '1 hours',
+    singletonKey: JOB_NAME
+  }
+});
+
+const handler = async job => {
+  logger.logHandlingJob(job);
+
+  try {
+    return importService.deleteRemovedDocuments();
+  } catch (err) {
+    logger.logJobError(job, err);
+    throw err;
+  }
+};
+
+exports.createMessage = createMessage;
+exports.handler = handler;
+exports.jobName = JOB_NAME;

--- a/src/modules/nald-import/jobs/index.js
+++ b/src/modules/nald-import/jobs/index.js
@@ -10,6 +10,11 @@ exports.populatePendingImport = {
   onCompleteHandler: require('./populate-pending-import-complete')
 };
 
+exports.deleteRemovedDocuments = {
+  job: require('./delete-removed-documents'),
+  onCompleteHandler: require('./delete-removed-documents-complete')
+};
+
 exports.importLicence = {
   job: require('./import-licence')
 };

--- a/src/modules/nald-import/jobs/s3-download-complete.js
+++ b/src/modules/nald-import/jobs/s3-download-complete.js
@@ -3,6 +3,7 @@
 const logger = require('./lib/logger');
 
 const populatePendingImportJob = require('./populate-pending-import');
+const deleteRemovedDocumentsJob = require('./delete-removed-documents');
 const importLicenceJob = require('./import-licence');
 
 const s3DownloadComplete = async (job, messageQueue) => {
@@ -22,11 +23,12 @@ const s3DownloadComplete = async (job, messageQueue) => {
     // Delete existing PG boss import queues
     await Promise.all([
       messageQueue.deleteQueue(importLicenceJob.jobName),
+      messageQueue.deleteQueue(deleteRemovedDocumentsJob.jobName),
       messageQueue.deleteQueue(populatePendingImportJob.jobName)
     ]);
 
-    // Publish a new job to populate pending import table
-    await messageQueue.publish(populatePendingImportJob.createMessage());
+    // Publish a new job to delete any removed documents
+    await messageQueue.publish(deleteRemovedDocumentsJob.createMessage());
   } catch (err) {
     logger.logHandlingOnCompleteError(job, err);
     throw err;

--- a/src/modules/nald-import/plugin.js
+++ b/src/modules/nald-import/plugin.js
@@ -24,6 +24,7 @@ const subscribe = async (server, job) => {
 
 const registerSubscribers = async server => {
   await subscribe(server, jobs.s3Download);
+  await subscribe(server, jobs.deleteRemovedDocuments);
   await subscribe(server, jobs.populatePendingImport);
   await subscribe(server, jobs.importLicence);
 

--- a/test/lib/services/import.js
+++ b/test/lib/services/import.js
@@ -16,6 +16,7 @@ const importService = require('../../../src/lib/services/import');
 experiment('lib/services/import', () => {
   beforeEach(async () => {
     sandbox.stub(importConnector, 'getLicenceNumbers');
+    sandbox.stub(importConnector, 'deleteRemovedDocuments');
   });
 
   afterEach(async () => {
@@ -43,6 +44,17 @@ experiment('lib/services/import', () => {
 
         expect(licences).to.equal(['111', '222', '333']);
       });
+    });
+  });
+
+  experiment('.deleteRemovedDocuments', () => {
+    beforeEach(async () => {
+      importConnector.deleteRemovedDocuments.resolves();
+      await importService.deleteRemovedDocuments();
+    });
+
+    test('calls through to the connector', async () => {
+      expect(importConnector.deleteRemovedDocuments.called).to.equal(true);
     });
   });
 });

--- a/test/modules/licence-import/connectors/documents.js
+++ b/test/modules/licence-import/connectors/documents.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const { pool } = require('../../../../src/lib/connectors/db');
+const queries = require('../../../../src/modules/licence-import/connectors/queries/documents');
+const connector = require('../../../../src/modules/licence-import/connectors/documents');
+
+experiment('modules/licence-import/connectors/documents', () => {
+  beforeEach(async () => {
+    sandbox.stub(pool, 'query');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('deleteRemovedDocuments', () => {
+    beforeEach(async () => {
+      await connector.deleteRemovedDocuments();
+    });
+
+    test('passes the expected query to the pool', async () => {
+      const [query] = pool.query.lastCall.args;
+      expect(query).to.equal(queries.deleteCrmV2Documents);
+    });
+  });
+});

--- a/test/modules/licence-import/controller.js
+++ b/test/modules/licence-import/controller.js
@@ -36,10 +36,10 @@ experiment('modules/licence-import/controller.js', () => {
         response = await controller.postImport(request, h);
       });
 
-      test('an "import companies" job is published', async () => {
+      test('an "import delete documents" job is published', async () => {
         expect(request.messageQueue.publish.callCount).to.equal(1);
         const [job] = request.messageQueue.publish.lastCall.args;
-        expect(job.name).to.equal(jobs.IMPORT_COMPANIES_JOB);
+        expect(job.name).to.equal(jobs.DELETE_DOCUMENTS_JOB);
       });
 
       test('a success response is returned', async () => {

--- a/test/modules/licence-import/plugin.js
+++ b/test/modules/licence-import/plugin.js
@@ -46,6 +46,18 @@ experiment('modules/licence-import/plugin.js', () => {
         await plugin.register(server);
       });
 
+      test('adds subscriber for delete removed documents job', async () => {
+        const [job, func] = server.messageQueue.subscribe.firstCall.args;
+        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB);
+        expect(func).to.equal(handlers.deleteDocuments);
+      });
+
+      test('adds on complete handler for delete removed documents job', async () => {
+        const [job, func] = server.messageQueue.onComplete.firstCall.args;
+        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB);
+        expect(func).to.be.a.function();
+      });
+
       test('adds subscriber for import companies job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           jobs.IMPORT_COMPANIES_JOB, handlers.importCompanies
@@ -53,7 +65,7 @@ experiment('modules/licence-import/plugin.js', () => {
       });
 
       test('adds on complete handler for import companies job', async () => {
-        const [job, func] = server.messageQueue.onComplete.firstCall.args;
+        const [job, func] = server.messageQueue.onComplete.secondCall.args;
         expect(job).to.equal(jobs.IMPORT_COMPANIES_JOB);
         expect(func).to.be.a.function();
       });
@@ -65,7 +77,7 @@ experiment('modules/licence-import/plugin.js', () => {
       });
 
       test('adds on complete handler for import company job', async () => {
-        const [job, func] = server.messageQueue.onComplete.secondCall.args;
+        const [job, func] = server.messageQueue.onComplete.thirdCall.args;
         expect(job).to.equal(jobs.IMPORT_COMPANY_JOB);
         expect(func).to.be.a.function();
       });
@@ -99,7 +111,7 @@ experiment('modules/licence-import/plugin.js', () => {
       });
 
       test('subscribers are bound', async () => {
-        expect(server.messageQueue.subscribe.callCount).to.equal(4);
+        expect(server.messageQueue.subscribe.callCount).to.equal(5);
       });
 
       test('cron job is scheduled', async () => {

--- a/test/modules/nald-import/jobs/delete-removed-documents-complete.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents-complete.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const { logger } = require('../../../../src/logger');
+const deleteRemovedDocumentsCompleteJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents-complete');
+
+const createJob = isFailed => ({
+  failed: isFailed,
+  data: {
+    request: {
+      name: 'nald-import.delete-removed-documents'
+    }
+  }
+});
+
+experiment('modules/nald-import/jobs/delete-removed-documents-complete', () => {
+  let messageQueue;
+
+  beforeEach(async () => {
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error');
+
+    messageQueue = {
+      publish: sandbox.stub(),
+      deleteQueue: sandbox.stub()
+    };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.handler', () => {
+    experiment('when the job fails', () => {
+      const job = createJob(true);
+
+      beforeEach(async () => {
+        await deleteRemovedDocumentsCompleteJob(job, messageQueue);
+      });
+
+      test('a message is logged', async () => {
+        const [message] = logger.error.lastCall.args;
+        expect(message).to.equal('Job: nald-import.delete-removed-documents failed, aborting');
+      });
+
+      test('no further jobs are published', async () => {
+        expect(messageQueue.publish.called).to.be.false();
+      });
+    });
+
+    experiment('when the job succeeds', () => {
+      const job = createJob(false);
+
+      beforeEach(async () => {
+        await deleteRemovedDocumentsCompleteJob(job, messageQueue);
+      });
+
+      test('a message is logged', async () => {
+        const [message] = logger.info.lastCall.args;
+        expect(message).to.equal('Handling onComplete job: nald-import.delete-removed-documents');
+      });
+
+      test('a new job is published to populate the pending imports table', async () => {
+        const [job] = messageQueue.publish.lastCall.args;
+        expect(job.name).to.equal('nald-import.populate-pending-import');
+      });
+
+      experiment('when publishing a new job fails', () => {
+        const err = new Error('oops');
+
+        const job = createJob(false);
+
+        beforeEach(async () => {
+          messageQueue.publish.rejects(err);
+        });
+
+        test('an error message is logged and rethrown', async () => {
+          const func = () => deleteRemovedDocumentsCompleteJob(job, messageQueue);
+          await expect(func()).to.reject();
+
+          const [message, error] = logger.error.lastCall.args;
+          expect(message).to.equal('Error handling onComplete job: nald-import.delete-removed-documents');
+          expect(error).to.equal(err);
+        });
+      });
+    });
+  });
+});

--- a/test/modules/nald-import/jobs/delete-removed-documents.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const { logger } = require('../../../../src/logger');
+const importService = require('../../../../src/lib/services/import');
+const deleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents');
+
+experiment('modules/nald-import/jobs/delete-removed-documents', () => {
+  beforeEach(async () => {
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error');
+
+    sandbox.stub(importService, 'deleteRemovedDocuments').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.createMessage', () => {
+    test('formats a message for PG boss', async () => {
+      const job = deleteRemovedDocumentsJob.createMessage();
+      expect(job).to.equal({
+        name: 'nald-import.delete-removed-documents',
+        options: {
+          expireIn: '1 hours',
+          singletonKey: 'nald-import.delete-removed-documents'
+        }
+      });
+    });
+  });
+
+  experiment('.handler', () => {
+    experiment('when the job is successful', () => {
+      const job = {
+        name: 'nald-import.delete-removed-documents'
+      };
+
+      beforeEach(async () => {
+        await deleteRemovedDocumentsJob.handler(job);
+      });
+
+      test('a message is logged', async () => {
+        const [message] = logger.info.lastCall.args;
+        expect(message).to.equal('Handling job: nald-import.delete-removed-documents');
+      });
+
+      test('deletes the removed documents', async () => {
+        expect(importService.deleteRemovedDocuments.called).to.equal(true);
+      });
+    });
+
+    experiment('when the job fails', () => {
+      const err = new Error('Oops!');
+
+      const job = {
+        name: 'nald-import.delete-removed-documents'
+      };
+
+      beforeEach(async () => {
+        importService.deleteRemovedDocuments.throws(err);
+      });
+
+      test('logs an error message', async () => {
+        const func = () => deleteRemovedDocumentsJob.handler(job);
+        await expect(func()).to.reject();
+        expect(logger.error.calledWith(
+          'Error handling job nald-import.delete-removed-documents', err
+        )).to.equal(true);
+      });
+
+      test('rethrows the error', async () => {
+        const func = () => deleteRemovedDocumentsJob.handler(job);
+        const err = await expect(func()).to.reject();
+        expect(err.message).to.equal('Oops!');
+      });
+    });
+  });
+});

--- a/test/modules/nald-import/jobs/s3-download-complete.js
+++ b/test/modules/nald-import/jobs/s3-download-complete.js
@@ -73,9 +73,13 @@ experiment('modules/nald-import/jobs/s3-download-import-complete', () => {
           expect(messageQueue.deleteQueue.calledWith('nald-import.populate-pending-import')).to.be.true();
         });
 
-        test('a new job is published to populate the pending import table', async () => {
+        test('existing nald-import.delete-removed-documents job queue is deleted', async () => {
+          expect(messageQueue.deleteQueue.calledWith('nald-import.delete-removed-documents')).to.be.true();
+        });
+
+        test('a new job is published to delete any removed documents', async () => {
           const [job] = messageQueue.publish.lastCall.args;
-          expect(job.name).to.equal('nald-import.populate-pending-import');
+          expect(job.name).to.equal('nald-import.delete-removed-documents');
         });
       });
 

--- a/test/modules/nald-import/plugin.js
+++ b/test/modules/nald-import/plugin.js
@@ -28,6 +28,7 @@ experiment('modules/nald-import/plugin', () => {
 
     sandbox.stub(jobs.s3Download, 'onCompleteHandler');
     sandbox.stub(jobs.populatePendingImport, 'onCompleteHandler');
+    sandbox.stub(jobs.deleteRemovedDocuments, 'onCompleteHandler');
   });
 
   afterEach(async () => {
@@ -45,7 +46,7 @@ experiment('modules/nald-import/plugin', () => {
     });
 
     test('registers s3Download job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.firstCall.args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(0).args;
 
       expect(jobName).to.equal(jobs.s3Download.job.jobName);
       expect(options).to.equal({});
@@ -55,7 +56,7 @@ experiment('modules/nald-import/plugin', () => {
     test('registers s3Download onComplete handler', async () => {
       const completedJob = { id: 'testing' };
 
-      const [jobName, func] = server.messageQueue.onComplete.firstCall.args;
+      const [jobName, func] = server.messageQueue.onComplete.getCall(0).args;
       func(completedJob);
 
       expect(jobName).to.equal(jobs.s3Download.job.jobName);
@@ -65,8 +66,29 @@ experiment('modules/nald-import/plugin', () => {
       )).to.equal(true);
     });
 
+    test('registers deleteRemovedDocuments job', async () => {
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(1).args;
+
+      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName);
+      expect(options).to.equal({});
+      expect(handler).to.equal(jobs.deleteRemovedDocuments.job.handler);
+    });
+
+    test('registers deleteRemovedDocuments onComplete handler', async () => {
+      const completedJob = { id: 'testing' };
+
+      const [jobName, func] = server.messageQueue.onComplete.getCall(1).args;
+      func(completedJob);
+
+      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName);
+      expect(jobs.deleteRemovedDocuments.onCompleteHandler.calledWith(
+        completedJob,
+        server.messageQueue
+      )).to.equal(true);
+    });
+
     test('registers populatePendingImport job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.secondCall.args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(2).args;
 
       expect(jobName).to.equal(jobs.populatePendingImport.job.jobName);
       expect(options).to.equal({});
@@ -76,7 +98,7 @@ experiment('modules/nald-import/plugin', () => {
     test('registers populatePendingImport onComplete handler', async () => {
       const completedJob = { id: 'testing' };
 
-      const [jobName, func] = server.messageQueue.onComplete.secondCall.args;
+      const [jobName, func] = server.messageQueue.onComplete.getCall(2).args;
       func(completedJob);
 
       expect(jobName).to.equal(jobs.populatePendingImport.job.jobName);
@@ -87,7 +109,7 @@ experiment('modules/nald-import/plugin', () => {
     });
 
     test('registers importLicence job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.thirdCall.args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(3).args;
 
       expect(jobName).to.equal(jobs.importLicence.job.jobName);
       expect(options).to.equal(jobs.importLicence.job.options);


### PR DESCRIPTION
WATER-2882

Updates the import to include a new step that deletes any documents
where the licence no longer exists in the NALD import data.