### PR TITLE
Modify TPT agreement import end date

### DIFF
--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -49,11 +49,14 @@ exports.getChargeVersions = `
   ORDER BY cv."VERS_NO"::integer;
 `;
 
-exports.getTwoPartTariffAgreements = `SELECT a.* FROM import."NALD_CHG_VERSIONS" cv
+exports.getTwoPartTariffAgreements = `
+SELECT a.*, cv."EFF_END_DATE" as charge_version_end_date 
+FROM import."NALD_CHG_VERSIONS" cv
 JOIN import."NALD_CHG_ELEMENTS" e ON cv."FGAC_REGION_CODE"=e."FGAC_REGION_CODE" AND cv."VERS_NO"=e."ACVR_VERS_NO" AND cv."AABL_ID"=e."ACVR_AABL_ID"
 JOIN import."NALD_CHG_AGRMNTS" a ON e."FGAC_REGION_CODE"=a."FGAC_REGION_CODE" AND e."ID"=a."ACEL_ID"
 WHERE cv."FGAC_REGION_CODE"=$1 AND cv."AABL_ID"=$2 AND a."AFSA_CODE"='S127'
-ORDER BY cv."VERS_NO"::integer`;
+ORDER BY cv."VERS_NO"::integer;
+`;
 
 exports.getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
 JOIN (

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -1,14 +1,26 @@
+'use strict';
+
 const helpers = require('@envage/water-abstraction-helpers');
 const date = require('./date');
+
 const { groupBy, sortBy, flatMap } = require('lodash');
 
-const mapAgreement = chargeAgreement => ({
-  agreementCode: chargeAgreement.AFSA_CODE,
-  startDate: date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
-  endDate: date.mapNaldDate(chargeAgreement.EFF_END_DATE)
-});
+const mapAgreement = chargeAgreement => {
+  // End date is the earlier of the agreement end date or the
+  // charge version end date.  Either can be null.
+  const endDate = date.getMinDate([
+    date.mapNaldDate(chargeAgreement.EFF_END_DATE),
+    date.mapNaldDate(chargeAgreement.charge_version_end_date)
+  ]);
 
-const mapAgreements = (tptAgreements, s130Agreements) => {
+  return {
+    agreementCode: chargeAgreement.AFSA_CODE,
+    startDate: date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
+    endDate
+  };
+};
+
+const mapAgreements = (tptAgreements, s130Agreements = []) => {
   const mapped = [...tptAgreements, ...s130Agreements].map(mapAgreement);
 
   // Group by agreement code

--- a/test/modules/licence-import/transform/mappers/agreement.js
+++ b/test/modules/licence-import/transform/mappers/agreement.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { test, experiment } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const { mapAgreements } = require('../../../../../src/modules/licence-import/transform/mappers/agreement');
+
+experiment('modules/licence-import/mappers/agreement', () => {
+  const createAgreement = (overrides = {}) => ({
+    AFSA_CODE: overrides.code || 'S127',
+    EFF_ST_DATE: overrides.startDate || '01/01/2020',
+    EFF_END_DATE: overrides.endDate || 'null',
+    charge_version_end_date: overrides.chargeVersionEndDate || 'null'
+  });
+
+  test('maps agreements with no end date', async () => {
+    const result = mapAgreements([createAgreement()]);
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: null }]);
+  });
+
+  test('maps agreements with an end date', async () => {
+    const result = mapAgreements([createAgreement({ endDate: '01/06/2021' })]);
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
+  });
+
+  test('maps agreements with a charge version end date', async () => {
+    const result = mapAgreements([createAgreement({ chargeVersionEndDate: '01/06/2021' })]);
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
+  });
+
+  test('uses the earliest end date when there is an end date and charge version end date', async () => {
+    const result = mapAgreements([createAgreement({ endDate: '02/07/2021', chargeVersionEndDate: '01/06/2021' })]);
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
+  });
+
+  test('merges adjacent date ranges with the same code', async () => {
+    const agreements = [
+      createAgreement({ code: 'S130', endDate: '01/05/2020' }),
+      createAgreement({ endDate: '01/06/2021' }),
+      createAgreement({ startDate: '02/06/2021' })
+    ];
+    const result = mapAgreements(agreements);
+    expect(result[0]).to.equal({
+      agreementCode: 'S130',
+      startDate: '2020-01-01',
+      endDate: '2020-05-01'
+    });
+    expect(result[1]).to.equal({ agreementCode: 'S127', startDate: '2020-01-01', endDate: null });
+  });
+});


### PR DESCRIPTION
`WATER-3141`

Import of TPT agreements now uses the earliest of:
* Agreement end date
* Charge version end date