### PR TITLE
Make licence agreements import configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ REDIS_URI=
 S3_NALD_IMPORT_PATH=
 
 WATER_SERVICE_MAILBOX=
+
+# For development only! See https://eaflood.atlassian.net/browse/WATER-3201
+# Enables import of licence agreements during the licence import process. This was a one time import
+# run in production that we often need to re-run in local and non-production environments
+IMPORT_LICENCE_AGREEMENTS=false

--- a/config.js
+++ b/config.js
@@ -84,7 +84,9 @@ module.exports = {
       // Update: I've changed those values to false ahead of the v2.0 charging
       // release as described in WATER-3201 - TT 20210603
       isInvoiceAccountImportEnabled: true,
-      isLicenceAgreementImportEnabled: false,
+      // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
+      // converting the env var to a boolean
+      isLicenceAgreementImportEnabled: (process.env.IMPORT_LICENCE_AGREEMENTS === 'true') || false,
       // Note: we think a solution is needed where a list of billing contacts
       // for a given licence is calculated from the charge version history
       // in the water service, and synced to CRM v2.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3201

From our investigations, it looks like the import of licence agreements was a 'one-off' process intended to be run just the once when charging went live in WRLS. We have a flag in the config that controls whether they get included when the main licence import takes place.

That is currently hard coded to `false`. The commit history shows it was set to `true`, code was released and shipped, then immediately set to `false`. So, being pedantic, it ain't really config!!

It also turns out that any new developer on the team needs to be able to import the original NALD charge agreements when setting up their local environment. The same is true for any environment where we drop the DB and start again.

We need a way to enable this part of the import that does not require amending the code. This change adds a new env var that if present, will allow us to control whether licence agreements are imported or not.