### PR TITLE
Feat/water 3157 import tpt agreement purposes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3406,7 +3406,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdir": {

--- a/src/modules/charging-import/jobs/charge-versions.js
+++ b/src/modules/charging-import/jobs/charge-versions.js
@@ -16,7 +16,10 @@ const handler = () => queryLoader.loadQueries('Import charge versions', [
   chargingQueries.importChargeVersions,
   chargingQueries.importChargeElements,
   chargingQueries.cleanupChargeElements,
-  chargingQueries.cleanupChargeVersions
+  chargingQueries.cleanupChargeVersions,
+  chargingQueries.cleanupTwoPartTariffAgreementsWithoutExternalId,
+  chargingQueries.importTwoPartTariffAgreements,
+  chargingQueries.importTwoPartTariffAgreementPurposeUses
 ]);
 
 exports.jobName = jobName;

--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -49,20 +49,6 @@ exports.getChargeVersions = `
   ORDER BY cv."VERS_NO"::integer;
 `;
 
-exports.getTwoPartTariffAgreements = `
-SELECT a.*, 
-  cv."EFF_END_DATE" as charge_version_end_date, 
-  cv."EFF_ST_DATE" as charge_start_date, 
-  cv."VERS_NO" as charge_version_number, 
-  cv."STATUS" as charge_version_status,
-  cv."IN_ERROR_STATUS" as charge_version_error_status,
-  e."APUR_APUS_CODE" as element_purpose_use
-FROM import."NALD_CHG_VERSIONS" cv
-JOIN import."NALD_CHG_ELEMENTS" e ON cv."FGAC_REGION_CODE"=e."FGAC_REGION_CODE" AND cv."VERS_NO"=e."ACVR_VERS_NO" AND cv."AABL_ID"=e."ACVR_AABL_ID"
-JOIN import."NALD_CHG_AGRMNTS" a ON e."FGAC_REGION_CODE"=a."FGAC_REGION_CODE" AND e."ID"=a."ACEL_ID"
-WHERE cv."FGAC_REGION_CODE"=$1 AND cv."AABL_ID"=$2 AND a."AFSA_CODE"='S127'
-ORDER BY cv."VERS_NO"::integer;`;
-
 exports.getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
 JOIN (
   SELECT DISTINCT cv."FGAC_REGION_CODE", cv."AIIA_ALHA_ACC_NO"

--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -50,13 +50,18 @@ exports.getChargeVersions = `
 `;
 
 exports.getTwoPartTariffAgreements = `
-SELECT a.*, cv."EFF_END_DATE" as charge_version_end_date 
+SELECT a.*, 
+  cv."EFF_END_DATE" as charge_version_end_date, 
+  cv."EFF_ST_DATE" as charge_start_date, 
+  cv."VERS_NO" as charge_version_number, 
+  cv."STATUS" as charge_version_status,
+  cv."IN_ERROR_STATUS" as charge_version_error_status,
+  e."APUR_APUS_CODE" as element_purpose_use
 FROM import."NALD_CHG_VERSIONS" cv
 JOIN import."NALD_CHG_ELEMENTS" e ON cv."FGAC_REGION_CODE"=e."FGAC_REGION_CODE" AND cv."VERS_NO"=e."ACVR_VERS_NO" AND cv."AABL_ID"=e."ACVR_AABL_ID"
 JOIN import."NALD_CHG_AGRMNTS" a ON e."FGAC_REGION_CODE"=a."FGAC_REGION_CODE" AND e."ID"=a."ACEL_ID"
 WHERE cv."FGAC_REGION_CODE"=$1 AND cv."AABL_ID"=$2 AND a."AFSA_CODE"='S127'
-ORDER BY cv."VERS_NO"::integer;
-`;
+ORDER BY cv."VERS_NO"::integer;`;
 
 exports.getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
 JOIN (

--- a/src/modules/licence-import/extract/index.js
+++ b/src/modules/licence-import/extract/index.js
@@ -22,10 +22,9 @@ const getLicenceData = async licenceNumber => {
   const licence = await importConnector.getLicence(licenceNumber);
   const { ID: id, FGAC_REGION_CODE: regionCode } = licence;
 
-  const [versions, chargeVersions, tptAgreements, section130Agreements, purposes, roles] = await Promise.all([
+  const [versions, chargeVersions, section130Agreements, purposes, roles] = await Promise.all([
     importConnector.getLicenceVersions(regionCode, id),
     importConnector.getChargeVersions(regionCode, id),
-    importConnector.getTwoPartTariffAgreements(regionCode, id),
     importConnector.getSection130Agreements(regionCode, id),
     importConnector.getLicencePurposes(regionCode, id),
     importConnector.getLicenceRoles(regionCode, id)
@@ -43,7 +42,6 @@ const getLicenceData = async licenceNumber => {
     parties,
     purposes,
     section130Agreements,
-    tptAgreements,
     versions,
     roles
   };

--- a/src/modules/licence-import/transform/licence.js
+++ b/src/modules/licence-import/transform/licence.js
@@ -34,7 +34,7 @@ const transformLicence = licenceData => {
   });
 
   // Agreements - section 127/130
-  licence.agreements = mappers.agreement.mapAgreements(licenceData.tptAgreements, licenceData.section130Agreements);
+  licence.agreements = mappers.agreement.mapAgreements(licenceData.section130Agreements);
 
   licence.versions = licenceData.versions.map(version => {
     return mappers.licenceVersion.mapLicenceVersion(version, purposes);

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -20,8 +20,8 @@ const mapAgreement = chargeAgreement => {
   };
 };
 
-const mapAgreements = (tptAgreements, s130Agreements = []) => {
-  const mapped = [...tptAgreements, ...s130Agreements].map(mapAgreement);
+const mapAgreements = (s130Agreements = []) => {
+  const mapped = s130Agreements.map(mapAgreement);
 
   // Group by agreement code
   const groups = groupBy(mapped, agreement => agreement.agreementCode);

--- a/test/modules/charging-import/jobs/charge-versions.js
+++ b/test/modules/charging-import/jobs/charge-versions.js
@@ -28,7 +28,11 @@ experiment('modules/charging-import/jobs/charge-versions.js', () => {
           chargeVersionQueries.importChargeVersions,
           chargeVersionQueries.importChargeElements,
           chargeVersionQueries.cleanupChargeElements,
-          chargeVersionQueries.cleanupChargeVersions
+          chargeVersionQueries.cleanupChargeVersions,
+          chargeVersionQueries.cleanupTwoPartTariffAgreementsWithoutExternalId,
+          chargeVersionQueries.importTwoPartTariffAgreements,
+          chargeVersionQueries.importTwoPartTariffAgreementPurposeUses
+
         ]
       )).to.be.true();
     });

--- a/test/modules/licence-import/extract/index.js
+++ b/test/modules/licence-import/extract/index.js
@@ -78,12 +78,6 @@ experiment('modules/licence-import/extract/index.js', () => {
       ).to.be.true();
     });
 
-    test('importConnector.getTwoPartTariffAgreements is called with the region code / licence ID', async () => {
-      expect(
-        importConnector.getTwoPartTariffAgreements.calledWith('4', '7')
-      ).to.be.true();
-    });
-
     test('importConnector.getSection130Agreements is called with the region code / licence ID', async () => {
       expect(
         importConnector.getSection130Agreements.calledWith('4', '7')
@@ -118,7 +112,6 @@ experiment('modules/licence-import/extract/index.js', () => {
       expect(result.licence).to.equal(data.licence);
       expect(result.versions).to.equal(data.licenceVersions);
       expect(result.chargeVersions).to.equal(data.chargeVersions);
-      expect(result.tptAgreements).to.equal(data.twoPartTariffAgreements);
       expect(result.section130Agreements).to.equal(data.section130Agreements);
       expect(result.parties).to.equal(data.parties);
       expect(result.addresses).to.equal(data.addresses);

--- a/test/modules/licence-import/transform/licence.js
+++ b/test/modules/licence-import/transform/licence.js
@@ -221,20 +221,10 @@ experiment('modules/licence-import/transform/licence.js', () => {
         expect(result.documents[1].roles.map(role => role.role)).to.only.include(['licenceHolder', 'billing']);
       });
 
-      test('the two part tariff agreements are merged where date ranges are adjacent', async () => {
-        expect(result.agreements[0].agreementCode).to.equal('S127');
-        expect(result.agreements[0].startDate).to.equal('2015-04-02');
-        expect(result.agreements[0].endDate).to.equal('2015-08-12');
-
-        expect(result.agreements[1].agreementCode).to.equal('S127');
-        expect(result.agreements[1].startDate).to.equal('2017-07-01');
-        expect(result.agreements[1].endDate).to.equal(null);
-      });
-
       test('the S130 agreement is added', async () => {
-        expect(result.agreements[2].agreementCode).to.equal('S130');
-        expect(result.agreements[2].startDate).to.equal('2015-04-02');
-        expect(result.agreements[2].endDate).to.equal('2015-07-05');
+        expect(result.agreements[0].agreementCode).to.equal('S130');
+        expect(result.agreements[0].startDate).to.equal('2015-04-02');
+        expect(result.agreements[0].endDate).to.equal('2015-07-05');
       });
 
       test('the versions contain the purposes', async () => {


### PR DESCRIPTION
'WATER-3157`

Modifies import of TPT licence agreements so that:
* Similar agreements in contiguous time ranges are no longer merged
* Agreement purposes are imported
* Agreement time range is constrained by charge version time range

Ignores agreements where:
* Start date is outside charge version time range
* Charge version is draft/error status
* Charge version is superseded by another with a higher version number starting on the same date