### PR TITLE
Fix query params in licence agreement import cleanup

### DIFF
--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -117,7 +117,7 @@ const cleanUpAgreements = licence => {
   const keys = licence.agreements.map(agreement =>
     `${agreement.agreementCode}:${agreement.startDate}`);
 
-  return pool.query(queries.cleanUpAgreements, [licence.licenceRef, keys]);
+  return pool.query(queries.cleanUpAgreements, [licence.licenceNumber, keys]);
 };
 
 exports.createAddress = createAddress;

--- a/test/modules/licence-import/load/connectors/index.js
+++ b/test/modules/licence-import/load/connectors/index.js
@@ -543,4 +543,27 @@ experiment('modules/licence-import/load/connectors', () => {
       expect(params).to.equal(['test-licence-id']);
     });
   });
+
+  experiment('.cleanupAgreements', () => {
+    beforeEach(async () => {
+      const lic = {
+        ...data.licence,
+        agreements: [data.agreement]
+      };
+      await connectors.cleanUpAgreements(lic);
+    });
+
+    test('Calls the correct query', () => {
+      const [query] = pool.query.lastCall.args;
+      expect(query).to.equal(queries.cleanUpAgreements);
+    });
+
+    test('passes the expected params', async () => {
+      const [, params] = pool.query.lastCall.args;
+      expect(params).to.equal([
+        data.licence.licenceNumber,
+        ['S127:2019-06-03']
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes issue where licence number wasn't being correctly passed to an SQL query cleaning up old agreements