### PR TITLE
Add additional mapping to agreements to handle cases where there are …

### DIFF
--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -65,7 +65,11 @@ exports.getChargeVersions = `
 `;
 
 exports.getTwoPartTariffAgreements = `
-SELECT a.*, cv."EFF_END_DATE" as charge_version_end_date, cv."EFF_ST_DATE" as charge_version_start_date  
+SELECT 
+  a.*, 
+  cv."EFF_END_DATE" as charge_version_end_date, 
+  cv."EFF_ST_DATE" as charge_version_start_date,
+  cv."VERS_NO" as version_number
 FROM import."NALD_CHG_VERSIONS" cv
 JOIN import."NALD_CHG_ELEMENTS" e ON cv."FGAC_REGION_CODE"=e."FGAC_REGION_CODE" AND cv."VERS_NO"=e."ACVR_VERS_NO" AND cv."AABL_ID"=e."ACVR_AABL_ID"
 JOIN import."NALD_CHG_AGRMNTS" a ON e."FGAC_REGION_CODE"=a."FGAC_REGION_CODE" AND e."ID"=a."ACEL_ID"

--- a/src/modules/licence-import/transform/mappers/date.js
+++ b/src/modules/licence-import/transform/mappers/date.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-const { sortBy } = require('lodash');
+const { sortBy, isNull } = require('lodash');
 const DATE_FORMAT = 'YYYY-MM-DD';
 const NALD_FORMAT = 'DD/MM/YYYY';
 const NALD_TRANSFER_FORMAT = 'DD/MM/YYYY HH:mm:ss';
@@ -9,6 +9,13 @@ const mapNaldDate = str => {
     return null;
   }
   return moment(str, NALD_FORMAT).format(DATE_FORMAT);
+};
+
+const mapIsoDateToNald = str => {
+  if (isNull(str)) {
+    return 'null';
+  }
+  return moment(str, DATE_FORMAT).format(NALD_FORMAT);
 };
 
 const getSortedDates = arr => {
@@ -40,3 +47,4 @@ exports.getMinDate = getMinDate;
 exports.getMaxDate = getMaxDate;
 exports.mapTransferDate = mapTransferDate;
 exports.getPreviousDay = getPreviousDay;
+exports.mapIsoDateToNald = mapIsoDateToNald;

--- a/test/modules/licence-import/transform/licence.js
+++ b/test/modules/licence-import/transform/licence.js
@@ -63,9 +63,9 @@ const createComplexLicence = () => {
       data.createChargeVersion(licence, { VERS_NO: '2', EFF_ST_DATE: '15/05/2016', ACON_APAR_ID: '1001', IAS_CUST_REF: 'Y7890' })
     ],
     tptAgreements: [
-      { AFSA_CODE: 'S127', EFF_ST_DATE: '02/04/2015', EFF_END_DATE: '05/07/2015' },
-      { AFSA_CODE: 'S127', EFF_ST_DATE: '06/07/2015', EFF_END_DATE: '12/08/2015' },
-      { AFSA_CODE: 'S127', EFF_ST_DATE: '01/07/2017', EFF_END_DATE: 'null' }
+      { AFSA_CODE: 'S127', EFF_ST_DATE: '02/04/2015', EFF_END_DATE: '05/07/2015', version_number: 1 },
+      { AFSA_CODE: 'S127', EFF_ST_DATE: '06/07/2015', EFF_END_DATE: '12/08/2015', version_number: 2 },
+      { AFSA_CODE: 'S127', EFF_ST_DATE: '01/07/2017', EFF_END_DATE: 'null', version_number: 3 }
     ],
     section130Agreements: [
       { AFSA_CODE: 'S130', EFF_ST_DATE: '02/04/2015', EFF_END_DATE: '05/07/2015' }

--- a/test/modules/licence-import/transform/mappers/agreement.js
+++ b/test/modules/licence-import/transform/mappers/agreement.js
@@ -11,7 +11,8 @@ experiment('modules/licence-import/mappers/agreement', () => {
     EFF_ST_DATE: overrides.startDate || '01/01/2020',
     EFF_END_DATE: overrides.endDate || 'null',
     charge_version_end_date: overrides.chargeVersionEndDate || 'null',
-    charge_version_start_date: overrides.chargeVersionStartDate || '01/01/2020'
+    charge_version_start_date: overrides.chargeVersionStartDate || '01/01/2020',
+    version_number: overrides.versionNumber || 1
   });
 
   test('maps agreements with no end date', async () => {
@@ -36,9 +37,9 @@ experiment('modules/licence-import/mappers/agreement', () => {
 
   test('merges adjacent date ranges with the same code', async () => {
     const agreements = [
-      createAgreement({ code: 'S130', endDate: '01/05/2020' }),
-      createAgreement({ endDate: '01/06/2021' }),
-      createAgreement({ startDate: '02/06/2021' })
+      createAgreement({ code: 'S130', endDate: '01/05/2020', versionNumber: 1 }),
+      createAgreement({ endDate: '01/06/2021', versionNumber: 2 }),
+      createAgreement({ startDate: '02/06/2021', versionNumber: 3 })
     ];
     const result = mapAgreements(agreements);
     expect(result[0]).to.equal({
@@ -61,5 +62,19 @@ experiment('modules/licence-import/mappers/agreement', () => {
     ];
     const result = mapAgreements(agreements);
     expect(result).to.be.an.array().length(1);
+  });
+
+  test('merges agreements with different date ranges on different elements', async () => {
+    const agreements = [
+      createAgreement({ startDate: '11/03/1993', chargeVersionStartDate: '11/10/1978', chargeVersionEndDate: '31/03/2006', versionNumber: 1 }),
+      createAgreement({ startDate: '11/10/1978', chargeVersionStartDate: '11/10/1978', chargeVersionEndDate: '31/03/2006', versionNumber: 1 }),
+      createAgreement({ startDate: '11/03/1993', chargeVersionStartDate: '01/04/2006', chargeVersionEndDate: '31/03/2014', versionNumber: 2 }),
+      createAgreement({ startDate: '11/10/1978', chargeVersionStartDate: '01/04/2006', chargeVersionEndDate: '31/03/2014', versionNumber: 2 }),
+      createAgreement({ startDate: '01/04/2014', chargeVersionStartDate: '01/04/2014', versionNumber: 4 })
+    ];
+    const result = mapAgreements(agreements);
+    expect(result).to.be.an.array().length(1);
+    expect(result[0].startDate).to.equal('1978-10-11');
+    expect(result[0].endDate).to.equal(null);
   });
 });

--- a/test/modules/licence-import/transform/mappers/date.js
+++ b/test/modules/licence-import/transform/mappers/date.js
@@ -79,4 +79,23 @@ experiment('modules/licence-import/mappers/date', () => {
       expect(result).to.equal('2018-06-06');
     });
   });
+
+  experiment('mapTransferDate', () => {
+    test('converts a full datestamp in NALD format to a date in YYYY-MM-DD format', async () => {
+      const result = date.mapTransferDate('04/12/2015 12:52:00');
+      expect(result).to.equal('2015-12-04');
+    });
+  });
+
+  experiment('mapIsoDateToNald', () => {
+    test('maps ISO format to NALD format', async () => {
+      const result = date.mapIsoDateToNald('2018-06-07');
+      expect(result).to.equal('07/06/2018');
+    });
+
+    test('maps true null to string "null"', async () => {
+      const result = date.mapIsoDateToNald(null);
+      expect(result).to.equal('null');
+    });
+  });
 });


### PR DESCRIPTION
`WATER-3186` TPT agreement mapping.

Adds an additional mapping step to cope with scenarios where there are multiple charge elements with a TPT agreement, and the date ranges are different.

The approach taken is to take the maximum possible range where it applies to any of the elements.  