### PR TITLE
Fix module.exports

### DIFF
--- a/migrations/20190812160211-charging.js
+++ b/migrations/20190812160211-charging.js
@@ -11,14 +11,14 @@ var Promise;
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+function setup(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
+function up(db) {
   var filePath = path.join(__dirname, 'sqls', '20190812160211-charging-up.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -33,7 +33,7 @@ exports.up = function(db) {
   });
 };
 
-exports.down = function(db) {
+function down(db) {
   var filePath = path.join(__dirname, 'sqls', '20190812160211-charging-down.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -48,6 +48,13 @@ exports.down = function(db) {
   });
 };
 
-exports._meta = {
+const _meta = {
   "version": 1
+};
+
+module.exports = {
+  setup,
+  up,
+  down,
+  _meta
 };

--- a/migrations/20191115135544-uuid-types.js
+++ b/migrations/20191115135544-uuid-types.js
@@ -11,14 +11,14 @@ var Promise;
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+function setup(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
+function up(db) {
   var filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-up.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -33,7 +33,7 @@ exports.up = function(db) {
   });
 };
 
-exports.down = function(db) {
+function down(db) {
   var filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-down.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -48,6 +48,13 @@ exports.down = function(db) {
   });
 };
 
-exports._meta = {
+const _meta = {
   "version": 1
+};
+
+module.exports = {
+  setup,
+  up,
+  down,
+  _meta
 };

--- a/migrations/20191119170656-import-companies-table.js
+++ b/migrations/20191119170656-import-companies-table.js
@@ -11,14 +11,14 @@ var Promise;
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+function setup(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
+function up(db) {
   var filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-up.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -33,7 +33,7 @@ exports.up = function(db) {
   });
 };
 
-exports.down = function(db) {
+function down(db) {
   var filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-down.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -48,6 +48,13 @@ exports.down = function(db) {
   });
 };
 
-exports._meta = {
+const _meta = {
   "version": 1
+};
+
+module.exports = {
+  setup,
+  up,
+  down,
+  _meta
 };

--- a/migrations/20201109161649-drop-charge-version-import-tables.js
+++ b/migrations/20201109161649-drop-charge-version-import-tables.js
@@ -11,14 +11,14 @@ var Promise;
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+function setup(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
+function up(db) {
   var filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-up.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -33,7 +33,7 @@ exports.up = function(db) {
   });
 };
 
-exports.down = function(db) {
+function down(db) {
   var filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-down.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -48,6 +48,13 @@ exports.down = function(db) {
   });
 };
 
-exports._meta = {
+const _meta = {
   "version": 1
+};
+
+module.exports = {
+  setup,
+  up,
+  down,
+  _meta
 };

--- a/migrations/20201120135927-create-charge-versions-metadata-table.js
+++ b/migrations/20201120135927-create-charge-versions-metadata-table.js
@@ -11,14 +11,14 @@ var Promise;
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+function setup(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
   Promise = options.Promise;
 };
 
-exports.up = function(db) {
+function up(db) {
   var filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-up.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -33,7 +33,7 @@ exports.up = function(db) {
   });
 };
 
-exports.down = function(db) {
+function down(db) {
   var filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-down.sql');
   return new Promise( function( resolve, reject ) {
     fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
@@ -48,6 +48,13 @@ exports.down = function(db) {
   });
 };
 
-exports._meta = {
+const _meta = {
   "version": 1
+};
+
+module.exports = {
+  setup,
+  up,
+  down,
+  _meta
 };

--- a/scripts/licence-creator/common.js
+++ b/scripts/licence-creator/common.js
@@ -20,5 +20,7 @@ const createNullKeys = (...keys) => {
   }, {});
 };
 
-exports.getCommonObject = getCommonObject;
-exports.createNullKeys = createNullKeys;
+module.exports = {
+  getCommonObject,
+  createNullKeys
+};

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -13,4 +13,8 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 const dateMapper = str => moment(str).format(DATE_FORMAT);
 pg.types.setTypeParser(pg.types.builtins.DATE, dateMapper);
 
-exports.pool = helpers.db.createPool(config.pg, logger);
+const pool = helpers.db.createPool(config.pg, logger);
+
+module.exports = {
+  pool
+};

--- a/src/lib/connectors/import.js
+++ b/src/lib/connectors/import.js
@@ -27,5 +27,7 @@ const deleteRemovedDocuments = () => {
   return pool.query(deleteCrmV1DocumentsQuery);
 };
 
-exports.getLicenceNumbers = getLicenceNumbers;
-exports.deleteRemovedDocuments = deleteRemovedDocuments;
+module.exports = {
+  getLicenceNumbers,
+  deleteRemovedDocuments
+};

--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -82,8 +82,10 @@ const deleteAllReturnsData = async returnId => {
   await pool.query(deleteReturnsQuery, [returnId]);
 };
 
-exports.versions = versions;
-exports.lines = lines;
-exports.returns = returns;
-exports.voidReturns = voidReturns;
-exports.deleteAllReturnsData = deleteAllReturnsData;
+module.exports = {
+  versions,
+  lines,
+  returns,
+  voidReturns,
+  deleteAllReturnsData
+};

--- a/src/lib/connectors/s3.js
+++ b/src/lib/connectors/s3.js
@@ -5,7 +5,7 @@ const proxyAgent = require('proxy-agent');
 
 const config = require('../../../config.js');
 
-const getS3Options = () => {
+const _getS3Options = () => {
   const { bucket, ...credentials } = config.s3;
   const { proxy } = config;
   return {
@@ -18,7 +18,9 @@ const getS3Options = () => {
   };
 };
 
-const getS3 = () => new aws.S3(getS3Options());
+const getS3 = () => new aws.S3(_getS3Options());
 
-exports._getS3Options = getS3Options;
-exports.getS3 = getS3;
+module.exports = {
+  _getS3Options,
+  getS3
+};

--- a/src/lib/connectors/water-import/jobs.js
+++ b/src/lib/connectors/water-import/jobs.js
@@ -58,5 +58,7 @@ const getFailedJobs = async () => {
   });
 };
 
-exports.getFailedJobs = getFailedJobs;
-exports.getJobSummary = getJobSummary;
+module.exports = {
+  getFailedJobs,
+  getJobSummary
+};

--- a/src/lib/connectors/water-import/queries.js
+++ b/src/lib/connectors/water-import/queries.js
@@ -48,5 +48,7 @@ const pgBossFailedJobs = `select name, sum(count) as count, max(max_completed_da
         group by a.name) cte 
         group by name`;
 
-exports.pgBossFailedJobs = pgBossFailedJobs;
-exports.pgBossJobOverview = pgBossJobOverview;
+module.exports = {
+  pgBossFailedJobs,
+  pgBossJobOverview
+};

--- a/src/lib/connectors/water/application-state.js
+++ b/src/lib/connectors/water/application-state.js
@@ -18,5 +18,7 @@ const postState = (key, data) => {
   });
 };
 
-exports.getState = getState;
-exports.postState = postState;
+module.exports = {
+  getState,
+  postState
+};

--- a/src/lib/connectors/water/events.js
+++ b/src/lib/connectors/water/events.js
@@ -14,4 +14,6 @@ const events = new APIClient(rp, {
   }
 });
 
-exports.events = events;
+module.exports = {
+  events
+};

--- a/src/lib/connectors/water/notify.js
+++ b/src/lib/connectors/water/notify.js
@@ -14,4 +14,6 @@ const postSendNotify = (key, data) => {
   });
 };
 
-exports.postSendNotify = postSendNotify;
+module.exports = {
+  postSendNotify
+};

--- a/src/lib/date-helpers.js
+++ b/src/lib/date-helpers.js
@@ -20,5 +20,7 @@ const getSortedDates = arr => sortBy(
 const getMinDate = arr => first(getSortedDates(arr));
 const getMaxDate = arr => last(getSortedDates(arr));
 
-exports.getMinDate = getMinDate;
-exports.getMaxDate = getMaxDate;
+module.exports = {
+  getMinDate,
+  getMaxDate
+};

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -10,4 +10,6 @@ class DBError extends Error {
   }
 }
 
-exports.DBError = DBError;
+module.exports = {
+  DBError
+};

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -15,4 +15,6 @@ const createRegister = (server, registerSubscribers) => {
   return registerSubscribers(server);
 };
 
-exports.createRegister = createRegister;
+module.exports = {
+  createRegister
+};

--- a/src/lib/services/application-state-service.js
+++ b/src/lib/services/application-state-service.js
@@ -10,5 +10,7 @@ const get = async identifier => {
 
 const save = (key = constants.APPLICATION_STATE_KEY, data = {}) => applicationStateConnector.postState(key, data);
 
-exports.get = get;
-exports.save = save;
+module.exports = {
+  get,
+  save
+};

--- a/src/lib/services/import.js
+++ b/src/lib/services/import.js
@@ -12,5 +12,7 @@ const deleteRemovedDocuments = async () => {
   return importConnector.deleteRemovedDocuments();
 };
 
-exports.deleteRemovedDocuments = deleteRemovedDocuments;
-exports.getLicenceNumbers = getLicenceNumbers;
+module.exports = {
+  deleteRemovedDocuments,
+  getLicenceNumbers
+};

--- a/src/lib/services/notify.js
+++ b/src/lib/services/notify.js
@@ -22,4 +22,6 @@ const sendEmail = async (recipient, messageRef, personalisation) => {
   return notifyConnector.postSendNotify('email', { templateId, recipient, personalisation });
 };
 
-exports.sendEmail = sendEmail;
+module.exports = {
+  sendEmail
+};

--- a/src/lib/services/s3.js
+++ b/src/lib/services/s3.js
@@ -61,7 +61,9 @@ const download = async (key, destination) => {
  */
 const getHead = key => callS3MethodWithKey('headObject', key);
 
-exports.upload = upload;
-exports.getObject = getObject;
-exports.download = download;
-exports.getHead = getHead;
+module.exports = {
+  upload,
+  getObject,
+  download,
+  getHead
+};

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -30,4 +30,6 @@ function post (message) {
     });
 }
 
-exports.post = post;
+module.exports = {
+  post
+};

--- a/src/logger.js
+++ b/src/logger.js
@@ -3,4 +3,6 @@ const { createLogger } = require('@envage/water-abstraction-helpers').logger;
 
 const logger = createLogger(config.logger);
 
-exports.logger = logger;
+module.exports = {
+  logger
+};

--- a/src/modules/bill-runs-import/controller.js
+++ b/src/modules/bill-runs-import/controller.js
@@ -9,4 +9,6 @@ const postImportBillRuns = async request => {
   };
 };
 
