### PR TITLE
Add feature flags to enable/disable import of invoice accounts and do…

### DIFF
--- a/config.js
+++ b/config.js
@@ -80,7 +80,12 @@ module.exports = {
       schedule: isProduction ? '0 4 * * 1,2,3,4,5' : '0 16 * * 1,2,3,4,5',
       isInvoiceAccountImportEnabled: true,
       isLicenceAgreementImportEnabled: true,
-      isBillingDocumentRoleImportEnabled: true
+      // Note: we think a solution is needed where a list of billing contacts
+      // for a given licence is calculated from the charge version history
+      // in the water service, and synced to CRM v2.
+      // This will supersede the implementation here were the billing contact history
+      // was calculated from NALD data
+      isBillingDocumentRoleImportEnabled: false
     },
     charging: {
       schedule: isProduction ? '0 2 * * 1,2,3,4,5' : '0 14 * * 1,2,3,4,5'

--- a/config.js
+++ b/config.js
@@ -77,7 +77,10 @@ module.exports = {
       path: process.env.S3_NALD_IMPORT_PATH || 'wal_nald_data_release'
     },
     licences: {
-      schedule: isProduction ? '0 4 * * 1,2,3,4,5' : '0 16 * * 1,2,3,4,5'
+      schedule: isProduction ? '0 4 * * 1,2,3,4,5' : '0 16 * * 1,2,3,4,5',
+      isInvoiceAccountImportEnabled: true,
+      isLicenceAgreementImportEnabled: true,
+      isBillingDocumentRoleImportEnabled: true
     },
     charging: {
       schedule: isProduction ? '0 2 * * 1,2,3,4,5' : '0 14 * * 1,2,3,4,5'

--- a/config.js
+++ b/config.js
@@ -78,12 +78,14 @@ module.exports = {
     },
     licences: {
       schedule: isProduction ? '0 4 * * 1,2,3,4,5' : '0 16 * * 1,2,3,4,5',
+      // Note: these 2 flags need to be set to false for charging go-live
+      // to suspend the import of invoice accounts and licence agreements
       isInvoiceAccountImportEnabled: true,
       isLicenceAgreementImportEnabled: true,
       // Note: we think a solution is needed where a list of billing contacts
       // for a given licence is calculated from the charge version history
       // in the water service, and synced to CRM v2.
-      // This will supersede the implementation here were the billing contact history
+      // This will supersede the implementation here where the billing contact history
       // was calculated from NALD data
       isBillingDocumentRoleImportEnabled: false
     },

--- a/src/modules/licence-import/load/company.js
+++ b/src/modules/licence-import/load/company.js
@@ -1,5 +1,6 @@
 const { uniqBy } = require('lodash');
 const connectors = require('./connectors');
+const config = require('../../../../config');
 
 const getAddresses = company => {
   const companyAddresses = company.addresses.map(row => row.address);
@@ -9,10 +10,11 @@ const getAddresses = company => {
     return [...acc, ...addresses];
   }, []);
 
-  const addresses = [
-    ...companyAddresses,
-    ...invoiceAccountAddresses
-  ];
+  // Allow import of invoice accounts to be disabled for charging go live
+  const addresses = config.import.licences.isInvoiceAccountImportEnabled
+    ? [...companyAddresses, ...invoiceAccountAddresses]
+    : companyAddresses;
+
   return uniqBy(addresses, row => row.externalId);
 };
 
@@ -37,6 +39,11 @@ const loadInvoiceAccount = async (company, invoiceAccount) => {
 };
 
 const loadInvoiceAccounts = async company => {
+  // Allow import of invoice accounts to be disabled for charging go live
+  if (!config.import.licences.isInvoiceAccountImportEnabled) {
+    return;
+  }
+
   const tasks = company.invoiceAccounts.map(invoiceAccount =>
     loadInvoiceAccount(company, invoiceAccount)
   );

--- a/src/modules/licence-import/load/company.js
+++ b/src/modules/licence-import/load/company.js
@@ -41,7 +41,7 @@ const loadInvoiceAccount = async (company, invoiceAccount) => {
 const loadInvoiceAccounts = async company => {
   // Allow import of invoice accounts to be disabled for charging go live
   if (!config.import.licences.isInvoiceAccountImportEnabled) {
-    return;
+    return [];
   }
 
   const tasks = company.invoiceAccounts.map(invoiceAccount =>

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -27,7 +27,7 @@ const loadDocument = async document => {
 const loadAgreements = licence => {
   // Allow import of licence agreements to be disabled for charging go live
   if (!config.import.licences.isLicenceAgreementImportEnabled) {
-    return;
+    return [];
   }
 
   const tasks = licence.agreements.map(agreement =>

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -27,7 +27,7 @@ const loadDocument = async document => {
 const loadAgreements = licence => {
   // Allow import of licence agreements to be disabled for charging go live
   if (!config.import.licences.isLicenceAgreementImportEnabled) {
-    return [];
+    return Promise.resolve([]);
   }
 
   const tasks = licence.agreements.map(agreement =>

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -6,7 +6,10 @@ const isImportableRole = role => {
   if (config.import.licences.isBillingDocumentRoleImportEnabled) {
     return true;
   }
-  // Allow import of billing document roles to be disabled for charging go live
+
+  // Where the import of billing document roles is disabled via the
+  // config flag, we will import any role where it does not have
+  // a "billing" role
   return role.role !== roles.ROLE_BILLING;
 };
 

--- a/test/modules/licence-import/load/company.js
+++ b/test/modules/licence-import/load/company.js
@@ -5,49 +5,51 @@ const sandbox = require('sinon').createSandbox();
 const { loadCompany } = require('../../../../src/modules/licence-import/load/company');
 const connectors = require('../../../../src/modules/licence-import/load/connectors');
 
-experiment('modules/licence-import/load/company', () => {
-  const createCompany = () => ({
-    externalId: '1:100',
+const config = require('../../../../config');
+
+const createCompany = () => ({
+  externalId: '1:100',
+  addresses: [{
+    startDate: '2018-01-15',
+    endDate: null,
+    address: {
+      externalId: '1:1040'
+    }
+  }],
+  invoiceAccounts: [{
+    startDate: '2018-02-05',
+    endDate: null,
+    invoiceAccount: {
+      invoiceAccountNumber: 'X1234'
+    },
     addresses: [{
-      startDate: '2018-01-15',
+      startDate: '2018-01-14',
       endDate: null,
       address: {
-        externalId: '1:1040'
+        externalId: '1:2056'
       }
-    }],
-    invoiceAccounts: [{
-      startDate: '2018-02-05',
-      endDate: null,
-      invoiceAccount: {
-        invoiceAccountNumber: 'X1234'
-      },
-      addresses: [{
-        startDate: '2018-01-14',
-        endDate: null,
-        address: {
-          externalId: '1:2056'
-        }
-      }]
-    }],
-    contacts: [{
-      role: 'licenceHolder',
-      startDate: '2018-01-01',
+    }]
+  }],
+  contacts: [{
+    role: 'licenceHolder',
+    startDate: '2018-01-01',
+    endDate: null,
+    contact: {
+      externalId: '1:25'
+    }
+  }, {
+    role: [{
+      role: 'billing',
+      startDate: '2018-06-06',
       endDate: null,
       contact: {
-        externalId: '1:25'
+        externalId: '1:50'
       }
-    }, {
-      role: [{
-        role: 'billing',
-        startDate: '2018-06-06',
-        endDate: null,
-        contact: {
-          externalId: '1:50'
-        }
-      }]
     }]
-  });
+  }]
+});
 
+experiment('modules/licence-import/load/company', () => {
   let company;
 
   beforeEach(async () => {
@@ -60,58 +62,91 @@ experiment('modules/licence-import/load/company', () => {
     sandbox.stub(connectors, 'createInvoiceAccountAddress');
 
     company = createCompany();
-    await loadCompany(company);
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  test('creates company', async () => {
-    expect(
-      connectors.createCompany.calledWith(company)
-    ).to.be.true();
+  experiment('when the flags are enabled in the config', () => {
+    beforeEach(async () => {
+      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(true);
+
+      await loadCompany(company);
+    });
+
+    test('creates company', async () => {
+      expect(
+        connectors.createCompany.calledWith(company)
+      ).to.be.true();
+    });
+
+    test('creates addresses', async () => {
+      expect(
+        connectors.createAddress.calledWith(company.addresses[0].address)
+      ).to.be.true();
+    });
+
+    test('creates company addresses', async () => {
+      expect(
+        connectors.createCompanyAddress.calledWith(company, company.addresses[0])
+      ).to.be.true();
+    });
+
+    test('creates invoice account addresses', async () => {
+      expect(
+        connectors.createAddress.calledWith(company.invoiceAccounts[0].addresses[0].address)
+      ).to.be.true();
+    });
+
+    test('creates contacts', async () => {
+      expect(
+        connectors.createContact.calledWith(company.contacts[0].contact)
+      ).to.be.true();
+    });
+
+    test('creates company contact', async () => {
+      expect(
+        connectors.createCompanyContact.calledWith(company, company.contacts[0])
+      ).to.be.true();
+    });
+
+    test('creates invoice account', async () => {
+      expect(
+        connectors.createInvoiceAccount.calledWith(company, company.invoiceAccounts[0])
+      ).to.be.true();
+    });
+
+    test('creates invoice account addresses', async () => {
+      expect(
+        connectors.createInvoiceAccountAddress.calledWith(company.invoiceAccounts[0], company.invoiceAccounts[0].addresses[0])
+      ).to.be.true();
+    });
   });
 
-  test('creates addresses', async () => {
-    expect(
-      connectors.createAddress.calledWith(company.addresses[0].address)
-    ).to.be.true();
-  });
+  experiment('when the isInvoiceAccountImportEnabled flag is disabled in the config', () => {
+    beforeEach(async () => {
+      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(false);
 
-  test('creates company addresses', async () => {
-    expect(
-      connectors.createCompanyAddress.calledWith(company, company.addresses[0])
-    ).to.be.true();
-  });
+      await loadCompany(company);
+    });
 
-  test('creates invoice account addresses', async () => {
-    expect(
-      connectors.createAddress.calledWith(company.invoiceAccounts[0].addresses[0].address)
-    ).to.be.true();
-  });
+    test('creates invoice account addresses', async () => {
+      expect(
+        connectors.createAddress.calledWith(company.invoiceAccounts[0].addresses[0].address)
+      ).to.be.false();
+    });
 
-  test('creates contacts', async () => {
-    expect(
-      connectors.createContact.calledWith(company.contacts[0].contact)
-    ).to.be.true();
-  });
+    test('creates invoice account', async () => {
+      expect(
+        connectors.createInvoiceAccount.calledWith(company, company.invoiceAccounts[0])
+      ).to.be.false();
+    });
 
-  test('creates company contact', async () => {
-    expect(
-      connectors.createCompanyContact.calledWith(company, company.contacts[0])
-    ).to.be.true();
-  });
-
-  test('creates invoice account', async () => {
-    expect(
-      connectors.createInvoiceAccount.calledWith(company, company.invoiceAccounts[0])
-    ).to.be.true();
-  });
-
-  test('creates invoice account addresses', async () => {
-    expect(
-      connectors.createInvoiceAccountAddress.calledWith(company.invoiceAccounts[0], company.invoiceAccounts[0].addresses[0])
-    ).to.be.true();
+    test('creates invoice account addresses', async () => {
+      expect(
+        connectors.createInvoiceAccountAddress.calledWith(company.invoiceAccounts[0], company.invoiceAccounts[0].addresses[0])
+      ).to.be.false();
+    });
   });
 });


### PR DESCRIPTION
`WATER-3079`

Adds feature flags to disable the import of:
* Invoice/billing accounts
* Document roles (billing role only)
* Licence agreements

These are data that will be managed in WRLS from go live date onwards