### PR TITLE
Remove logic to skip return import for older returns - causes bug 3019

### DIFF
--- a/config.js
+++ b/config.js
@@ -71,7 +71,6 @@ module.exports = {
   proxy: process.env.PROXY,
 
   import: {
-    returns: { importYears: process.env.IMPORT_RETURNS_YEARS || 6 },
     nald: {
       isEtagCheckEnabled: !isTest,
       zipPassword: process.env.NALD_ZIP_PASSWORD

--- a/src/modules/nald-import/lib/persist-returns.js
+++ b/src/modules/nald-import/lib/persist-returns.js
@@ -42,7 +42,7 @@ const getUpdateRow = (row) => {
  * @param {Object} row
  * @return {Promise} resolves when row is created/updated
  */
-const createOrUpdateReturn = async (row, date) => {
+const createOrUpdateReturn = async row => {
   const { return_id: returnId } = row;
 
   const exists = await returnExists(returnId);

--- a/src/modules/nald-import/lib/persist-returns.js
+++ b/src/modules/nald-import/lib/persist-returns.js
@@ -6,7 +6,6 @@
 const { pick } = require('lodash');
 const moment = require('moment');
 const returnsApi = require('../../../lib/connectors/returns');
-const config = require('../../../../config');
 
 const { returns } = returnsApi;
 
@@ -46,19 +45,14 @@ const getUpdateRow = (row) => {
 const createOrUpdateReturn = async (row, date) => {
   const { return_id: returnId } = row;
 
-  const configYear = moment(date).year() - config.import.returns.importYears;
-  const rowYear = moment(row.start_date).year();
+  const exists = await returnExists(returnId);
 
-  if (rowYear > configYear) {
-    const exists = await returnExists(returnId);
-
-    // Conditional update
-    if (exists) {
-      return returns.updateOne(returnId, getUpdateRow(row));
-    }
-    // Insert
-    return returns.create(row);
+  // Conditional update
+  if (exists) {
+    return returns.updateOne(returnId, getUpdateRow(row));
   }
+  // Insert
+  return returns.create(row);
 };
 
 /**

--- a/test/modules/nald-import/lib/persist-returns.js
+++ b/test/modules/nald-import/lib/persist-returns.js
@@ -4,7 +4,6 @@ const sandbox = require('sinon').createSandbox();
 
 const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
 const { expect } = require('@hapi/code');
-const config = require('../../../../config');
 
 const returnsApi = require('../../../../src/lib/connectors/returns');
 const persistReturns = require('../../../../src/modules/nald-import/lib/persist-returns');
@@ -46,7 +45,6 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
     sandbox.stub(returnsApi.returns, 'findOne');
     sandbox.stub(returnsApi.returns, 'create');
     sandbox.stub(returnsApi.returns, 'updateOne');
-    sandbox.stub(config.import.returns, 'importYears').value(3);
   });
 
   afterEach(async () => {
@@ -98,16 +96,6 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
       expect(returnsApi.returns.updateOne.firstCall).to.equal(null);
     });
 
-    test('does not create a row if the record is old', async () => {
-      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null });
-      returnsApi.returns.create.resolves({ error: null });
-
-      await persistReturns.createOrUpdateReturn(naldReturn, '2020-01-01');
-
-      expect(returnsApi.returns.create.firstCall).to.equal(null);
-      expect(returnsApi.returns.updateOne.firstCall).to.equal(null);
-    });
-
     test('updates a NALD return if the record is present', async () => {
       returnsApi.returns.findOne.resolves({ error: null, data: naldReturn });
       returnsApi.returns.updateOne.resolves({ error: null });
@@ -120,15 +108,6 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
         received_date: naldReturn.received_date,
         due_date: naldReturn.due_date
       }]);
-    });
-
-    test('does not update a NALD return if the record is old', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: naldReturn });
-      returnsApi.returns.updateOne.resolves({ error: null });
-      await persistReturns.createOrUpdateReturn(naldReturn, '2020-01-01');
-
-      expect(returnsApi.returns.create.firstCall).to.equal(null);
-      expect(returnsApi.returns.updateOne.firstCall).to.equal(null);
     });
 
     test('updates a digital service return metadata only if the record is present', async () => {


### PR DESCRIPTION
`WATER-3019`

Logic had been added to speed up the import by skipping import of older returns.

However this causes the `metadata->>'isCurrent'` flag to not get refreshed, meaning that in some cases the returns for the wrong owner are displayed in the service.

The logic to skip import of older returns has therefore been removed.