-exports.postImportBillRuns = postImportBillRuns;
+module.exports = {
+  postImportBillRuns
+};

--- a/src/modules/bill-runs-import/lib/constants.js
+++ b/src/modules/bill-runs-import/lib/constants.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const IMPORT_BILL_RUNS = 'import.bill-runs';
-
 module.exports = {
-  IMPORT_BILL_RUNS
+  IMPORT_BILL_RUNS: 'import.bill-runs'
 };

--- a/src/modules/bill-runs-import/lib/constants.js
+++ b/src/modules/bill-runs-import/lib/constants.js
@@ -1,3 +1,7 @@
 'use strict';
 
-exports.IMPORT_BILL_RUNS = 'import.bill-runs';
+const IMPORT_BILL_RUNS = 'import.bill-runs';
+
+module.exports = {
+  IMPORT_BILL_RUNS
+};

--- a/src/modules/bill-runs-import/lib/import.js
+++ b/src/modules/bill-runs-import/lib/import.js
@@ -57,4 +57,6 @@ const importBillRuns = async () => {
   }
 };
 
-exports.importBillRuns = importBillRuns;
+module.exports = {
+  importBillRuns
+};

--- a/src/modules/bill-runs-import/lib/queries.js
+++ b/src/modules/bill-runs-import/lib/queries.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.importNaldBillRuns = `
+const importNaldBillRuns = `
 insert into water.billing_batches (
   region_id, batch_type, date_created, date_updated, from_financial_year_ending,
   to_financial_year_ending, status, invoice_count, credit_note_count,
@@ -97,7 +97,7 @@ and nbr."FIN_YEAR"::integer>=2015
 on conflict (legacy_id) do nothing;
 `;
 
-exports.importNaldBillHeaders = `
+const importNaldBillHeaders = `
 insert into water.billing_invoices (
   invoice_account_id, address, invoice_account_number, net_amount,
   is_credit, date_created, date_updated, billing_batch_id, financial_year_ending,
@@ -123,7 +123,7 @@ join water.billing_batches b on b.legacy_id=concat_ws(':', nbh."FGAC_REGION_CODE
 on conflict (legacy_id) do nothing;
 `;
 
-exports.importInvoiceLicences = `
+const importInvoiceLicences = `
 insert into water.billing_invoice_licences (
   billing_invoice_id, licence_ref, date_created, date_updated, licence_id
 )
@@ -141,17 +141,17 @@ left join water.licences l on nl."LIC_NO"=l.licence_ref
 on conflict (billing_invoice_id, licence_id) do nothing;
 `;
 
-exports.resetIsSecondPartChargeFlag = `
+const resetIsSecondPartChargeFlag = `
 update water.billing_transactions 
 set is_two_part_second_part_charge = false;
 `;
-exports.setIsSecondPartChargeFlag = `
+const setIsSecondPartChargeFlag = `
 update water.billing_transactions 
 set is_two_part_second_part_charge = true
 where description ilike 'second%';
 `;
 
-exports.importTransactions = `
+const importTransactions = `
 insert into water.billing_transactions ( 
   billing_invoice_licence_id, 
   charge_element_id, 
@@ -321,7 +321,7 @@ left join(
 on conflict (legacy_id) do nothing;
 `;
 
-exports.importBillingVolumes = `
+const importBillingVolumes = `
 insert into water.billing_volumes (
   charge_element_id, financial_year, is_summer,
   calculated_volume, two_part_tariff_error, two_part_tariff_status,
@@ -376,7 +376,7 @@ join (
 where b.source='nald' and b.batch_type='two_part_tariff';
 `;
 
-exports.importBillingBatchChargeVersionYears = `
+const importBillingBatchChargeVersionYears = `
 insert into water.billing_batch_charge_version_years (
   billing_batch_id, charge_version_id, financial_year_ending,
   date_created, date_updated, status, 
@@ -404,7 +404,7 @@ on conflict do nothing;
 `
 ;
 
-exports.removeConstraints = `
+const removeConstraints = `
 alter table water.billing_invoices 
 drop constraint fk_original_billing_invoice_id;
 
@@ -412,7 +412,7 @@ alter table water.billing_transactions
 drop constraint billing_transactions_billing_invoice_licence_id_fkey,
 drop constraint billing_transactions_billing_transactions_fk_source_transaction_id;`;
 
-exports.addConstraints = `               
+const addConstraints = `               
 alter table water.billing_invoices 
 add constraint fk_original_billing_invoice_id 
 foreign key (original_billing_invoice_id) 
@@ -425,3 +425,16 @@ ADD constraint billing_transactions_billing_invoice_licence_id_fkey
 ADD constraint billing_transactions_billing_transactions_fk_source_transaction_id
   foreign key (source_transaction_id) 
   references water.billing_transactions (billing_transaction_id);`;
+
+module.exports = {
+  addConstraints,
+  removeConstraints,
+  importBillingBatchChargeVersionYears,
+  importBillingVolumes,
+  importTransactions,
+  setIsSecondPartChargeFlag,
+  resetIsSecondPartChargeFlag,
+  importInvoiceLicences,
+  importNaldBillHeaders,
+  importNaldBillRuns
+};

--- a/src/modules/bill-runs-import/plugin.js
+++ b/src/modules/bill-runs-import/plugin.js
@@ -4,7 +4,7 @@ const routes = require('./routes');
 const importer = require('./lib/import');
 const constants = require('./lib/constants');
 
-exports.plugin = {
+const plugin = {
   name: 'importBillRunData',
   dependencies: ['pgBoss'],
   register: async server => {
@@ -14,4 +14,8 @@ exports.plugin = {
     // Register PG boss job
     await server.messageQueue.subscribe(constants.IMPORT_BILL_RUNS, {}, importer.importBillRuns);
   }
+};
+
+module.exports = {
+  plugin
 };

--- a/src/modules/charging-import/controller.js
+++ b/src/modules/charging-import/controller.js
@@ -19,4 +19,6 @@ const createPostHandler = async (createMessage, request) => {
  */
 const postImportChargingData = partial(createPostHandler, chargeVersionsJob.createMessage);
 
-exports.postImportChargingData = postImportChargingData;
+module.exports = {
+  postImportChargingData
+};

--- a/src/modules/charging-import/jobs/charge-versions.js
+++ b/src/modules/charging-import/jobs/charge-versions.js
@@ -19,6 +19,8 @@ const handler = () => queryLoader.loadQueries('Import charge versions', [
   chargingQueries.cleanupChargeVersions
 ]);
 
-exports.jobName = jobName;
-exports.createMessage = createMessage;
-exports.handler = handler;
+module.exports = {
+  jobName,
+  createMessage,
+  handler
+};

--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -25,6 +25,8 @@ const handler = () => queryLoader.loadQueries('Import charging data', [
   returnVersionQueries.importReturnRequirementPurposes
 ]);
 
-exports.jobName = jobName;
-exports.createMessage = createMessage;
-exports.handler = handler;
+module.exports = {
+  jobName,
+  createMessage,
+  handler
+};

--- a/src/modules/charging-import/lib/import-charge-version-metadata.js
+++ b/src/modules/charging-import/lib/import-charge-version-metadata.js
@@ -21,4 +21,6 @@ const importChargeVersionMetadata = async () => {
   }
 };
 
-exports.importChargeVersionMetadata = importChargeVersionMetadata;
+module.exports = {
+  importChargeVersionMetadata
+};

--- a/src/modules/charging-import/lib/job.js
+++ b/src/modules/charging-import/lib/job.js
@@ -7,4 +7,6 @@ const createMessage = jobName => ({
   }
 });
 
-exports.createMessage = createMessage;
+module.exports = {
+  createMessage
+};

--- a/src/modules/charging-import/lib/queries/charging.js
+++ b/src/modules/charging-import/lib/queries/charging.js
@@ -194,8 +194,10 @@ DELETE FROM water.charge_versions WHERE charge_version_id IN (
     and billing_batch_charge_version_year_id is null
 );`;
 
-exports.importChargeElements = importChargeElements;
-exports.cleanupChargeElements = cleanupChargeElements;
-exports.insertChargeVersion = insertChargeVersion;
-exports.importChargeVersions = importChargeVersions;
-exports.cleanupChargeVersions = cleanupChargeVersions;
+module.exports = {
+  importChargeElements,
+  cleanupChargeElements,
+  insertChargeVersion,
+  importChargeVersions,
+  cleanupChargeVersions
+};

--- a/src/modules/charging-import/lib/queries/financial-agreement-types.js
+++ b/src/modules/charging-import/lib/queries/financial-agreement-types.js
@@ -11,4 +11,6 @@ DO
     date_updated = now();
 `;
 
-exports.importFinancialAgreementTypes = importFinancialAgreementTypes;
+module.exports = {
+  importFinancialAgreementTypes
+};

--- a/src/modules/charging-import/lib/queries/purposes.js
+++ b/src/modules/charging-import/lib/queries/purposes.js
@@ -51,7 +51,9 @@ JOIN water.purposes_secondary as ps ON NALD_P."APSE_CODE" = ps."legacy_id"
 JOIN water.purposes_uses as pu ON NALD_P."APUS_CODE" = pu."legacy_id"
 WHERE NALD_P."DISABLED" = 'N' ON CONFLICT DO NOTHING;`;
 
-exports.importPrimaryPurposes = importPrimaryPurposes;
-exports.importSecondaryPurposes = importSecondaryPurposes;
-exports.importUses = importUses;
-exports.importValidPurposeCombinations = importValidPurposeCombinations;
+module.exports = {
+  importPrimaryPurposes,
+  importSecondaryPurposes,
+  importUses,
+  importValidPurposeCombinations
+};

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -89,6 +89,8 @@ join water.purposes_uses u on nrp."APUR_APUS_CODE"=u.legacy_id
 join water.return_requirements r on r.external_id = concat_ws(':', nrp."FGAC_REGION_CODE", nrp."ARTY_ID") on conflict(external_id) do update set  purpose_alias=excluded.purpose_alias, date_updated=excluded.date_updated;
 `;
 
-exports.importReturnVersions = importReturnVersions;
-exports.importReturnRequirements = importReturnRequirements;
-exports.importReturnRequirementPurposes = importReturnRequirementPurposes;
+module.exports = {
+  importReturnVersions,
+  importReturnRequirements,
+  importReturnRequirementPurposes
+};

--- a/src/modules/charging-import/lib/query-loader.js
+++ b/src/modules/charging-import/lib/query-loader.js
@@ -33,4 +33,6 @@ const loadQueries = async (name, queries) => {
   }
 };
 
-exports.loadQueries = loadQueries;
+module.exports = {
+  loadQueries
+};

--- a/src/modules/charging-import/plugin.js
+++ b/src/modules/charging-import/plugin.js
@@ -19,8 +19,12 @@ const registerSubscribers = async server => {
   );
 };
 
-exports.plugin = {
+const plugin = {
   name: 'importChargingData',
   dependencies: ['pgBoss'],
   register: server => createRegister(server, registerSubscribers)
+};
+
+module.exports = {
+  plugin
 };

--- a/src/modules/core/controller.js
+++ b/src/modules/core/controller.js
@@ -5,4 +5,6 @@ const statusResponse = pick(pkg, 'version');
 
 const getStatus = () => statusResponse;
 
-exports.getStatus = getStatus;
+module.exports = {
+  getStatus
+};

--- a/src/modules/core/jobs/import-tracker.js
+++ b/src/modules/core/jobs/import-tracker.js
@@ -45,6 +45,8 @@ const handler = async job => {
   }
 };
 
-exports.createMessage = createMessage;
-exports.handler = handler;
-exports.jobName = JOB_NAME;
+module.exports = {
+  createMessage,
+  handler,
+  JOB_NAME
+};

--- a/src/modules/core/plugin.js
+++ b/src/modules/core/plugin.js
@@ -31,8 +31,12 @@ const registerSubscribers = async server => {
   }
 };
 
-exports.plugin = {
+const plugin = {
   name: 'importTracker',
   dependencies: ['pgBoss'],
   register: registerSubscribers
+};
+
+module.exports = {
+  plugin
 };

--- a/src/modules/jobs/controller.js
+++ b/src/modules/jobs/controller.js
@@ -4,4 +4,6 @@ const jobsConnector = require('../../lib/connectors/water-import/jobs');
 
 const getJobSummary = () => jobsConnector.getJobSummary();
 
-exports.getJobSummary = getJobSummary;
+module.exports = {
+  getJobSummary
+};

--- a/src/modules/licence-import/connectors/documents.js
+++ b/src/modules/licence-import/connectors/documents.js
@@ -9,4 +9,6 @@ const queries = require('./queries/documents');
  */
 const deleteRemovedDocuments = () => pool.query(queries.deleteCrmV2Documents);
 
-exports.deleteRemovedDocuments = deleteRemovedDocuments;
+module.exports = {
+  deleteRemovedDocuments
+};

--- a/src/modules/licence-import/connectors/import-companies.js
+++ b/src/modules/licence-import/connectors/import-companies.js
@@ -36,7 +36,9 @@ const getPendingCount = async () => {
   return parseInt(count);
 };
 
-exports.clear = clear;
-exports.initialise = initialise;
-exports.setImportedStatus = setImportedStatus;
-exports.getPendingCount = getPendingCount;
+module.exports = {
+  clear,
+  initialise,
+  setImportedStatus,
+  getPendingCount
+};

--- a/src/modules/licence-import/connectors/purpose-conditions-types.js
+++ b/src/modules/licence-import/connectors/purpose-conditions-types.js
@@ -9,4 +9,6 @@ const queries = require('./queries/purpose-condition-types');
  */
 const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes);
 
-exports.createPurposeConditionTypes = createPurposeConditionTypes;
+module.exports = {
+  createPurposeConditionTypes
+};

--- a/src/modules/licence-import/connectors/queries/documents.js
+++ b/src/modules/licence-import/connectors/queries/documents.js
@@ -1,4 +1,4 @@
-exports.deleteCrmV2Documents = `
+const deleteCrmV2Documents = `
   update crm_v2.documents
   set date_deleted = now()
   where document_ref not in (
@@ -9,3 +9,7 @@ exports.deleteCrmV2Documents = `
   and regime = 'water'
   and document_type = 'abstraction_licence';
 `;
+
+module.exports = {
+  deleteCrmV2Documents
+};

--- a/src/modules/licence-import/connectors/queries/import-companies.js
+++ b/src/modules/licence-import/connectors/queries/import-companies.js
@@ -1,10 +1,17 @@
-exports.clear = 'DELETE FROM water_import.import_companies;';
+const clear = 'DELETE FROM water_import.import_companies;';
 
-exports.initialise = `INSERT INTO water_import.import_companies 
+const initialise = `INSERT INTO water_import.import_companies 
 (region_code, party_id, date_created, date_updated)
 SELECT p."FGAC_REGION_CODE"::integer, p."ID"::integer, NOW(), NOW()
 FROM import."NALD_PARTIES" p ON CONFLICT (region_code, party_id) DO NOTHING RETURNING *;`;
 
-exports.setImportedStatus = 'UPDATE water_import.import_companies  SET imported=true, date_updated=NOW() WHERE region_code=$1 AND party_id=$2;';
+const setImportedStatus = 'UPDATE water_import.import_companies  SET imported=true, date_updated=NOW() WHERE region_code=$1 AND party_id=$2;';
 
-exports.getPendingCount = 'SELECT COUNT(*) FROM water_import.import_companies WHERE imported=false;';
+const getPendingCount = 'SELECT COUNT(*) FROM water_import.import_companies WHERE imported=false;';
+
+module.exports = {
+  clear,
+  initialise,
+  setImportedStatus,
+  getPendingCount
+};

--- a/src/modules/licence-import/connectors/queries/purpose-condition-types.js
+++ b/src/modules/licence-import/connectors/queries/purpose-condition-types.js
@@ -1,5 +1,5 @@
 
-exports.createPurposeConditionTypes = `
+const createPurposeConditionTypes = `
 INSERT INTO water.licence_version_purpose_condition_types (
   code,
   subcode,
@@ -14,3 +14,7 @@ INSERT INTO water.licence_version_purpose_condition_types (
     subcode_description = excluded.subcode_description,
     date_updated = now();
 `;
+
+module.exports = {
+  createPurposeConditionTypes
+};

--- a/src/modules/licence-import/controller.js
+++ b/src/modules/licence-import/controller.js
@@ -28,17 +28,23 @@ const createImportLicenceJob = request => jobs.importLicence(request.query.licen
 /**
  * Import all companies/licences
  */
-exports.postImport = partialRight(postImportHandler, createImportJob, 'Error importing companies');
+const postImport = partialRight(postImportHandler, createImportJob, 'Error importing companies');
 
 /**
  * Import single licence
  * @param {String} request.query.licenceNumber
  */
-exports.postImportLicence = partialRight(postImportHandler, createImportLicenceJob, 'Error importing licence');
+const postImportLicence = partialRight(postImportHandler, createImportLicenceJob, 'Error importing licence');
 
 /**
  * Import single company
  * @param {Number} request.query.regionCode
  * @param {Number} request.query.partyId
  */
-exports.postImportCompany = partialRight(postImportHandler, createImportCompanyJob, 'Error importing company');
+const postImportCompany = partialRight(postImportHandler, createImportCompanyJob, 'Error importing company');
+
+module.exports = {
+  postImport,
+  postImportLicence,
+  postImportCompany
+};

--- a/src/modules/licence-import/extract/connectors/index.js
+++ b/src/modules/licence-import/extract/connectors/index.js
@@ -62,20 +62,22 @@ const getLicenceRoles = (regionCode, licenceId) =>
 const getPartyLicenceRoles = (regionCode, partyId) =>
   findMany(queries.getPartyLicenceRoles, [regionCode, partyId]);
 
-exports.getPurposeConditions = getPurposeConditions;
-exports.getAddresses = getAddresses;
-exports.getAllAddresses = getAllAddresses;
-exports.getAllLicenceNumbers = getAllLicenceNumbers;
-exports.getAllParties = getAllParties;
-exports.getChargeVersions = getChargeVersions;
-exports.getInvoiceAccounts = getInvoiceAccounts;
-exports.getLicence = getLicence;
-exports.getLicencePurposes = getLicencePurposes;
-exports.getLicenceVersions = getLicenceVersions;
-exports.getParties = getParties;
-exports.getParty = getParty;
-exports.getPartyLicenceVersions = getPartyLicenceVersions;
-exports.getSection130Agreements = getSection130Agreements;
-exports.getTwoPartTariffAgreements = getTwoPartTariffAgreements;
-exports.getLicenceRoles = getLicenceRoles;
-exports.getPartyLicenceRoles = getPartyLicenceRoles;
+module.exports = {
+  getPurposeConditions,
+  getAddresses,
+  getAllAddresses,
+  getAllLicenceNumbers,
+  getAllParties,
+  getChargeVersions,
+  getInvoiceAccounts,
+  getLicence,
+  getLicencePurposes,
+  getLicenceVersions,
+  getParties,
+  getParty,
+  getPartyLicenceVersions,
+  getSection130Agreements,
+  getTwoPartTariffAgreements,
+  getLicenceRoles,
+  getPartyLicenceRoles
+};

--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -1,10 +1,10 @@
-exports.getLicence = `
+const getLicence = `
   SELECT *
   FROM import."NALD_ABS_LICENCES" l
   WHERE l."LIC_NO"=$1;
 `;
 
-exports.getLicenceVersions = `
+const getLicenceVersions = `
   SELECT *
   FROM import."NALD_ABS_LIC_VERSIONS" v
   WHERE v."FGAC_REGION_CODE"=$1
@@ -12,7 +12,7 @@ exports.getLicenceVersions = `
   AND v."STATUS"<>'DRAFT';
 `;
 
-exports.getLicencePurposes = `
+const getLicencePurposes = `
   select purposes.*
   from import."NALD_ABS_LIC_VERSIONS" versions
     join import."NALD_ABS_LIC_PURPOSES" purposes
@@ -24,7 +24,7 @@ exports.getLicencePurposes = `
   and versions."AABL_ID" = $2;
 `;
 
-exports.getPurposeConditions = `
+const getPurposeConditions = `
 select conditions.*
 from import."NALD_ABS_LIC_VERSIONS" versions
   join import."NALD_ABS_LIC_PURPOSES" purposes
@@ -39,19 +39,19 @@ where versions."FGAC_REGION_CODE" = $1
 and versions."AABL_ID" = $2
 `;
 
-exports.getParty = `SELECT * FROM import."NALD_PARTIES" p
+const getParty = `SELECT * FROM import."NALD_PARTIES" p
   WHERE p."FGAC_REGION_CODE"=$1
   AND p."ID" = $2`;
 
-exports.getAddress = `SELECT * FROM import."NALD_ADDRESSES" a
+const getAddress = `SELECT * FROM import."NALD_ADDRESSES" a
   WHERE a."FGAC_REGION_CODE"=$1
   AND a."ID" = $2`;
 
-exports.getAllAddresses = 'SELECT * FROM import."NALD_ADDRESSES"';
+const getAllAddresses = 'SELECT * FROM import."NALD_ADDRESSES"';
 
-exports.getAllParties = 'SELECT "FGAC_REGION_CODE", "ID" FROM import."NALD_PARTIES"';
+const getAllParties = 'SELECT "FGAC_REGION_CODE", "ID" FROM import."NALD_PARTIES"';
 
-exports.getChargeVersions = `
+const getChargeVersions = `
   SELECT *
   FROM import."NALD_CHG_VERSIONS" cv
     JOIN import."NALD_IAS_INVOICE_ACCS" ia
@@ -64,7 +64,7 @@ exports.getChargeVersions = `
   ORDER BY cv."VERS_NO"::integer;
 `;
 
-exports.getTwoPartTariffAgreements = `
+const getTwoPartTariffAgreements = `
 SELECT 
   a.*, 
   cv."EFF_END_DATE" as charge_version_end_date, 
@@ -96,7 +96,7 @@ WHERE
 ORDER BY cv."VERS_NO"::integer;
 `;
 
-exports.getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
+const getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
 JOIN (
   SELECT DISTINCT cv."FGAC_REGION_CODE", cv."AIIA_ALHA_ACC_NO"
   FROM import."NALD_CHG_VERSIONS" cv
@@ -105,7 +105,7 @@ JOIN (
 AND ag."AFSA_CODE" IN ('S127', 'S130S', 'S130T', 'S130U', 'S130W')
 `;
 
-exports.getInvoiceAccounts = `
+const getInvoiceAccounts = `
 select a."ACON_APAR_ID" AS licence_holder_party_id, p."NAME" AS licence_holder_party_name,
 p2."NAME" AS invoice_account_party_name,
 i.*
@@ -131,31 +131,52 @@ where
   and a."ACON_APAR_ID"=$2
 `;
 
-exports.getPartyLicenceVersions = `SELECT lv.*, l."REV_DATE", l."LAPSED_DATE", l."EXPIRY_DATE" FROM import."NALD_ABS_LIC_VERSIONS" lv
+const getPartyLicenceVersions = `SELECT lv.*, l."REV_DATE", l."LAPSED_DATE", l."EXPIRY_DATE" FROM import."NALD_ABS_LIC_VERSIONS" lv
 JOIN import."NALD_ABS_LICENCES" l ON lv."AABL_ID"=l."ID" AND lv."FGAC_REGION_CODE"=l."FGAC_REGION_CODE"
 WHERE lv."FGAC_REGION_CODE"=$1 AND lv."ACON_APAR_ID"=$2
 AND lv."STATUS"<>'DRAFT'`;
 
-exports.getParties = `SELECT * FROM import."NALD_PARTIES" p
+const getParties = `SELECT * FROM import."NALD_PARTIES" p
 WHERE p."FGAC_REGION_CODE"=$1
 AND p."ID" =  any (string_to_array($2, ',')::text[])`;
 
-exports.getAddresses = `SELECT * FROM import."NALD_ADDRESSES" a
+const getAddresses = `SELECT * FROM import."NALD_ADDRESSES" a
 WHERE a."FGAC_REGION_CODE"=$1
 AND a."ID" =  any (string_to_array($2, ',')::text[])`;
 
-exports.getAllLicenceNumbers = `
+const getAllLicenceNumbers = `
   SELECT l."LIC_NO"
   FROM import."NALD_ABS_LICENCES" l;
 `;
 
-exports.getLicenceRoles = `
+const getLicenceRoles = `
 select * from import."NALD_LIC_ROLES" r
 where r."FGAC_REGION_CODE"=$1 and r."AABL_ID"=$2
 order by to_date(r."EFF_ST_DATE", 'DD/MM/YYYY')
 `;
 
-exports.getPartyLicenceRoles = `
+const getPartyLicenceRoles = `
 select * from import."NALD_LIC_ROLES" r
   where r."FGAC_REGION_CODE"=$1 and r."ACON_APAR_ID"=$2
 `;
+
+module.exports = {
+  getLicence,
+  getLicenceVersions,
+  getLicencePurposes,
+  getPurposeConditions,
+  getParty,
+  getAddress,
+  getAllAddresses,
+  getAllParties,
+  getChargeVersions,
+  getTwoPartTariffAgreements,
+  getSection130Agreements,
+  getInvoiceAccounts,
+  getPartyLicenceVersions,
+  getParties,
+  getAddresses,
+  getAllLicenceNumbers,
+  getLicenceRoles,
+  getPartyLicenceRoles
+};

--- a/src/modules/licence-import/extract/index.js
+++ b/src/modules/licence-import/extract/index.js
@@ -75,7 +75,9 @@ const getCompanyData = async (regionCode, partyId) => {
   };
 };
 
-exports.getLicenceData = getLicenceData;
-exports.getCompanyData = getCompanyData;
-exports.getAllParties = importConnector.getAllParties;
-exports.getAllLicenceNumbers = importConnector.getAllLicenceNumbers;
+module.exports = {
+  getLicenceData,
+  getCompanyData,
+  getAllParties: importConnector.getAllParties,
+  getAllLicenceNumbers: importConnector.getAllLicenceNumbers
+};

--- a/src/modules/licence-import/jobs/index.js
+++ b/src/modules/licence-import/jobs/index.js
@@ -75,16 +75,17 @@ const importPurposeConditionTypes = () => ({
   name: IMPORT_PURPOSE_CONDITION_TYPES_JOB
 });
 
-exports.IMPORT_PURPOSE_CONDITION_TYPES_JOB = IMPORT_PURPOSE_CONDITION_TYPES_JOB;
-exports.IMPORT_COMPANIES_JOB = IMPORT_COMPANIES_JOB;
-exports.IMPORT_COMPANY_JOB = IMPORT_COMPANY_JOB;
-exports.IMPORT_LICENCES_JOB = IMPORT_LICENCES_JOB;
-exports.IMPORT_LICENCE_JOB = IMPORT_LICENCE_JOB;
-exports.DELETE_DOCUMENTS_JOB = DELETE_DOCUMENTS_JOB;
-
-exports.importPurposeConditionTypes = importPurposeConditionTypes;
-exports.importCompanies = importCompanies;
-exports.importCompany = importCompany;
-exports.importLicences = importLicences;
-exports.importLicence = importLicence;
-exports.deleteDocuments = deleteDocuments;
+module.exports = {
+  IMPORT_PURPOSE_CONDITION_TYPES_JOB,
+  IMPORT_COMPANIES_JOB,
+  IMPORT_COMPANY_JOB,
+  IMPORT_LICENCES_JOB,
+  IMPORT_LICENCE_JOB,
+  DELETE_DOCUMENTS_JOB,
+  importPurposeConditionTypes,
+  importCompanies,
+  importCompany,
+  importLicences,
+  importLicence,
+  deleteDocuments
+};

--- a/src/modules/licence-import/load/company.js
+++ b/src/modules/licence-import/load/company.js
@@ -80,4 +80,6 @@ const loadCompany = async company => {
   return { entities, relationships };
 };
 
-exports.loadCompany = loadCompany;
+module.exports = {
+  loadCompany
+};

--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -139,21 +139,23 @@ const createPurposeCondition = (condition, purposeId) =>
     condition.externalId
   ]);
 
-exports.createPurposeCondition = createPurposeCondition;
-exports.createPurposeConditionTypes = createPurposeConditionTypes;
-exports.createAddress = createAddress;
-exports.createAgreement = createAgreement;
-exports.createCompany = createCompany;
-exports.createCompanyAddress = createCompanyAddress;
-exports.createCompanyContact = createCompanyContact;
-exports.createContact = createContact;
-exports.createDocument = createDocument;
-exports.createDocumentRole = createDocumentRole;
-exports.createInvoiceAccount = createInvoiceAccount;
-exports.createInvoiceAccountAddress = createInvoiceAccountAddress;
-exports.createLicence = createLicence;
-exports.createLicenceVersion = createLicenceVersion;
-exports.createLicenceVersionPurpose = createLicenceVersionPurpose;
-exports.getLicenceByRef = getLicenceByRef;
-exports.flagLicenceForSupplementaryBilling = flagLicenceForSupplementaryBilling;
-exports.cleanUpAgreements = cleanUpAgreements;
+module.exports = {
+  createPurposeCondition,
+  createPurposeConditionTypes,
+  createAddress,
+  createAgreement,
+  createCompany,
+  createCompanyAddress,
+  createCompanyContact,
+  createContact,
+  createDocument,
+  createDocumentRole,
+  createInvoiceAccount,
+  createInvoiceAccountAddress,
+  createLicence,
+  createLicenceVersion,
+  createLicenceVersionPurpose,
+  getLicenceByRef,
+  flagLicenceForSupplementaryBilling,
+  cleanUpAgreements
+};

--- a/src/modules/licence-import/load/connectors/queries.js
+++ b/src/modules/licence-import/load/connectors/queries.js
@@ -1,4 +1,4 @@
-exports.createDocument = `
+const createDocument = `
   INSERT INTO crm_v2.documents (regime, document_type, document_ref, start_date, end_date, external_id, date_created, date_updated, date_deleted)
   VALUES ('water', 'abstraction_licence', $1, $2, $3, $4, NOW(), NOW(), null)
   ON CONFLICT (regime, document_type, document_ref)
@@ -9,7 +9,7 @@ exports.createDocument = `
     date_updated=EXCLUDED.date_updated,
     date_deleted=EXCLUDED.date_deleted;`;
 
-exports.createDocumentRole = `INSERT INTO crm_v2.document_roles (document_id, role_id, company_id, contact_id, address_id, start_date, end_date, date_created, date_updated, invoice_account_id)
+const createDocumentRole = `INSERT INTO crm_v2.document_roles (document_id, role_id, company_id, contact_id, address_id, start_date, end_date, date_created, date_updated, invoice_account_id)
 SELECT d.document_id, r.role_id, c.company_id, co.contact_id, a.address_id, $7, $8, NOW(), NOW(), ia.invoice_account_id
   FROM crm_v2.documents d
   JOIN crm_v2.roles r ON r.name=$2
@@ -27,11 +27,11 @@ ON CONFLICT (document_id, role_id, start_date)
     end_date=EXCLUDED.end_date,
     date_updated=EXCLUDED.date_updated;`;
 
-exports.createCompany = `INSERT INTO crm_v2.companies (name, type, external_id, date_created, date_updated, current_hash)
+const createCompany = `INSERT INTO crm_v2.companies (name, type, external_id, date_created, date_updated, current_hash)
 VALUES ($1, $2, $3, NOW(), NOW(), md5(CONCAT($1::varchar, $2::varchar)::varchar)) ON CONFLICT (external_id) DO UPDATE SET name=EXCLUDED.name,
 date_updated=EXCLUDED.date_updated, type=EXCLUDED.type, last_hash=EXCLUDED.current_hash, current_hash=md5(CONCAT(EXCLUDED.name::varchar,EXCLUDED.type::varchar)::varchar);`;
 
-exports.createAddress = `INSERT INTO crm_v2.addresses (address_1, address_2, address_3, address_4,
+const createAddress = `INSERT INTO crm_v2.addresses (address_1, address_2, address_3, address_4,
 town, county, postcode, country, external_id, data_source, date_created, date_updated, current_hash)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'nald', NOW(), NOW(), md5(
 CONCAT(
@@ -58,7 +58,7 @@ EXCLUDED.postcode::varchar
 )::varchar),
 date_updated=EXCLUDED.date_updated;`;
 
-exports.createContact = `INSERT INTO crm_v2.contacts (salutation, initials, first_name, last_name, external_id, data_source, date_created, date_updated, current_hash)
+const createContact = `INSERT INTO crm_v2.contacts (salutation, initials, first_name, last_name, external_id, data_source, date_created, date_updated, current_hash)
 VALUES ($1, $2, $3, $4, $5, 'nald', NOW(), NOW(), md5(CONCAT($1::varchar,$3::varchar,$4::varchar)::varchar)) ON CONFLICT (external_id) DO UPDATE SET
   salutation=EXCLUDED.salutation,
   initials=EXCLUDED.initials,
@@ -73,7 +73,7 @@ VALUES ($1, $2, $3, $4, $5, 'nald', NOW(), NOW(), md5(CONCAT($1::varchar,$3::var
   EXCLUDED.last_name::varchar
   )::varchar);`;
 
-exports.createInvoiceAccount = `INSERT INTO crm_v2.invoice_accounts (company_id, invoice_account_number, start_date, end_date, date_created, date_updated)
+const createInvoiceAccount = `INSERT INTO crm_v2.invoice_accounts (company_id, invoice_account_number, start_date, end_date, date_created, date_updated)
 SELECT company_id, $1, $2, $3, NOW(), NOW() FROM crm_v2.companies WHERE external_id=$4
 ON CONFLICT (invoice_account_number) DO UPDATE SET
   company_id=EXCLUDED.company_id,
@@ -81,7 +81,7 @@ ON CONFLICT (invoice_account_number) DO UPDATE SET
   end_date=EXCLUDED.end_date,
   date_updated=EXCLUDED.date_updated;`;
 
-exports.createInvoiceAccountAddress = `INSERT INTO crm_v2.invoice_account_addresses (invoice_account_id, address_id, agent_company_id, start_date, end_date, date_updated, date_created)
+const createInvoiceAccountAddress = `INSERT INTO crm_v2.invoice_account_addresses (invoice_account_id, address_id, agent_company_id, start_date, end_date, date_updated, date_created)
 SELECT ia.invoice_account_id, a.address_id, c.company_id, $3, $4, NOW(), NOW()
 FROM crm_v2.invoice_accounts ia
 JOIN crm_v2.addresses a ON a.external_id=$2
@@ -91,7 +91,7 @@ WHERE ia.invoice_account_number=$1 ON CONFLICT (invoice_account_id, start_date) 
   date_updated=EXCLUDED.date_updated,
   agent_company_id=EXCLUDED.agent_company_id;`;
 
-exports.createCompanyContact = `INSERT INTO crm_v2.company_contacts (company_id, contact_id, role_id, start_date, end_date, is_default, date_created, date_updated)
+const createCompanyContact = `INSERT INTO crm_v2.company_contacts (company_id, contact_id, role_id, start_date, end_date, is_default, date_created, date_updated)
 SELECT c.company_id, o.contact_id, r.role_id, $4, $5, true, NOW(), NOW()
 FROM crm_v2.companies c
 JOIN crm_v2.contacts o ON o.external_id=$2
@@ -102,7 +102,7 @@ WHERE c.external_id=$1 ON CONFLICT (company_id, contact_id, role_id, start_date)
   end_date=EXCLUDED.end_date,
   date_updated=EXCLUDED.date_updated;`;
 
-exports.createCompanyAddress = `INSERT INTO crm_v2.company_addresses (company_id, address_id, role_id, start_date, end_date, is_default, date_created, date_updated)
+const createCompanyAddress = `INSERT INTO crm_v2.company_addresses (company_id, address_id, role_id, start_date, end_date, is_default, date_created, date_updated)
 SELECT c.company_id, a.address_id, r.role_id, $4, $5, true, NOW(), NOW()
 FROM crm_v2.companies c
 JOIN crm_v2.addresses a ON a.external_id=$2
@@ -114,13 +114,13 @@ ON CONFLICT (company_id, address_id, role_id) DO UPDATE SET
   end_date=EXCLUDED.end_date,
   date_updated=EXCLUDED.date_updated`;
 
-exports.createAgreement = `insert into water.licence_agreements (licence_ref, financial_agreement_type_id, start_date, end_date, date_created, date_updated, source)
+const createAgreement = `insert into water.licence_agreements (licence_ref, financial_agreement_type_id, start_date, end_date, date_created, date_updated, source)
   select $1, t.financial_agreement_type_id, $3, $4, NOW(), NOW(), 'nald' 
     from water.financial_agreement_types t
     where t.financial_agreement_code=$2 on conflict (licence_ref, financial_agreement_type_id, start_date) WHERE date_deleted is null 
     do update set end_date=EXCLUDED.end_date, date_updated=EXCLUDED.date_updated, source=EXCLUDED.source;`;
 
-exports.createLicence = `insert into water.licences (region_id, licence_ref, is_water_undertaker, regions, start_date, expired_date, lapsed_date, revoked_date)
+const createLicence = `insert into water.licences (region_id, licence_ref, is_water_undertaker, regions, start_date, expired_date, lapsed_date, revoked_date)
   values (
     (select region_id from water.regions where nald_region_id = $1),
     $2,
@@ -140,7 +140,7 @@ exports.createLicence = `insert into water.licences (region_id, licence_ref, is_
     date_updated=now()
   returning licence_id;`;
 
-exports.createLicenceVersion = `insert into water.licence_versions (
+const createLicenceVersion = `insert into water.licence_versions (
     licence_id,
     issue,
     increment,
@@ -158,7 +158,7 @@ exports.createLicenceVersion = `insert into water.licence_versions (
     date_updated = now()
   returning licence_version_id;`;
 
-exports.createLicenceVersionPurpose = `insert into water.licence_version_purposes (
+const createLicenceVersionPurpose = `insert into water.licence_version_purposes (
     licence_version_id,
     purpose_primary_id,
     purpose_secondary_id,
@@ -205,11 +205,11 @@ exports.createLicenceVersionPurpose = `insert into water.licence_version_purpose
     date_updated = now()
     returning licence_version_purpose_id;`;
 
-exports.getLicenceByRef = 'SELECT * FROM water.licences WHERE licence_ref = $1';
+const getLicenceByRef = 'SELECT * FROM water.licences WHERE licence_ref = $1';
 
-exports.flagLicenceForSupplementaryBilling = 'UPDATE water.licences set include_in_supplementary_billing = \'yes\' WHERE licence_id = $1';
+const flagLicenceForSupplementaryBilling = 'UPDATE water.licences set include_in_supplementary_billing = \'yes\' WHERE licence_id = $1';
 
-exports.cleanUpAgreements = `
+const cleanUpAgreements = `
 delete 
   from water.licence_agreements la
   using water.financial_agreement_types fat
@@ -220,7 +220,7 @@ delete
     and la.financial_agreement_type_id=fat.financial_agreement_type_id
 `;
 
-exports.createPurposeConditionTypes = `
+const createPurposeConditionTypes = `
 INSERT INTO water.licence_version_purpose_condition_types (
   code,
   subcode,
@@ -236,7 +236,7 @@ INSERT INTO water.licence_version_purpose_condition_types (
     date_updated = now();
 `;
 
-exports.createPurposeCondition = `
+const createPurposeCondition = `
 INSERT INTO water.licence_version_purpose_conditions (
   licence_version_purpose_id,
   licence_version_purpose_condition_type_id,
@@ -261,3 +261,24 @@ DO UPDATE SET
  notes = excluded.notes,
  date_updated = now();
 `;
+
+module.exports = {
+  createDocument,
+  createDocumentRole,
+  createCompany,
+  createAddress,
+  createContact,
+  createInvoiceAccount,
+  createInvoiceAccountAddress,
+  createCompanyContact,
+  createCompanyAddress,
+  createAgreement,
+  createLicence,
+  createLicenceVersion,
+  createLicenceVersionPurpose,
+  getLicenceByRef,
+  flagLicenceForSupplementaryBilling,
+  cleanUpAgreements,
+  createPurposeConditionTypes,
+  createPurposeCondition
+};

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -89,4 +89,6 @@ const loadLicence = async licence => {
   return loadVersions(licence, savedLicence.licence_id);
 };
 
-exports.loadLicence = loadLicence;
+module.exports = {
+  loadLicence
+};

--- a/src/modules/licence-import/load/purpose-condition-types.js
+++ b/src/modules/licence-import/load/purpose-condition-types.js
@@ -2,4 +2,8 @@
 
 const connectors = require('./connectors');
 
-exports.createPurposeConditionTypes = () => connectors.createPurposeConditionTypes();
+const createPurposeConditionTypes = () => connectors.createPurposeConditionTypes();
+
+module.exports = {
+  createPurposeConditionTypes
+};

--- a/src/modules/licence-import/plugin.js
+++ b/src/modules/licence-import/plugin.js
@@ -47,8 +47,12 @@ const registerSubscribers = async server => {
   });
 };
 
-exports.plugin = {
+const plugin = {
   name: 'importLicenceData',
   dependencies: ['pgBoss'],
   register: server => createRegister(server, registerSubscribers)
+};
+
+module.exports = {
+  plugin
 };

--- a/src/modules/licence-import/transform/company.js
+++ b/src/modules/licence-import/transform/company.js
@@ -24,4 +24,6 @@ const transformCompany = companyData => {
   return mappers.licence.omitNaldData(company);
 };
 
-exports.transformCompany = transformCompany;
+module.exports = {
+  transformCompany
+};

--- a/src/modules/licence-import/transform/licence.js
+++ b/src/modules/licence-import/transform/licence.js
@@ -42,4 +42,6 @@ const transformLicence = licenceData => {
   return finalLicence;
 };
 
-exports.transformLicence = transformLicence;
+module.exports = {
+  transformLicence
+};

--- a/src/modules/licence-import/transform/mappers/address.js
+++ b/src/modules/licence-import/transform/mappers/address.js
@@ -20,5 +20,7 @@ const mapAddresses = addresses => addresses.reduce((acc, address) => {
   return acc;
 }, createRegionSkeleton());
 
-exports.mapAddress = mapAddress;
-exports.mapAddresses = mapAddresses;
+module.exports = {
+  mapAddress,
+  mapAddresses
+};

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -76,4 +76,6 @@ const mapAgreements = (tptAgreements, s130Agreements = []) => {
   return flatMap(merged);
 };
 
-exports.mapAgreements = mapAgreements;
+module.exports = {
+  mapAgreements
+};

--- a/src/modules/licence-import/transform/mappers/company-address.js
+++ b/src/modules/licence-import/transform/mappers/company-address.js
@@ -89,4 +89,6 @@ const mapCompanyAddresses = (licenceVersions, chargeVersions, licenceRoles, cont
   ];
 };
 
-exports.mapCompanyAddresses = mapCompanyAddresses;
+module.exports = {
+  mapCompanyAddresses
+};

--- a/src/modules/licence-import/transform/mappers/company-contact.js
+++ b/src/modules/licence-import/transform/mappers/company-contact.js
@@ -39,4 +39,6 @@ const mapCompanyContacts = (contact, licenceVersions, chargeVersions) => {
   return contacts;
 };
 
-exports.mapCompanyContacts = mapCompanyContacts;
+module.exports = {
+  mapCompanyContacts
+};

--- a/src/modules/licence-import/transform/mappers/company.js
+++ b/src/modules/licence-import/transform/mappers/company.js
@@ -33,4 +33,6 @@ const mapCompany = party => ({
   _nald: party
 });
 
-exports.mapCompany = mapCompany;
+module.exports = {
+  mapCompany
+};

--- a/src/modules/licence-import/transform/mappers/contact.js
+++ b/src/modules/licence-import/transform/mappers/contact.js
@@ -19,4 +19,6 @@ const mapContact = party => {
   };
 };
 
-exports.mapContact = mapContact;
+module.exports = {
+  mapContact
+};

--- a/src/modules/licence-import/transform/mappers/date.js
+++ b/src/modules/licence-import/transform/mappers/date.js
@@ -42,9 +42,11 @@ const mapTransferDate = str =>
 const getPreviousDay = str =>
   moment(str, DATE_FORMAT).subtract(1, 'day').format(DATE_FORMAT);
 
-exports.mapNaldDate = mapNaldDate;
-exports.getMinDate = getMinDate;
-exports.getMaxDate = getMaxDate;
-exports.mapTransferDate = mapTransferDate;
-exports.getPreviousDay = getPreviousDay;
-exports.mapIsoDateToNald = mapIsoDateToNald;
+module.exports = {
+  mapNaldDate,
+  getMinDate,
+  getMaxDate,
+  mapTransferDate,
+  getPreviousDay,
+  mapIsoDateToNald
+};

--- a/src/modules/licence-import/transform/mappers/document.js
+++ b/src/modules/licence-import/transform/mappers/document.js
@@ -9,4 +9,6 @@ const mapLicenceToDocument = licence => ({
   _nald: licence._nald
 });
 
-exports.mapLicenceToDocument = mapLicenceToDocument;
+module.exports = {
+  mapLicenceToDocument
+};

--- a/src/modules/licence-import/transform/mappers/invoice-account.js
+++ b/src/modules/licence-import/transform/mappers/invoice-account.js
@@ -65,5 +65,7 @@ const mapInvoiceAccounts = (iasAccounts, context) => {
   });
 };
 
-exports.mapInvoiceAccount = mapInvoiceAccount;
-exports.mapInvoiceAccounts = mapInvoiceAccounts;
+module.exports = {
+  mapInvoiceAccount,
+  mapInvoiceAccounts
+};

--- a/src/modules/licence-import/transform/mappers/licence-purpose.js
+++ b/src/modules/licence-import/transform/mappers/licence-purpose.js
@@ -26,4 +26,6 @@ const mapLicencePurpose = data => {
   return purpose;
 };
 
-exports.mapLicencePurpose = mapLicencePurpose;
+module.exports = {
+  mapLicencePurpose
+};

--- a/src/modules/licence-import/transform/mappers/licence-version.js
+++ b/src/modules/licence-import/transform/mappers/licence-version.js
@@ -39,4 +39,6 @@ const mapLicenceVersion = (licenceVersionData, mappedPurposes = [], mappedCondit
   };
 };
 
-exports.mapLicenceVersion = mapLicenceVersion;
+module.exports = {
+  mapLicenceVersion
+};

--- a/src/modules/licence-import/transform/mappers/licence.js
+++ b/src/modules/licence-import/transform/mappers/licence.js
@@ -101,5 +101,7 @@ const omitNaldData = value => {
   return value;
 };
 
-exports.mapLicence = mapLicence;
-exports.omitNaldData = omitNaldData;
+module.exports = {
+  mapLicence,
+  omitNaldData
+};

--- a/src/modules/licence-import/transform/mappers/party.js
+++ b/src/modules/licence-import/transform/mappers/party.js
@@ -16,4 +16,6 @@ const mapParties = parties => parties.reduce((acc, party) => {
   return acc;
 }, createRegionSkeleton());
 
-exports.mapParties = mapParties;
+module.exports = {
+  mapParties
+};

--- a/src/modules/licence-import/transform/mappers/purpose-condition.js
+++ b/src/modules/licence-import/transform/mappers/purpose-condition.js
@@ -18,4 +18,6 @@ const mapPurposeConditionFromNALD = data => {
   };
 };
 
-exports.mapPurposeConditionFromNALD = mapPurposeConditionFromNALD;
+module.exports = {
+  mapPurposeConditionFromNALD
+};

--- a/src/modules/licence-import/transform/mappers/region-skeleton.js
+++ b/src/modules/licence-import/transform/mappers/region-skeleton.js
@@ -9,4 +9,6 @@ const createRegionSkeleton = () => ({
   8: {}
 });
 
-exports.createRegionSkeleton = createRegionSkeleton;
+module.exports = {
+  createRegionSkeleton
+};

--- a/src/modules/licence-import/transform/mappers/role.js
+++ b/src/modules/licence-import/transform/mappers/role.js
@@ -85,5 +85,7 @@ const mapLicenceRoles = (licenceRoles, context) => licenceRoles
   .filter(isRoleForImport)
   .map(role => mapLicenceRole(role, context));
 
-exports.mapLicenceHolderRoles = mapLicenceHolderRoles;
-exports.mapLicenceRoles = mapLicenceRoles;
+module.exports = {
+  mapLicenceHolderRoles,
+  mapLicenceRoles
+};

--- a/src/modules/licence-import/transform/mappers/roles.js
+++ b/src/modules/licence-import/transform/mappers/roles.js
@@ -11,8 +11,9 @@ const ROLE_RETURNS_TO = 'returnsTo';
 const naldRoles = new Map();
 naldRoles.set('RT', ROLE_RETURNS_TO);
 
-exports.ROLE_LICENCE_HOLDER = ROLE_LICENCE_HOLDER;
-exports.ROLE_BILLING = ROLE_BILLING;
-exports.ROLE_RETURNS_TO = ROLE_RETURNS_TO;
-
-exports.naldRoles = naldRoles;
+module.exports = {
+  ROLE_LICENCE_HOLDER,
+  ROLE_BILLING,
+  ROLE_RETURNS_TO,
+  naldRoles
+};

--- a/src/modules/licence-import/transform/mappers/str.js
+++ b/src/modules/licence-import/transform/mappers/str.js
@@ -1,3 +1,5 @@
 const mapNull = str => str === 'null' ? null : str;
 
-exports.mapNull = mapNull;
+module.exports = {
+  mapNull
+};

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -102,9 +102,11 @@ const postImportLicence = async (request, h) => {
   }
 };
 
-exports.getLicence = getLicence;
-exports.getReturns = getReturns;
-exports.getReturnsFormats = getReturnsFormats;
-exports.getReturnsLogs = getReturnsLogs;
-exports.getReturnsLogLines = getReturnsLogLines;
-exports.postImportLicence = postImportLicence;
+module.exports = {
+  getLicence,
+  getReturns,
+  getReturnsFormats,
+  getReturnsLogs,
+  getReturnsLogLines,
+  postImportLicence
+};

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -24,6 +24,8 @@ const handler = async job => {
   }
 };
 
-exports.createMessage = createMessage;
-exports.handler = handler;
-exports.jobName = JOB_NAME;
+module.exports = {
+  createMessage,
+  handler,
+  jobName: JOB_NAME
+};

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -38,7 +38,9 @@ const handler = async job => {
   }
 };
 
-exports.createMessage = createMessage;
-exports.handler = handler;
-exports.jobName = JOB_NAME;
-exports.options = options;
+module.exports = {
+  createMessage,
+  handler,
+  jobName: JOB_NAME,
+  options
+};

--- a/src/modules/nald-import/jobs/index.js
+++ b/src/modules/nald-import/jobs/index.js
@@ -1,20 +1,27 @@
 'use strict';
 
-exports.s3Download = {
+const s3Download = {
   job: require('./s3-download'),
   onCompleteHandler: require('./s3-download-complete')
 };
 
-exports.populatePendingImport = {
+const populatePendingImport = {
   job: require('./populate-pending-import'),
   onCompleteHandler: require('./populate-pending-import-complete')
 };
 
-exports.deleteRemovedDocuments = {
+const deleteRemovedDocuments = {
   job: require('./delete-removed-documents'),
   onCompleteHandler: require('./delete-removed-documents-complete')
 };
 
-exports.importLicence = {
+const importLicence = {
   job: require('./import-licence')
+};
+
+module.exports = {
+  s3Download,
+  populatePendingImport,
+  deleteRemovedDocuments,
+  importLicence
 };

--- a/src/modules/nald-import/jobs/lib/logger.js
+++ b/src/modules/nald-import/jobs/lib/logger.js
@@ -18,10 +18,11 @@ const logHandlingOnCompleteError = (job, err) =>
 const logAbortingOnComplete = job =>
   logger.info(`Aborting onComplete job: ${job.data.request.name}`, job.data);
 
-exports.logHandlingJob = logHandlingJob;
-exports.logFailedJob = logFailedJob;
-exports.logJobError = logJobError;
-
-exports.logHandlingOnCompleteJob = logHandlingOnCompleteJob;
-exports.logHandlingOnCompleteError = logHandlingOnCompleteError;
-exports.logAbortingOnComplete = logAbortingOnComplete;
+module.exports = {
+  logHandlingJob,
+  logFailedJob,
+  logJobError,
+  logHandlingOnCompleteJob,
+  logHandlingOnCompleteError,
+  logAbortingOnComplete
+};

--- a/src/modules/nald-import/jobs/populate-pending-import.js
+++ b/src/modules/nald-import/jobs/populate-pending-import.js
@@ -28,6 +28,8 @@ const handler = async job => {
   }
 };
 
-exports.createMessage = createMessage;
-exports.handler = handler;
-exports.jobName = JOB_NAME;
+module.exports = {
+  createMessage,
+  handler,
+  jobName: JOB_NAME
+};

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -78,6 +78,8 @@ const handler = async job => {
   }
 };
 
-exports.createMessage = createMessage;
-exports.handler = handler;
-exports.jobName = JOB_NAME;
+module.exports = {
+  createMessage,
+  handler,
+  jobName: JOB_NAME
+};

--- a/src/modules/nald-import/lib/assert-import-tables-exist.js
+++ b/src/modules/nald-import/lib/assert-import-tables-exist.js
@@ -10,4 +10,6 @@ const assertImportTablesExist = async () => {
   }
 };
 
-exports.assertImportTablesExist = assertImportTablesExist;
+module.exports = {
+  assertImportTablesExist
+};

--- a/src/modules/nald-import/lib/constants.js
+++ b/src/modules/nald-import/lib/constants.js
@@ -1,9 +1,11 @@
 const config = require('../../../../config');
 
-exports.S3_IMPORT_PATH = config.import.nald.path;
-exports.S3_IMPORT_FILE = 'nald_enc.zip';
-exports.LOCAL_TEMP_PATH = './temp/';
-exports.CSV_DIRECTORY = 'NALD';
-exports.SCHEMA_IMPORT = 'import';
-exports.SCHEMA_TEMP = 'import_temp';
-exports.APPLICATION_STATE_KEY = 'nald-import';
+module.exports = {
+  S3_IMPORT_PATH: config.import.nald.path,
+  S3_IMPORT_FILE: 'nald_enc.zip',
+  LOCAL_TEMP_PATH: './temp/',
+  CSV_DIRECTORY: 'NALD',
+  SCHEMA_IMPORT: 'import',
+  SCHEMA_TEMP: 'import_temp',
+  APPLICATION_STATE_KEY: 'nald-import'
+};

--- a/src/modules/nald-import/lib/due-date.js
+++ b/src/modules/nald-import/lib/due-date.js
@@ -65,4 +65,6 @@ const getDueDate = async (endDate, format) => {
   return moment(refDate, 'YYYY-MM-DD').add(28, 'days').format('YYYY-MM-DD');
 };
 
-exports.getDueDate = getDueDate;
+module.exports = {
+  getDueDate
+};

--- a/src/modules/nald-import/lib/end-date.js
+++ b/src/modules/nald-import/lib/end-date.js
@@ -24,4 +24,6 @@ const getEndDate = (data = {}) => {
   return first(sortedAndFiltered);
 };
 
-exports.getEndDate = getEndDate;
+module.exports = {
+  getEndDate
+};

--- a/src/modules/nald-import/lib/nald-queries/addresses.js
+++ b/src/modules/nald-import/lib/nald-queries/addresses.js
@@ -7,4 +7,6 @@ const getAddress = async (addressId, regionCode) => {
   return db.dbQuery(sql.getAddress, [addressId, regionCode]);
 };
 
-exports.getAddress = getAddress;
+module.exports = {
+  getAddress
+};

--- a/src/modules/nald-import/lib/nald-queries/cache.js
+++ b/src/modules/nald-import/lib/nald-queries/cache.js
@@ -22,5 +22,7 @@ const createId = (key, params) => {
   };
 };
 
-exports.createCachedQuery = createCachedQuery;
-exports.createId = createId;
+module.exports = {
+  createCachedQuery,
+  createId
+};

--- a/src/modules/nald-import/lib/nald-queries/cams.js
+++ b/src/modules/nald-import/lib/nald-queries/cams.js
@@ -19,6 +19,8 @@ const getCams = (code, regionCode) => {
   return _getCamsCache.get(id);
 };
 
-exports.getCams = getCams;
-exports._getCamsCache = _getCamsCache;
-exports._createCamsCache = _createCamsCache;
+module.exports = {
+  getCams,
+  _getCamsCache,
+  _createCamsCache
+};

--- a/src/modules/nald-import/lib/nald-queries/charge-versions-metadata.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions-metadata.js
@@ -13,4 +13,6 @@ on conflict (external_id) do update set
   date_updated=NOW();
 `;
 
-exports.insertChargeVersionMetadata = insertChargeVersionMetadata;
+module.exports = {
+  insertChargeVersionMetadata
+};

--- a/src/modules/nald-import/lib/nald-queries/charge-versions.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions.js
@@ -32,4 +32,6 @@ ORDER BY
   v."VERS_NO"::integer;
 `;
 
-exports.getNonDraftChargeVersionsForLicence = getNonDraftChargeVersionsForLicence;
+module.exports = {
+  getNonDraftChargeVersionsForLicence
+};

--- a/src/modules/nald-import/lib/nald-queries/core.js
+++ b/src/modules/nald-import/lib/nald-queries/core.js
@@ -16,4 +16,6 @@ const importTableExists = async () => {
   return false;
 };
 
-exports.importTableExists = importTableExists;
+module.exports = {
+  importTableExists
+};

--- a/src/modules/nald-import/lib/nald-queries/licences.js
+++ b/src/modules/nald-import/lib/nald-queries/licences.js
@@ -26,7 +26,9 @@ const getCurrentFormats = async (licenceId, regionCode) => {
   return db.dbQuery(sql.getCurrentFormats, [licenceId, regionCode]);
 };
 
-exports.getLicence = getLicence;
-exports.getCurrentVersion = getCurrentVersion;
-exports.getVersions = getVersions;
-exports.getCurrentFormats = getCurrentFormats;
+module.exports = {
+  getLicence,
+  getCurrentVersion,
+  getVersions,
+  getCurrentFormats
+};

--- a/src/modules/nald-import/lib/nald-queries/parties.js
+++ b/src/modules/nald-import/lib/nald-queries/parties.js
@@ -34,12 +34,12 @@ const getParty = async (partyId, regionCode) => {
   return db.dbQuery(sql.getParty, [partyId, regionCode]);
 };
 
-exports._createPartiesCache = _createPartiesCache;
-exports._createPartyContactsCache = _createPartyContactsCache;
-
-exports._getPartiesCache = _getPartiesCache;
-exports._getPartyContactsCache = _getPartyContactsCache;
-
-exports.getParties = getParties;
-exports.getParty = getParty;
-exports.getPartyContacts = getPartyContacts;
+module.exports = {
+  _createPartiesCache,
+  _createPartyContactsCache,
+  _getPartiesCache,
+  _getPartyContactsCache,
+  getParties,
+  getParty,
+  getPartyContacts
+};

--- a/src/modules/nald-import/lib/nald-queries/purposes.js
+++ b/src/modules/nald-import/lib/nald-queries/purposes.js
@@ -58,10 +58,12 @@ const getPurposePointLicenceConditions = async (AABP_ID, FGAC_REGION_CODE) => {
   return db.dbQuery(sql.getPurposePointLicenceConditions, params);
 };
 
-exports._getPurposeCache = _getPurposeCache;
-exports._createPurposeCache = _createPurposeCache;
-exports.getPurposes = getPurposes;
-exports.getPurposePoints = getPurposePoints;
-exports.getPurpose = getPurpose;
-exports.getPurposePointLicenceAgreements = getPurposePointLicenceAgreements;
-exports.getPurposePointLicenceConditions = getPurposePointLicenceConditions;
+module.exports = {
+  _getPurposeCache,
+  _createPurposeCache,
+  getPurposes,
+  getPurposePoints,
+  getPurpose,
+  getPurposePointLicenceAgreements,
+  getPurposePointLicenceConditions
+};

--- a/src/modules/nald-import/lib/nald-queries/returns.js
+++ b/src/modules/nald-import/lib/nald-queries/returns.js
@@ -125,14 +125,16 @@ const _createReturnVersionReasonCache = () => {
 
 const _getReturnVersionReasonCache = _createReturnVersionReasonCache();
 
-exports._createReturnVersionReasonCache = _createReturnVersionReasonCache;
-exports._getReturnVersionReasonCache = _getReturnVersionReasonCache;
-exports.getFormats = getFormats;
-exports.getFormatPurposes = getFormatPurposes;
-exports.getFormatPoints = getFormatPoints;
-exports.getLogs = getLogs;
-exports.getLines = getLines;
-exports.getLogLines = getLogLines;
-exports.isNilReturn = isNilReturn;
-exports.getSplitDate = getSplitDate;
-exports.getReturnVersionReason = getReturnVersionReason;
+module.exports = {
+  _createReturnVersionReasonCache,
+  _getReturnVersionReasonCache,
+  getFormats,
+  getFormatPurposes,
+  getFormatPoints,
+  getLogs,
+  getLines,
+  getLogLines,
+  isNilReturn,
+  getSplitDate,
+  getReturnVersionReason
+};

--- a/src/modules/nald-import/lib/nald-queries/roles.js
+++ b/src/modules/nald-import/lib/nald-queries/roles.js
@@ -7,4 +7,6 @@ const getRoles = async (AABL_ID, FGAC_REGION_CODE) => {
   return db.dbQuery(sql.getRoles, [AABL_ID, FGAC_REGION_CODE]);
 };
 
-exports.getRoles = getRoles;
+module.exports = {
+  getRoles
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/addresses.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/addresses.js
@@ -6,4 +6,6 @@ const getAddress = `
   where "ID"=$1 and "FGAC_REGION_CODE" = $2;
 `;
 
-exports.getAddress = getAddress;
+module.exports = {
+  getAddress
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/cams.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/cams.js
@@ -6,4 +6,6 @@ const getCams = `
   where "CODE" = $1 and "FGAC_REGION_CODE" = $2;
 `;
 
-exports.getCams = getCams;
+module.exports = {
+  getCams
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/core.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/core.js
@@ -6,4 +6,6 @@ const importTableExists = `
   where table_schema = 'import';
 `;
 
-exports.importTableExists = importTableExists;
+module.exports = {
+  importTableExists
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/licences.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/licences.js
@@ -66,7 +66,9 @@ const getCurrentFormats = `
   AND rv."STATUS" = 'CURR';
 `;
 
-exports.getLicence = getLicence;
-exports.getCurrentVersion = getCurrentVersion;
-exports.getVersions = getVersions;
-exports.getCurrentFormats = getCurrentFormats;
+module.exports = {
+  getLicence,
+  getCurrentVersion,
+  getVersions,
+  getCurrentFormats
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/parties.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/parties.js
@@ -22,6 +22,8 @@ const getParty = `
   where "ID" = $1 and "FGAC_REGION_CODE" = $2;
 `;
 
-exports.getParties = getParties;
-exports.getPartyContacts = getPartyContacts;
-exports.getParty = getParty;
+module.exports = {
+  getParties,
+  getPartyContacts,
+  getParty
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/purposes.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/purposes.js
@@ -43,7 +43,9 @@ const getPurposePointLicenceConditions = `
   order by "DISP_ORD" asc;
 `;
 
-exports.getPurpose = getPurpose;
-exports.getPurposePoints = getPurposePoints;
-exports.getPurposePointLicenceAgreements = getPurposePointLicenceAgreements;
-exports.getPurposePointLicenceConditions = getPurposePointLicenceConditions;
+module.exports = {
+  getPurpose,
+  getPurposePoints,
+  getPurposePointLicenceAgreements,
+  getPurposePointLicenceConditions
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/returns.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/returns.js
@@ -112,12 +112,14 @@ const getReturnVersionReason = `
   AND rv."FGAC_REGION_CODE" = $3;
 `;
 
-exports.getFormats = getFormats;
-exports.getFormatPurposes = getFormatPurposes;
-exports.getFormatPoints = getFormatPoints;
-exports.getLogs = getLogs;
-exports.getLines = getLines;
-exports.getLogLines = getLogLines;
-exports.isNilReturn = isNilReturn;
-exports.getSplitDate = getSplitDate;
-exports.getReturnVersionReason = getReturnVersionReason;
+module.exports = {
+  getFormats,
+  getFormatPurposes,
+  getFormatPoints,
+  getLogs,
+  getLines,
+  getLogLines,
+  isNilReturn,
+  getSplitDate,
+  getReturnVersionReason
+};

--- a/src/modules/nald-import/lib/nald-queries/sql/roles.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/roles.js
@@ -28,4 +28,6 @@ const getRoles = `
     and (r."EFF_END_DATE" = 'null' or to_date(r."EFF_END_DATE", 'DD/MM/YYYY') > now());
 `;
 
-exports.getRoles = getRoles;
+module.exports = {
+  getRoles
+};

--- a/src/modules/nald-import/lib/persist-returns.js
+++ b/src/modules/nald-import/lib/persist-returns.js
@@ -78,7 +78,9 @@ const persistReturns = async (returns) => {
   }
 };
 
-exports.createOrUpdateReturn = createOrUpdateReturn;
-exports.getUpdateRow = getUpdateRow;
-exports.returnExists = returnExists;
-exports.persistReturns = persistReturns;
+module.exports = {
+  createOrUpdateReturn,
+  getUpdateRow,
+  returnExists,
+  persistReturns
+};

--- a/src/modules/nald-import/lib/transform-returns-helpers.js
+++ b/src/modules/nald-import/lib/transform-returns-helpers.js
@@ -277,13 +277,15 @@ const getFormatCycles = (format, splitDate) => {
  */
 const getStatus = receivedDate => receivedDate === null ? 'due' : 'completed';
 
-exports.mapPeriod = mapPeriod;
-exports.mapProductionMonth = mapProductionMonth;
-exports.formatReturnMetadata = formatReturnMetadata;
-exports.getFormatCycles = getFormatCycles;
-exports.mapReceivedDate = mapReceivedDate;
-exports.getReturnCycles = getReturnCycles;
-exports.addDate = addDate;
-exports.getStatus = getStatus;
-exports.getFormatStartDate = getFormatStartDate;
-exports.getFormatEndDate = getFormatEndDate;
+module.exports = {
+  mapPeriod,
+  mapProductionMonth,
+  formatReturnMetadata,
+  getFormatCycles,
+  mapReceivedDate,
+  getReturnCycles,
+  addDate,
+  getStatus,
+  getFormatStartDate,
+  getFormatEndDate
+};

--- a/src/modules/nald-import/load.js
+++ b/src/modules/nald-import/load.js
@@ -68,4 +68,6 @@ const load = async (licenceNumber) => {
   await chargeVersionMetadataImportService.importChargeVersionMetadataForLicence(licenceData);
 };
 
-exports.load = load;
+module.exports = {
+  load
+};

--- a/src/modules/nald-import/mappers/charge-versions.js
+++ b/src/modules/nald-import/mappers/charge-versions.js
@@ -166,4 +166,6 @@ const mapNALDChargeVersionsToWRLS = (licence, chargeVersions) => {
   return sortBy(arr, ['start_date', 'version_number']);
 };
 
-exports.mapNALDChargeVersionsToWRLS = mapNALDChargeVersionsToWRLS;
+module.exports = {
+  mapNALDChargeVersionsToWRLS
+};

--- a/src/modules/nald-import/plugin.js
+++ b/src/modules/nald-import/plugin.js
@@ -34,8 +34,12 @@ const registerSubscribers = async server => {
   }
 };
 
-exports.plugin = {
+const plugin = {
   name: 'importNaldData',
   dependencies: ['pgBoss'],
   register: registerSubscribers
+};
+
+module.exports = {
+  plugin
 };

--- a/src/modules/nald-import/services/charge-version-metadata-import.js
+++ b/src/modules/nald-import/services/charge-version-metadata-import.js
@@ -80,4 +80,6 @@ const importChargeVersionMetadataForLicence = async licence => {
   }
 };
 
-exports.importChargeVersionMetadataForLicence = importChargeVersionMetadataForLicence;
+module.exports = {
+  importChargeVersionMetadataForLicence
+};

--- a/src/modules/nald-import/services/extract-service.js
+++ b/src/modules/nald-import/services/extract-service.js
@@ -88,5 +88,7 @@ const copyTestFiles = async () => {
   return loadCsvService.importFiles(constants.SCHEMA_IMPORT);
 };
 
-exports.copyTestFiles = copyTestFiles;
-exports.downloadAndExtract = downloadAndExtract;
+module.exports = {
+  copyTestFiles,
+  downloadAndExtract
+};

--- a/src/modules/nald-import/services/load-csv-service.js
+++ b/src/modules/nald-import/services/load-csv-service.js
@@ -134,4 +134,6 @@ async function importFiles (schemaName) {
   }
 }
 
-exports.importFiles = importFiles;
+module.exports = {
+  importFiles
+};

--- a/src/modules/nald-import/services/s3-service.js
+++ b/src/modules/nald-import/services/s3-service.js
@@ -24,5 +24,7 @@ const download = async () => {
   return s3.download(s3Path, localPath);
 };
 
-exports.getEtag = getEtag;
-exports.download = download;
+module.exports = {
+  getEtag,
+  download
+};

--- a/src/modules/nald-import/services/schema-service.js
+++ b/src/modules/nald-import/services/schema-service.js
@@ -22,6 +22,8 @@ const swapTemporarySchema = async () => {
   await renameSchema(constants.SCHEMA_TEMP, constants.SCHEMA_IMPORT);
 };
 
-exports.dropAndCreateSchema = dropAndCreateSchema;
-exports.swapTemporarySchema = swapTemporarySchema;
-exports.renameSchema = renameSchema;
+module.exports = {
+  dropAndCreateSchema,
+  swapTemporarySchema,
+  renameSchema
+};

--- a/src/modules/nald-import/services/zip-service.js
+++ b/src/modules/nald-import/services/zip-service.js
@@ -41,4 +41,6 @@ const extract = async () => {
   }
 };
 
-exports.extract = extract;
+module.exports = {
+  extract
+};

--- a/src/modules/nald-import/transform-crm.js
+++ b/src/modules/nald-import/transform-crm.js
@@ -126,6 +126,8 @@ function buildCRMPacket (licenceData, licenceRef, licenceId) {
   return crmData;
 }
 
-exports.buildCRMPacket = buildCRMPacket;
-exports.buildCRMMetadata = buildCRMMetadata;
-exports.contactsFormatter = contactsFormatter;
+module.exports = {
+  buildCRMPacket,
+  buildCRMMetadata,
+  contactsFormatter
+};

--- a/src/modules/nald-import/transform-permit.js
+++ b/src/modules/nald-import/transform-permit.js
@@ -185,5 +185,7 @@ const buildPermitRepoPacket = (licenceRef, regimeId, licenceTypeId, data) => {
   return permitRepoData;
 };
 
-exports.getLicenceJson = getLicenceJson;
-exports.buildPermitRepoPacket = buildPermitRepoPacket;
+module.exports = {
+  getLicenceJson,
+  buildPermitRepoPacket
+};

--- a/src/modules/nald-import/transform-returns.js
+++ b/src/modules/nald-import/transform-returns.js
@@ -97,6 +97,8 @@ const buildReturnsPacket = async (licenceNumber) => {
   return returnsData;
 };
 
-exports.buildReturnsPacket = buildReturnsPacket;
-exports.getLicenceFormats = getLicenceFormats;
-exports.getCycleLogs = getCycleLogs;
+module.exports = {
+  buildReturnsPacket,
+  getLicenceFormats,
+  getCycleLogs
+};

--- a/src/modules/returns/lib/generate-nil-lines.js
+++ b/src/modules/returns/lib/generate-nil-lines.js
@@ -225,11 +225,13 @@ const generateNilLines = (returnData) => {
   return lines.map(line => mapLine(line, absPeriod));
 };
 
-exports.getDays = getDays;
-exports.getMonths = getMonths;
-exports.getWeeks = getWeeks;
-exports.getRequiredLines = getRequiredLines;
-exports.generateNilLines = generateNilLines;
-exports.isDateWithinAbstractionPeriod = isDateWithinAbstractionPeriod;
-exports.getAbsPeriod = getAbsPeriod;
-exports.mapLine = mapLine;
+module.exports = {
+  getDays,
+  getMonths,
+  getWeeks,
+  getRequiredLines,
+  generateNilLines,
+  isDateWithinAbstractionPeriod,
+  getAbsPeriod,
+  mapLine
+};

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -21,4 +21,6 @@ const createServerForRoute = route => {
   return server;
 };
 
-exports.createServerForRoute = createServerForRoute;
+module.exports = {
+  createServerForRoute
+};


### PR DESCRIPTION
VS Code has a handy feature which lets us jump to a function's implementation by command-clicking it, however this breaks when exports are declared as they currently are. They have to be defined in the more regular way instead.