### PR TITLE
Update 20201120135927-create-charge-versions-metadata-table-up.sql

### DIFF
--- a/migrations/sqls/20201120135927-create-charge-versions-metadata-table-up.sql
+++ b/migrations/sqls/20201120135927-create-charge-versions-metadata-table-up.sql
@@ -8,5 +8,6 @@ CREATE TABLE water_import.charge_versions_metadata
 	status charge_version_metadata_status not null,
 	is_nald_gap boolean not null,
 	date_created timestamp with time zone NOT NULL DEFAULT NOW(),
-    date_updated timestamp with time zone
+    date_updated timestamp with time zone,
+    PRIMARY KEY ("external_id")
 );


### PR DESCRIPTION
Minor fix whereby I forgot to mark the primary key as.... the primary key. [Sorry](https://media.tenor.com/images/5c735243bd7bf04b6bbe5c5b55b28b72/tenor.gif). 