### PR TITLE
Fix date mapping issue

### DIFF
--- a/src/modules/licence-import/transform/mappers/document.js
+++ b/src/modules/licence-import/transform/mappers/document.js
@@ -14,8 +14,7 @@ const statuses = {
 const mapStatus = status => statuses[status];
 
 const getDocumentEndDate = (licenceVersion, licence) => {
-  const endDates = [licence.endDate, licenceVersion.EFF_END_DATE]
-    .map(date.mapNaldDate)
+  const endDates = [licence.endDate, date.mapNaldDate(licenceVersion.EFF_END_DATE)]
     .filter(identity);
 
   return date.getMinDate(endDates);

--- a/test/modules/licence-import/transform/mappers/documents.js
+++ b/test/modules/licence-import/transform/mappers/documents.js
@@ -236,7 +236,7 @@ experiment('modules/licence-import/transform/mappers/document', () => {
     test('the licence end date is used', async () => {
       const licence = {
         licenceNumber: '123/123',
-        endDate: '01/01/2020'
+        endDate: '2020-01-01'
       };
 
       const versions = [
@@ -261,7 +261,7 @@ experiment('modules/licence-import/transform/mappers/document', () => {
     test('the earliest date is used', async () => {
       const licence = {
         licenceNumber: '123/123',
-        endDate: '01/01/2020'
+        endDate: '2020-01-01'
       };
 
       const versions = [


### PR DESCRIPTION
Fixes an issue mapping document end dates.
A NALD format date was expected for the licence `endDate` property (DD/MM/YYYY).  However this date was already in ISO format (YYYY-MM-DD)