### PR TITLE
Include flag for if TPT enabled at element level

### DIFF
--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -112,6 +112,14 @@ const getLicenceByRef = async licenceRef => {
 
 const flagLicenceForSupplementaryBilling = async licenceId => pool.query(queries.flagLicenceForSupplementaryBilling, [licenceId]);
 
+const cleanUpAgreements = licence => {
+  // Create keys for the agreements we wish to keep
+  const keys = licence.agreements.map(agreement =>
+    `${agreement.agreementCode}:${agreement.startDate}`);
+
+  return pool.query(queries.cleanUpAgreements, [licence.licenceRef, keys]);
+};
+
 exports.createAddress = createAddress;
 exports.createAgreement = createAgreement;
 exports.createCompany = createCompany;
@@ -127,3 +135,4 @@ exports.createLicenceVersion = createLicenceVersion;
 exports.createLicenceVersionPurpose = createLicenceVersionPurpose;
 exports.getLicenceByRef = getLicenceByRef;
 exports.flagLicenceForSupplementaryBilling = flagLicenceForSupplementaryBilling;
+exports.cleanUpAgreements = cleanUpAgreements;

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const connectors = require('./connectors');
 const config = require('../../../../config');
 const roles = require('../transform/mappers/roles');
@@ -27,11 +29,14 @@ const loadDocument = async document => {
   return loadDocumentRoles(document);
 };
 
-const loadAgreements = licence => {
+const loadAgreements = async licence => {
   // Allow import of licence agreements to be disabled for charging go live
   if (!config.import.licences.isLicenceAgreementImportEnabled) {
     return Promise.resolve([]);
   }
+
+  // Deletes any "nald" agreements not found via the current import process
+  await connectors.cleanUpAgreements(licence);
 
   const tasks = licence.agreements.map(agreement =>
     connectors.createAgreement(licence, agreement)

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -6,6 +6,13 @@ const date = require('./date');
 const { groupBy, sortBy, flatMap } = require('lodash');
 
 const mapAgreement = chargeAgreement => {
+  // Start date is the later of the agreement start date or the
+  // charge version start date.
+  const startDate = date.getMaxDate([
+    date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
+    date.mapNaldDate(chargeAgreement.charge_version_start_date)
+  ]);
+
   // End date is the earlier of the agreement end date or the
   // charge version end date.  Either can be null.
   const endDate = date.getMinDate([
@@ -15,7 +22,7 @@ const mapAgreement = chargeAgreement => {
 
   return {
     agreementCode: chargeAgreement.AFSA_CODE,
-    startDate: date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
+    startDate,
     endDate
   };
 };

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -3,7 +3,10 @@
 const helpers = require('@envage/water-abstraction-helpers');
 const date = require('./date');
 
-const { groupBy, sortBy, flatMap } = require('lodash');
+const { groupBy, sortBy, flatMap, uniqBy } = require('lodash');
+
+const getUniqueKey = agreement =>
+ `${agreement.startDate}:${agreement.endDate}:${agreement.agreementCode}`;
 
 const mapAgreement = chargeAgreement => {
   // Start date is the later of the agreement start date or the
@@ -28,7 +31,11 @@ const mapAgreement = chargeAgreement => {
 };
 
 const mapAgreements = (tptAgreements, s130Agreements = []) => {
-  const mapped = [...tptAgreements, ...s130Agreements].map(mapAgreement);
+  // Map and de-duplicate identical agreements
+  const mapped = uniqBy(
+    [...tptAgreements, ...s130Agreements].map(mapAgreement),
+    getUniqueKey
+  );
 
   // Group by agreement code
   const groups = groupBy(mapped, agreement => agreement.agreementCode);

--- a/test/modules/licence-import/load/licence.js
+++ b/test/modules/licence-import/load/licence.js
@@ -96,6 +96,7 @@ experiment('modules/licence-import/load/licence', () => {
       licence_id: licenceId = uuid()
     });
     await sandbox.stub(connectors, 'createLicenceVersionPurpose');
+    await sandbox.stub(connectors, 'cleanUpAgreements');
 
     licence = createLicence();
   });
@@ -131,6 +132,12 @@ experiment('modules/licence-import/load/licence', () => {
     test('creates the billing document role', async () => {
       expect(connectors.createDocumentRole.calledWith(
         licence.documents[0], licence.documents[0].roles[1]
+      )).to.be.true();
+    });
+
+    test('cleans up old agreements', async () => {
+      expect(connectors.cleanUpAgreements.calledWith(
+        licence
       )).to.be.true();
     });
 

--- a/test/modules/licence-import/transform/mappers/agreement.js
+++ b/test/modules/licence-import/transform/mappers/agreement.js
@@ -10,7 +10,8 @@ experiment('modules/licence-import/mappers/agreement', () => {
     AFSA_CODE: overrides.code || 'S127',
     EFF_ST_DATE: overrides.startDate || '01/01/2020',
     EFF_END_DATE: overrides.endDate || 'null',
-    charge_version_end_date: overrides.chargeVersionEndDate || 'null'
+    charge_version_end_date: overrides.chargeVersionEndDate || 'null',
+    charge_version_start_date: overrides.chargeVersionStartDate || '01/01/2020'
   });
 
   test('maps agreements with no end date', async () => {
@@ -46,5 +47,19 @@ experiment('modules/licence-import/mappers/agreement', () => {
       endDate: '2020-05-01'
     });
     expect(result[1]).to.equal({ agreementCode: 'S127', startDate: '2020-01-01', endDate: null });
+  });
+
+  test('uses the latest start date when the charge version starts after the agreement start date', async () => {
+    const result = mapAgreements([createAgreement({ chargeVersionStartDate: '02/01/2020' })]);
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-02', endDate: null }]);
+  });
+
+  test('merges duplicate agreements', async () => {
+    const agreements = [
+      createAgreement(),
+      createAgreement()
+    ];
+    const result = mapAgreements(agreements);
+    expect(result).to.be.an.array().length(1);
   });
 });


### PR DESCRIPTION
`WATER-3165`

Adds the calculation of a per-charge element flag `is_section_127_agreement_enabled` during charging data import.

This flag is true by default in the target table, but is false if the user wishes to exclude a particular element from a TPT agreement