### PR TITLE
Bugfix - water 3136 - reduce calls to the DB and DB insert errors

### DIFF
--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -125,7 +125,7 @@ const cleanUpAgreements = licence => {
 
 const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes);
 
-const createPurposeCondition = async (condition, purposeId) =>
+const createPurposeCondition = (condition, purposeId) =>
   pool.query(queries.createPurposeCondition, [
     purposeId,
     condition.code,

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -45,7 +45,7 @@ const loadAgreements = async licence => {
 };
 
 const loadPurposeConditions = (purposeId, purpose) => {
-  return Promise.all(purpose.conditions.map(async condition => {
+  Promise.all(purpose.conditions.map(async condition => {
     return connectors.createPurposeCondition(condition, purposeId);
   }));
 };
@@ -53,7 +53,10 @@ const loadPurposeConditions = (purposeId, purpose) => {
 const loadVersionPurposes = (licenceVersionId, version) => {
   return Promise.all(version.purposes.map(async purpose => {
     const purposeResult = await connectors.createLicenceVersionPurpose(purpose, licenceVersionId);
-    return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose);
+    if (purpose.conditions.length > 0) {
+      return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose);
+    }
+    return purposeResult;
   }));
 };
 

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -45,7 +45,7 @@ const loadAgreements = async licence => {
 };
 
 const loadPurposeConditions = (purposeId, purpose) => {
-  Promise.all(purpose.conditions.map(async condition => {
+  return Promise.all(purpose.conditions.map(condition => {
     return connectors.createPurposeCondition(condition, purposeId);
   }));
 };
@@ -53,10 +53,7 @@ const loadPurposeConditions = (purposeId, purpose) => {
 const loadVersionPurposes = (licenceVersionId, version) => {
   return Promise.all(version.purposes.map(async purpose => {
     const purposeResult = await connectors.createLicenceVersionPurpose(purpose, licenceVersionId);
-    if (purpose.conditions.length > 0) {
-      return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose);
-    }
-    return purposeResult;
+    return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose);
   }));
 };
 

--- a/test/modules/licence-import/load/licence.js
+++ b/test/modules/licence-import/load/licence.js
@@ -16,7 +16,7 @@ const createLicence = (expiryDate = null) => ({
   lapsedDate: null,
   revokedDate: null,
   versions: [{
-    issue: 100,
+    issue: 101,
     increment: 1,
     status: 'current',
     startDate: '2019-01-01',
@@ -42,6 +42,28 @@ const createLicence = (expiryDate = null) => ({
         notes: null,
         externalId: '123:20'
       }]
+    }]
+  },
+  {
+    issue: 100,
+    increment: 1,
+    status: 'current',
+    startDate: '2019-01-01',
+    endDate: null,
+    externalId: '1:100:100:1',
+    purposes: [{
+      purposePrimary: 'A',
+      purposeSecondary: 'ABC',
+      purposeUse: '123',
+      abstractionPeriodStartDay: 1,
+      abstractionPeriodStartMonth: 1,
+      abstractionPeriodEndDay: 2,
+      abstractionPeriodEndMonth: 2,
+      timeLimitedStartDate: null,
+      timeLimitedEndDate: null,
+      notes: 'testing',
+      annualQuantity: 100,
+      conditions: []
     }]
   }],
   documents: [{
@@ -200,7 +222,7 @@ experiment('modules/licence-import/load/licence', () => {
       expect(purpose.annualQuantity).to.equal(100);
     });
 
-    test('creates the licence version purpose', async () => {
+    test('creates the licence version purpose condition', async () => {
       const [condition, savedId] = connectors.createPurposeCondition.lastCall.args;
       expect(savedId).to.equal(purposeId);
       expect(condition.code).to.equal('AGG');
@@ -209,6 +231,7 @@ experiment('modules/licence-import/load/licence', () => {
       expect(condition.param2).to.equal(null);
       expect(condition.notes).to.equal(null);
       expect(condition.externalId).to.equal('123:20');
+      expect(connectors.createPurposeCondition.callCount).to.equal(1);
     });
 
     test('attempts to grab the licence record', () => {


### PR DESCRIPTION
bugfix/water-3136
-- only create licence version purpose conditions if they exist