### PR TITLE
Schedule licence/charging imports overnight in production

### DIFF
--- a/config.js
+++ b/config.js
@@ -88,7 +88,13 @@ module.exports = {
 
   import: {
     returns: { importYears: process.env.IMPORT_RETURNS_YEARS || 6 },
-    zipPassword: process.env.NALD_ZIP_PASSWORD
+    zipPassword: process.env.NALD_ZIP_PASSWORD,
+    licences: {
+      schedule: isProduction ? '0 4 * * 1,3,5' : '0 16 * * 1,3,5'
+    },
+    charging: {
+      schedule: isProduction ? '0 2 * * 1,3,5' : '0 14 * * 1,3,5'
+    }
   },
 
   redis: {

--- a/src/modules/charging-import/plugin.js
+++ b/src/modules/charging-import/plugin.js
@@ -3,15 +3,13 @@ const jobs = require('./jobs');
 
 const chargingImport = require('./lib/import');
 const { createRegister } = require('../../lib/plugin');
-
-// run at 1000 Mon, Weds and Fri
-const cronSchedule = '0 10 * * 1,3,5';
+const config = require('../../../config');
 
 const registerSubscribers = async server => {
   // Import charging data
   await server.messageQueue.subscribe(jobs.IMPORT_CHARGING_DATA, chargingImport.importChargingData);
 
-  cron.schedule(cronSchedule, async () => {
+  cron.schedule(config.import.charging.schedule, async () => {
     await server.messageQueue.publish(jobs.importChargingData());
   });
 };

--- a/src/modules/licence-import/plugin.js
+++ b/src/modules/licence-import/plugin.js
@@ -2,6 +2,7 @@ const cron = require('node-cron');
 const jobs = require('./jobs');
 const handlers = require('./handlers');
 const { createRegister } = require('../../lib/plugin');
+const config = require('../../../config');
 
 const getOptions = () => ({
   teamSize: 750,
@@ -37,8 +38,7 @@ const registerSubscribers = async server => {
 
   await server.messageQueue.subscribe(jobs.IMPORT_LICENCE_JOB, getOptions(), handlers.importLicence);
 
-  // At 15:10 on Monday, Wednesday, and Friday
-  cron.schedule('10 15 * * 1,3,5', async () => {
+  cron.schedule(config.import.licences.schedule, async () => {
     await server.messageQueue.publish(jobs.deleteDocuments());
   });
 };

--- a/test/modules/charging-import/plugin.js
+++ b/test/modules/charging-import/plugin.js
@@ -51,9 +51,9 @@ experiment('modules/charging-import/plugin.js', () => {
         )).to.be.true();
       });
 
-      test('schedules a cron job to run the import 1000 on Mon, Wed and Fri', async () => {
+      test('schedules a cron job to run the import at 2pm on Mon, Wed and Fri in non-prod environments', async () => {
         const [schedule] = cron.schedule.lastCall.args;
-        expect(schedule).to.equal('0 10 * * 1,3,5');
+        expect(schedule).to.equal('0 14 * * 1,3,5');
       });
     });
 

--- a/test/modules/licence-import/plugin.js
+++ b/test/modules/licence-import/plugin.js
@@ -94,9 +94,9 @@ experiment('modules/licence-import/plugin.js', () => {
         )).to.be.true();
       });
 
-      test('schedules a cron job at 15:10 on Monday, Wednesday, and Friday', async () => {
+      test('schedules a cron job at 16 on Monday, Wednesday, and Friday in non-production environments', async () => {
         expect(cron.schedule.calledWith(
-          '10 15 * * 1,3,5'
+          '0 16 * * 1,3,5'
         )).to.be.true();
       });
     });


### PR DESCRIPTION
WATER-2934

Moves licence import and charging data import jobs overnight for `production` to avoid impacting users.