### PR TITLE
Replace ESLint with StandardJS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# node_modules ignored by default
-coverage
-migrations

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "standard",
-   "rules": {
-        "semi": [2, "always"]
-    }
-}

--- a/config.js
+++ b/config.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-require('dotenv').config();
+require('dotenv').config()
 
-const ENV_LOCAL = 'local';
-const ENV_DEV = 'dev';
-const ENV_QA = 'qa';
-const ENV_TEST = 'test';
-const ENV_PREPROD = 'preprod';
-const ENV_PRODUCTION = 'production';
+const ENV_LOCAL = 'local'
+const ENV_DEV = 'dev'
+const ENV_QA = 'qa'
+const ENV_TEST = 'test'
+const ENV_PREPROD = 'preprod'
+const ENV_PRODUCTION = 'production'
 
-const isAcceptanceTestTarget = [ENV_LOCAL, ENV_DEV, ENV_TEST, ENV_QA, ENV_PREPROD].includes(process.env.NODE_ENV);
-const testMode = parseInt(process.env.TEST_MODE) === 1;
-const isProduction = process.env.NODE_ENV === ENV_PRODUCTION;
-const isLocal = process.env.NODE_ENV === ENV_LOCAL;
-const isTest = process.env.NODE_ENV === ENV_TEST;
+const isAcceptanceTestTarget = [ENV_LOCAL, ENV_DEV, ENV_TEST, ENV_QA, ENV_PREPROD].includes(process.env.NODE_ENV)
+const testMode = parseInt(process.env.TEST_MODE) === 1
+const isProduction = process.env.NODE_ENV === ENV_PRODUCTION
+const isLocal = process.env.NODE_ENV === ENV_LOCAL
+const isTest = process.env.NODE_ENV === ENV_TEST
 
 module.exports = {
 
@@ -116,4 +116,4 @@ module.exports = {
       service_status_alert: 'c34d1b16-694b-4364-8e7e-83e9dbd34a62'
     }
   }
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,30 +1,30 @@
 // provides all API services consumed by VML and VML Admin front ends
-require('dotenv').config();
+require('dotenv').config()
 
 // -------------- Require vendor code -----------------
-const Blipp = require('blipp');
-const Good = require('@hapi/good');
-const GoodWinston = require('good-winston');
+const Blipp = require('blipp')
+const Good = require('@hapi/good')
+const GoodWinston = require('good-winston')
 
-const HapiAuthJwt2 = require('hapi-auth-jwt2');
-const moment = require('moment');
+const HapiAuthJwt2 = require('hapi-auth-jwt2')
+const moment = require('moment')
 
-moment.locale('en-gb');
+moment.locale('en-gb')
 
 // -------------- Shared code --------------------------
-const helpers = require('@envage/water-abstraction-helpers');
+const helpers = require('@envage/water-abstraction-helpers')
 
 // -------------- Require project code -----------------
-const config = require('./config');
-const routes = require('./src/routes.js');
-const db = require('./src/lib/connectors/db');
+const config = require('./config')
+const routes = require('./src/routes.js')
+const db = require('./src/lib/connectors/db')
 
 // Initialise logger
-const { logger } = require('./src/logger');
-const goodWinstonStream = new GoodWinston({ winston: logger });
+const { logger } = require('./src/logger')
+const goodWinstonStream = new GoodWinston({ winston: logger })
 
 // Define server
-const server = require('./server');
+const server = require('./server')
 
 const plugins = [
   {
@@ -55,59 +55,59 @@ const plugins = [
   require('./src/modules/nald-import/plugin'),
   require('./src/modules/bill-runs-import/plugin'),
   require('./src/modules/core/plugin')
-];
+]
 
 const configureServerAuthStrategy = (server) => {
   server.auth.strategy('jwt', 'jwt', {
     ...config.jwt,
     validate: async (decoded) => ({ isValid: !!decoded.id })
-  });
-  server.auth.default('jwt');
-};
+  })
+  server.auth.default('jwt')
+}
 
 const start = async function () {
   try {
-    await server.register(plugins);
-    configureServerAuthStrategy(server);
-    server.route(routes);
+    await server.register(plugins)
+    configureServerAuthStrategy(server)
+    server.route(routes)
 
     if (!module.parent) {
-      await server.start();
-      const name = process.env.SERVICE_NAME;
-      const uri = server.info.uri;
-      server.log('info', `Service ${name} running at: ${uri}`);
+      await server.start()
+      const name = process.env.SERVICE_NAME
+      const uri = server.info.uri
+      server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error(err);
+    logger.error(err)
   }
-};
+}
 
 const processError = message => err => {
-  logger.error(message, err);
-  process.exit(1);
-};
+  logger.error(message, err)
+  process.exit(1)
+}
 
 process
   .on('unhandledRejection', processError('unhandledRejection'))
   .on('uncaughtException', processError('uncaughtException'))
   .on('SIGINT', async () => {
-    logger.info('Stopping import service');
+    logger.info('Stopping import service')
 
-    await server.stop();
-    logger.info('1/3: Hapi server stopped');
+    await server.stop()
+    logger.info('1/3: Hapi server stopped')
 
-    await server.messageQueue.stop();
-    logger.info('2/3: Message queue stopped');
-    logger.info('Waiting 5 secs to allow pg-boss to finish');
+    await server.messageQueue.stop()
+    logger.info('2/3: Message queue stopped')
+    logger.info('Waiting 5 secs to allow pg-boss to finish')
 
     setTimeout(async () => {
-      await db.pool.end();
-      logger.info('3/3: Connection pool closed');
+      await db.pool.end()
+      logger.info('3/3: Connection pool closed')
 
-      return process.exit(0);
-    }, 5000);
-  });
+      return process.exit(0)
+    }, 5000)
+  })
 
-start();
+start()
 
-module.exports = server;
+module.exports = server

--- a/migrations/20190812160211-charging.js
+++ b/migrations/20190812160211-charging.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,12 +8,9 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+function setup (options, _seedLink) {
   Promise = options.Promise
-};
+}
 
 function up (db) {
   const filePath = path.join(__dirname, 'sqls', '20190812160211-charging-up.sql')
@@ -31,7 +25,7 @@ function up (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 function down (db) {
   const filePath = path.join(__dirname, 'sqls', '20190812160211-charging-down.sql')
@@ -46,7 +40,7 @@ function down (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 const _meta = {
   version: 1

--- a/migrations/20190812160211-charging.js
+++ b/migrations/20190812160211-charging.js
@@ -1,60 +1,60 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
+function setup (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
 };
 
-function up(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190812160211-charging-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function up (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190812160211-charging-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
-function down(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190812160211-charging-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function down (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190812160211-charging-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
 const _meta = {
-  "version": 1
-};
+  version: 1
+}
 
 module.exports = {
   setup,
   up,
   down,
   _meta
-};
+}

--- a/migrations/20191115135544-uuid-types.js
+++ b/migrations/20191115135544-uuid-types.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,12 +8,9 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+function setup (options, _seedLink) {
   Promise = options.Promise
-};
+}
 
 function up (db) {
   const filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-up.sql')
@@ -31,7 +25,7 @@ function up (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 function down (db) {
   const filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-down.sql')
@@ -46,7 +40,7 @@ function down (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 const _meta = {
   version: 1

--- a/migrations/20191115135544-uuid-types.js
+++ b/migrations/20191115135544-uuid-types.js
@@ -1,60 +1,60 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
+function setup (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
 };
 
-function up(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function up (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
-function down(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function down (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191115135544-uuid-types-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
 const _meta = {
-  "version": 1
-};
+  version: 1
+}
 
 module.exports = {
   setup,
   up,
   down,
   _meta
-};
+}

--- a/migrations/20191119170656-import-companies-table.js
+++ b/migrations/20191119170656-import-companies-table.js
@@ -1,60 +1,60 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
+function setup (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
 };
 
-function up(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function up (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
-function down(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function down (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
 const _meta = {
-  "version": 1
-};
+  version: 1
+}
 
 module.exports = {
   setup,
   up,
   down,
   _meta
-};
+}

--- a/migrations/20191119170656-import-companies-table.js
+++ b/migrations/20191119170656-import-companies-table.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,12 +8,9 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+function setup (options, _seedLink) {
   Promise = options.Promise
-};
+}
 
 function up (db) {
   const filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-up.sql')
@@ -31,7 +25,7 @@ function up (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 function down (db) {
   const filePath = path.join(__dirname, 'sqls', '20191119170656-import-companies-table-down.sql')
@@ -46,7 +40,7 @@ function down (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 const _meta = {
   version: 1

--- a/migrations/20201109161649-drop-charge-version-import-tables.js
+++ b/migrations/20201109161649-drop-charge-version-import-tables.js
@@ -1,60 +1,60 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
+function setup (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
 };
 
-function up(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function up (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
-function down(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function down (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
 const _meta = {
-  "version": 1
-};
+  version: 1
+}
 
 module.exports = {
   setup,
   up,
   down,
   _meta
-};
+}

--- a/migrations/20201109161649-drop-charge-version-import-tables.js
+++ b/migrations/20201109161649-drop-charge-version-import-tables.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,12 +8,9 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+function setup (options, _seedLink) {
   Promise = options.Promise
-};
+}
 
 function up (db) {
   const filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-up.sql')
@@ -31,7 +25,7 @@ function up (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 function down (db) {
   const filePath = path.join(__dirname, 'sqls', '20201109161649-drop-charge-version-import-tables-down.sql')
@@ -46,7 +40,7 @@ function down (db) {
     .then(function (data) {
       return db.runSql(data)
     })
-};
+}
 
 const _meta = {
   version: 1

--- a/migrations/20201120135927-create-charge-versions-metadata-table.js
+++ b/migrations/20201120135927-create-charge-versions-metadata-table.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+function setup (options, _seedLink) {
   Promise = options.Promise
 };
 

--- a/migrations/20201120135927-create-charge-versions-metadata-table.js
+++ b/migrations/20201120135927-create-charge-versions-metadata-table.js
@@ -1,60 +1,60 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-function setup(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
+function setup (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
 };
 
-function up(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function up (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
-function down(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+function down (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201120135927-create-charge-versions-metadata-table-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
+    .then(function (data) {
+      return db.runSql(data)
+    })
 };
 
 const _meta = {
-  "version": 1
-};
+  version: 1
+}
 
 module.exports = {
   setup,
   up,
   down,
   _meta
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,13 +47,8 @@
         "auto-changelog": "^1.16.4",
         "codecov": "^3.7.1",
         "db-migrate-pg": "^1.2.2",
-        "eslint": "^6.8.0",
-        "eslint-config-standard": "^14.1.1",
-        "eslint-plugin-import": "^2.21.2",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^4.2.1",
-        "eslint-plugin-standard": "^4.0.1",
-        "sinon": "^9.0.2"
+        "sinon": "^9.0.2",
+        "standard": "^17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -899,6 +894,115 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@hapi/accept": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
@@ -1701,6 +1805,26 @@
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "deprecated": "This version has been deprecated and is no longer supported or maintained"
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1822,7 +1946,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -1965,14 +2089,14 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -2012,6 +2136,24 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2373,6 +2515,48 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3159,18 +3343,29 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -3182,9 +3377,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3373,19 +3569,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=6.2.2",
-        "eslint-plugin-import": ">=2.18.0",
-        "eslint-plugin-node": ">=9.1.0",
-        "eslint-plugin-promise": ">=4.2.1",
-        "eslint-plugin-standard": ">=4.0.0"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -3428,9 +3611,9 @@
       }
     },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^2.0.0",
@@ -3524,83 +3707,73 @@
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": ">=5.16.0"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
+        "esutils": "^2.0.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -4094,7 +4267,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4231,10 +4404,37 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -4245,17 +4445,29 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4398,6 +4610,12 @@
         "moment": "^2.18.1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4487,9 +4705,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4911,6 +5129,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -4957,9 +5181,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5273,6 +5497,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -5348,6 +5578,19 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
+      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -5393,10 +5636,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/load-json-file/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5462,6 +5730,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -5472,6 +5746,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -5802,6 +6088,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -5881,9 +6176,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5922,6 +6217,50 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6025,7 +6364,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6045,7 +6384,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6117,6 +6456,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -6133,7 +6485,7 @@
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6346,6 +6698,80 @@
         "node": ">=6"
       }
     },
+    "node_modules/pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -6423,6 +6849,17 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/proxy-agent": {
@@ -6553,6 +6990,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -6623,6 +7066,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -7405,10 +7865,638 @@
         "node": "*"
       }
     },
+    "node_modules/standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      },
+      "bin": {
+        "standard": "bin/cmd.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
+    "node_modules/standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/standard/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/standard/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/standard/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/standard/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/standard/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/standard/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/standard/node_modules/eslint": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+      "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.2",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-config-standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.8.0",
+        "eslint-plugin-react": "^7.28.0"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-plugin-n": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.3.tgz",
+      "integrity": "sha512-H+KC7U5R+3IWTeRnACm/4wlqLvS1Q7M6t7BGhn89qXDkZan8HTAEv3ouIONA0ifDwc2YzPFmyPzHuNLddNK4jw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.10.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-plugin-promise": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
+      "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/standard/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/standard/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/standard/node_modules/flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "dev": true
+    },
+    "node_modules/standard/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/standard/node_modules/globals": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/standard/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/standard/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/standard/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/standard/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/standard/node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/standard/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/standard/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/standard/node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/standard/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/standard/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/standard/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/standard/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/standard/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/standard/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/standard/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/standard/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/standard/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -7565,27 +8653,48 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7613,7 +8722,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8014,14 +9123,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -8375,6 +9484,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xml2js": {
@@ -9211,6 +10329,84 @@
         }
       }
     },
+    "@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "dev": true
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "espree": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+          "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.7.1",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "globals": {
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
     "@hapi/accept": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
@@ -9985,6 +11181,23 @@
         }
       }
     },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -10091,7 +11304,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -10192,14 +11405,14 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -10224,6 +11437,18 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10508,6 +11733,41 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -11120,18 +12380,29 @@
         "once": "^1.4.0"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -11143,9 +12414,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -11313,13 +12585,6 @@
         }
       }
     },
-    "eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-      "dev": true,
-      "requires": {}
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -11363,9 +12628,9 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -11431,54 +12696,60 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
       },
       "dependencies": {
-        "eslint-utils": {
+        "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "esutils": "^2.0.2"
           }
         },
-        "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
         }
       }
-    },
-    "eslint-plugin-promise": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
-      "dev": true
-    },
-    "eslint-plugin-standard": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true,
-      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -11854,7 +13125,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -11955,10 +13226,28 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -11966,15 +13255,21 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -12093,6 +13388,12 @@
         "moment": "^2.18.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -12160,9 +13461,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -12489,6 +13790,12 @@
         "kind-of": "^6.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -12520,9 +13827,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -12740,6 +14047,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -12804,6 +14117,16 @@
         "verror": "1.10.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
+      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
+      }
+    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -12843,10 +14166,31 @@
         "type-check": "~0.3.2"
       }
     },
+    "load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -12909,6 +14253,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -12919,6 +14269,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lower-case": {
       "version": "2.0.2",
@@ -13173,6 +14532,12 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -13235,9 +14600,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -13264,6 +14629,38 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "object.pick": {
@@ -13337,7 +14734,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -13351,7 +14748,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "pac-proxy-agent": {
@@ -13408,6 +14805,16 @@
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
       "dev": true
     },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -13421,7 +14828,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
@@ -13586,6 +14993,61 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -13639,6 +15101,17 @@
         "read": "1.0.x",
         "revalidator": "0.1.x",
         "winston": "2.x"
+      }
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "proxy-agent": {
@@ -13735,6 +15208,12 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13795,6 +15274,17 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -14381,10 +15871,414 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
+    "standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "requires": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint": {
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+          "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
+          "dev": true,
+          "requires": {
+            "@eslint/eslintrc": "^1.3.0",
+            "@humanwhocodes/config-array": "^0.9.2",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.3.2",
+            "doctrine": "^3.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^7.1.1",
+            "eslint-utils": "^3.0.0",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.2",
+            "esquery": "^1.4.0",
+            "esutils": "^2.0.2",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^6.0.1",
+            "globals": "^13.15.0",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^4.1.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
+            "minimatch": "^3.1.2",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.1",
+            "regexpp": "^3.2.0",
+            "strip-ansi": "^6.0.1",
+            "strip-json-comments": "^3.1.0",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-config-standard": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+          "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+          "dev": true,
+          "requires": {}
+        },
+        "eslint-config-standard-jsx": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+          "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "eslint-plugin-n": {
+          "version": "15.2.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.3.tgz",
+          "integrity": "sha512-H+KC7U5R+3IWTeRnACm/4wlqLvS1Q7M6t7BGhn89qXDkZan8HTAEv3ouIONA0ifDwc2YzPFmyPzHuNLddNK4jw==",
+          "dev": true,
+          "requires": {
+            "builtins": "^5.0.1",
+            "eslint-plugin-es": "^4.1.0",
+            "eslint-utils": "^3.0.0",
+            "ignore": "^5.1.1",
+            "is-core-module": "^2.9.0",
+            "minimatch": "^3.1.2",
+            "resolve": "^1.10.1",
+            "semver": "^7.3.7"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
+          "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+          "dev": true,
+          "requires": {}
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+              "dev": true
+            }
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "espree": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+          "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.7.1",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+          "dev": true,
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+          "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "globals": {
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+          "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
+    "standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -14515,24 +16409,42 @@
         }
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -14553,7 +16465,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -14868,14 +16780,14 @@
       "optional": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -15181,6 +17093,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "DATABASE_URL=postgres://water_user:password@localhost:5432/permits lab",
     "test:bail": "DATABASE_URL=postgres://water_user:password@localhost:5432/permits lab --bail",
     "test:ci": "lab -t 55 -m 0 -r lcov -o coverage/lcov.info -r console -o stdout",
-    "lint": "eslint .",
+    "lint": "standard",
+    "lint:fix": "standard --fix",
     "codecov": "codecov",
     "version": "auto-changelog -p --commit-limit false && git add CHANGELOG.md",
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
@@ -25,20 +26,6 @@
     "url": "https://github.com/DEFRA/water-abstraction-import/issues"
   },
   "homepage": "https://github.com/DEFRA/water-abstraction-import#readme",
-  "devDependencies": {
-    "@hapi/code": "^8.0.1",
-    "@hapi/lab": "^22.0.4",
-    "auto-changelog": "^1.16.4",
-    "codecov": "^3.7.1",
-    "db-migrate-pg": "^1.2.2",
-    "eslint": "^6.8.0",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.21.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1",
-    "sinon": "^9.0.2"
-  },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^4.1.2",
     "@envage/water-abstraction-helpers": "4.8.0",
@@ -71,5 +58,14 @@
     "traverse": "^0.6.6",
     "url-join": "^4.0.1",
     "winston": "2.4.4"
+  },
+  "devDependencies": {
+    "@hapi/code": "^8.0.1",
+    "@hapi/lab": "^22.0.4",
+    "auto-changelog": "^1.16.4",
+    "codecov": "^3.7.1",
+    "db-migrate-pg": "^1.2.2",
+    "sinon": "^9.0.2",
+    "standard": "^17.0.0"
   }
 }

--- a/scripts/create-schema.js
+++ b/scripts/create-schema.js
@@ -1,10 +1,10 @@
-require('dotenv').config();
-const { pool } = require('../src/lib/connectors/db');
+require('dotenv').config()
+const { pool } = require('../src/lib/connectors/db')
 
 async function run () {
-  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS water_import;');
-  console.log(error || 'OK');
-  process.exit(error ? 1 : 0);
+  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS water_import;')
+  console.log(error || 'OK')
+  process.exit(error ? 1 : 0)
 }
 
-run();
+run()

--- a/scripts/licence-creator/address.js
+++ b/scripts/licence-creator/address.js
@@ -1,4 +1,4 @@
-const getNextId = require('./next-id');
+const getNextId = require('./next-id')
 
 /**
  * NALD address class for building dummy licences
@@ -6,7 +6,7 @@ const getNextId = require('./next-id');
  */
 class Address {
   constructor () {
-    this.id = getNextId();
+    this.id = getNextId()
   }
 
   export () {
@@ -26,8 +26,8 @@ class Address {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Address;
+module.exports = Address

--- a/scripts/licence-creator/agreement.js
+++ b/scripts/licence-creator/agreement.js
@@ -1,16 +1,16 @@
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
 class Agreement {
   constructor () {
-    this.id = getNextId();
-    this.startDate = '01/01/2018';
-    this.endDate = '01/01/2020';
-    this.purpose = null;
+    this.id = getNextId()
+    this.startDate = '01/01/2018'
+    this.endDate = '01/01/2020'
+    this.purpose = null
   }
 
   setPurpose (purpose) {
-    this.purpose = purpose;
-    return this;
+    this.purpose = purpose
+    return this
   }
 
   export () {
@@ -28,8 +28,8 @@ class Agreement {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Agreement;
+module.exports = Agreement

--- a/scripts/licence-creator/common.js
+++ b/scripts/licence-creator/common.js
@@ -1,26 +1,26 @@
-'use strict';
+'use strict'
 
 const common = {
   FGAC_REGION_CODE: 1,
   SOURCE_CODE: 'NALD',
   BATCH_RUN_DATE: '12/02/2018 20:02:11'
-};
+}
 
 const getCommonObject = (...keys) => {
   return keys.reduce((acc, key) => {
-    acc[key] = common[key];
-    return acc;
-  }, {});
-};
+    acc[key] = common[key]
+    return acc
+  }, {})
+}
 
 const createNullKeys = (...keys) => {
   return keys.reduce((acc, key) => {
-    acc[key] = null;
-    return acc;
-  }, {});
-};
+    acc[key] = null
+    return acc
+  }, {})
+}
 
 module.exports = {
   getCommonObject,
   createNullKeys
-};
+}

--- a/scripts/licence-creator/condition-type.js
+++ b/scripts/licence-creator/condition-type.js
@@ -1,10 +1,10 @@
 
 class ConditionType {
   constructor () {
-    this.code = 'CES';
-    this.subCode = 'FLOW';
-    this.description = 'Cessation Condition';
-    this.subCodeDescription = 'Flow';
+    this.code = 'CES'
+    this.subCode = 'FLOW'
+    this.description = 'Cessation Condition'
+    this.subCodeDescription = 'Flow'
   }
 
   export () {
@@ -18,8 +18,8 @@ class ConditionType {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = ConditionType;
+module.exports = ConditionType

--- a/scripts/licence-creator/condition.js
+++ b/scripts/licence-creator/condition.js
@@ -1,24 +1,24 @@
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
 class Condition {
   constructor () {
-    this.id = getNextId();
+    this.id = getNextId()
 
-    this.purpose = null;
-    this.param1 = 'AUTHOR';
-    this.param2 = 17.5;
+    this.purpose = null
+    this.param1 = 'AUTHOR'
+    this.param2 = 17.5
 
-    this.type = null;
+    this.type = null
   }
 
   setType (conditionType) {
-    this.type = conditionType;
-    return this;
+    this.type = conditionType
+    return this
   }
 
   setPurpose (purpose) {
-    this.purpose = purpose;
-    return this;
+    this.purpose = purpose
+    return this
   }
 
   export () {
@@ -35,8 +35,8 @@ class Condition {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Condition;
+module.exports = Condition

--- a/scripts/licence-creator/contact-no-type.js
+++ b/scripts/licence-creator/contact-no-type.js
@@ -1,7 +1,7 @@
 class ContactNotype {
   constructor () {
-    this.code = 'WP';
-    this.description = 'Work Phone';
+    this.code = 'WP'
+    this.description = 'Work Phone'
   }
 
   export () {
@@ -12,8 +12,8 @@ class ContactNotype {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:32'
-    };
+    }
   }
 }
 
-module.exports = ContactNotype;
+module.exports = ContactNotype

--- a/scripts/licence-creator/contact-no.js
+++ b/scripts/licence-creator/contact-no.js
@@ -4,24 +4,24 @@
  */
 class ContactNo {
   constructor () {
-    this.party = null;
-    this.address = null;
-    this.contactNoType = null;
+    this.party = null
+    this.address = null
+    this.contactNoType = null
   }
 
   setContactNoType (contactNoType) {
-    this.contactNoType = contactNoType;
-    return this;
+    this.contactNoType = contactNoType
+    return this
   }
 
   setParty (party) {
-    this.party = party;
-    return this;
+    this.party = party
+    return this
   }
 
   setAddress (address) {
-    this.address = address;
-    return this;
+    this.address = address
+    return this
   }
 
   export () {
@@ -34,8 +34,8 @@ class ContactNo {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = ContactNo;
+module.exports = ContactNo

--- a/scripts/licence-creator/contact.js
+++ b/scripts/licence-creator/contact.js
@@ -1,17 +1,17 @@
 class Contact {
   constructor () {
-    this.party = null;
-    this.address = null;
+    this.party = null
+    this.address = null
   }
 
   setParty (party) {
-    this.party = party;
-    return this;
+    this.party = party
+    return this
   }
 
   setAddress (address) {
-    this.address = address;
-    return this;
+    this.address = address
+    return this
   }
 
   export () {
@@ -22,8 +22,8 @@ class Contact {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Contact;
+module.exports = Contact

--- a/scripts/licence-creator/index.js
+++ b/scripts/licence-creator/index.js
@@ -1,137 +1,137 @@
-'use strict';
+'use strict'
 
-const fs = require('fs');
-const Promise = require('bluebird');
-const csvStringify = require('csv-stringify/lib/sync');
-const writeFile = Promise.promisify(fs.writeFile);
-const deepMap = require('deep-map');
-const { mkdirsSync } = require('mkdir');
+const fs = require('fs')
+const Promise = require('bluebird')
+const csvStringify = require('csv-stringify/lib/sync')
+const writeFile = Promise.promisify(fs.writeFile)
+const deepMap = require('deep-map')
+const { mkdirsSync } = require('mkdir')
 
 // Licence classes
-const Licence = require('./licence');
-const Version = require('./version');
+const Licence = require('./licence')
+const Version = require('./version')
 
-const Address = require('./address');
-const Agreement = require('./agreement');
-const Condition = require('./condition');
-const ConditionType = require('./condition-type');
-const Contact = require('./contact');
-const ContactNo = require('./contact-no');
-const ContactNoType = require('./contact-no-type');
-const MeansOfAbstraction = require('./means-of-abstraction');
-const Party = require('./party');
-const Point = require('./point');
-const Purpose = require('./purpose');
-const PurposePrimary = require('./purpose-primary');
-const PurposeSecondary = require('./purpose-secondary');
-const PurposeTertiary = require('./purpose-tertiary');
+const Address = require('./address')
+const Agreement = require('./agreement')
+const Condition = require('./condition')
+const ConditionType = require('./condition-type')
+const Contact = require('./contact')
+const ContactNo = require('./contact-no')
+const ContactNoType = require('./contact-no-type')
+const MeansOfAbstraction = require('./means-of-abstraction')
+const Party = require('./party')
+const Point = require('./point')
+const Purpose = require('./purpose')
+const PurposePrimary = require('./purpose-primary')
+const PurposeSecondary = require('./purpose-secondary')
+const PurposeTertiary = require('./purpose-tertiary')
 
-const PurposePoint = require('./purpose-point');
-const Role = require('./role');
-const RoleType = require('./role-type');
-const Source = require('./source');
-const WALicenceType = require('./wa-licence-type');
+const PurposePoint = require('./purpose-point')
+const Role = require('./role')
+const RoleType = require('./role-type')
+const Source = require('./source')
+const WALicenceType = require('./wa-licence-type')
 
-const ReturnVersion = require('./return-version');
-const ReturnFormat = require('./return-format');
-const ReturnFormatPoint = require('./return-format-point');
-const ReturnFormatPurpose = require('./return-format-purpose');
+const ReturnVersion = require('./return-version')
+const ReturnFormat = require('./return-format')
+const ReturnFormatPoint = require('./return-format-point')
+const ReturnFormatPurpose = require('./return-format-purpose')
 
 // Construct licence
-const l = new Licence('12/34/56/78');
+const l = new Licence('12/34/56/78')
 
-const type = new WALicenceType('TEST', 'Test licence type');
+const type = new WALicenceType('TEST', 'Test licence type')
 
-const version = new Version();
-version.setLicence(this);
-version.setWALicenceType(type);
-l.addVersion(version);
+const version = new Version()
+version.setLicence(this)
+version.setWALicenceType(type)
+l.addVersion(version)
 
 // Add party to version
-const party = new Party();
-version.setParty(party);
+const party = new Party()
+version.setParty(party)
 
 // Add contact to party
-const contact = new Contact();
-contact.setParty(party);
-party.addContact(contact);
+const contact = new Contact()
+contact.setParty(party)
+party.addContact(contact)
 
 // Add address to contact
-const address = new Address();
-contact.setAddress(address);
-version.setAddress(address);
+const address = new Address()
+contact.setAddress(address)
+version.setAddress(address)
 
 // Add role
-const role = new Role();
-const roleType = new RoleType();
-role.setRoleType(roleType);
+const role = new Role()
+const roleType = new RoleType()
+role.setRoleType(roleType)
 
-l.addRole(role);
+l.addRole(role)
 
 // role.setLicence(this);
-role.setParty(party);
-role.setAddress(address);
+role.setParty(party)
+role.setAddress(address)
 
 // Add contact no to role
-const contactNo = new ContactNo();
-const contactNoType = new ContactNoType();
-contactNo.setParty(party);
-contactNo.setAddress(address);
-contactNo.setContactNoType(contactNoType);
-role.addContactNo(contactNo);
+const contactNo = new ContactNo()
+const contactNoType = new ContactNoType()
+contactNo.setParty(party)
+contactNo.setAddress(address)
+contactNo.setContactNoType(contactNoType)
+role.addContactNo(contactNo)
 
 // Add purpose
-const purpose = new Purpose();
+const purpose = new Purpose()
 
-const primary = new PurposePrimary();
-purpose.setPrimaryPurpose(primary);
+const primary = new PurposePrimary()
+purpose.setPrimaryPurpose(primary)
 
-const secondary = new PurposeSecondary();
-purpose.setSecondaryPurpose(secondary);
+const secondary = new PurposeSecondary()
+purpose.setSecondaryPurpose(secondary)
 
-const tertiary = new PurposeTertiary();
-purpose.setTertiaryPurpose(tertiary);
+const tertiary = new PurposeTertiary()
+purpose.setTertiaryPurpose(tertiary)
 
-purpose.setLicence(l);
-version.addPurpose(purpose);
+purpose.setLicence(l)
+version.addPurpose(purpose)
 
 // Add condition
-const cond1 = new Condition();
-const conditionType = new ConditionType();
-cond1.setType(conditionType);
-purpose.addCondition(cond1);
+const cond1 = new Condition()
+const conditionType = new ConditionType()
+cond1.setType(conditionType)
+purpose.addCondition(cond1)
 
 // Add agreement
-const aggreement = new Agreement();
-purpose.addAggreement(aggreement);
+const aggreement = new Agreement()
+purpose.addAggreement(aggreement)
 
 // Add point
-const point = new Point();
-const source = new Source();
-point.setSource(source);
+const point = new Point()
+const source = new Source()
+point.setSource(source)
 
 // Add purpose points
-const pp = new PurposePoint();
-const means = new MeansOfAbstraction('UNP', 'Unspecified Pump');
-pp.setMeansOfAbstraction(means);
-pp.setPoint(point);
-purpose.addPurposePoint(pp);
+const pp = new PurposePoint()
+const means = new MeansOfAbstraction('UNP', 'Unspecified Pump')
+pp.setMeansOfAbstraction(means)
+pp.setPoint(point)
+purpose.addPurposePoint(pp)
 
 // Return version
-const rv = new ReturnVersion();
-l.addReturnVersion(rv);
+const rv = new ReturnVersion()
+l.addReturnVersion(rv)
 
 // Create format
-const format = new ReturnFormat();
-format.setLicence(l);
-rv.addFormat(format);
+const format = new ReturnFormat()
+format.setLicence(l)
+rv.addFormat(format)
 
-const fp = new ReturnFormatPoint();
-fp.setPoint(point);
-format.addPoint(fp);
+const fp = new ReturnFormatPoint()
+fp.setPoint(point)
+format.addPoint(fp)
 
-const fpu = new ReturnFormatPurpose();
-format.addPurpose(fpu);
+const fpu = new ReturnFormatPurpose()
+format.addPurpose(fpu)
 
 /**
  * Export data as CSV files
@@ -140,28 +140,28 @@ format.addPurpose(fpu);
  * @return {Promise} resolves when CSV files written
  */
 function writeCsv (outputPath, exportData) {
-  const keys = Object.keys(exportData);
+  const keys = Object.keys(exportData)
   return Promise.map(keys, (tableName) => {
     // Convert JS null to 'null' string as in CSV data
     const data = deepMap(exportData[tableName], (value) => {
-      return value === null ? 'null' : value;
-    });
-    console.log(`Exporting ${tableName}`);
-    const columns = Object.keys(data[0]);
-    const csv = csvStringify(data, { columns, header: true, quoted: false, quotedEmpty: false, quotedString: false });
-    return writeFile(`${outputPath}${tableName}.txt`, csv);
-  });
+      return value === null ? 'null' : value
+    })
+    console.log(`Exporting ${tableName}`)
+    const columns = Object.keys(data[0])
+    const csv = csvStringify(data, { columns, header: true, quoted: false, quotedEmpty: false, quotedString: false })
+    return writeFile(`${outputPath}${tableName}.txt`, csv)
+  })
 }
 
 function dumpCsv () {
-  const outputPath = './test/dummy-csv/';
-  mkdirsSync(outputPath);
-  const data = l.exportAll();
-  return writeCsv(outputPath, data);
+  const outputPath = './test/dummy-csv/'
+  mkdirsSync(outputPath)
+  const data = l.exportAll()
+  return writeCsv(outputPath, data)
 }
 
-module.exports = dumpCsv;
+module.exports = dumpCsv
 
 if (!module.parent) {
-  dumpCsv();
+  dumpCsv()
 }

--- a/scripts/licence-creator/licence.js
+++ b/scripts/licence-creator/licence.js
@@ -1,6 +1,6 @@
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
-const RepUnit = require('./rep-unit');
+const RepUnit = require('./rep-unit')
 
 /**
  * NALD licence class for building dummy licences
@@ -8,175 +8,175 @@ const RepUnit = require('./rep-unit');
  */
 class Licence {
   constructor (licenceNumber) {
-    this.id = getNextId();
-    this.licenceNumber = licenceNumber;
-    this.startDate = '01/01/2018';
-    this.expiryDate = '01/01/2220';
+    this.id = getNextId()
+    this.licenceNumber = licenceNumber
+    this.startDate = '01/01/2018'
+    this.expiryDate = '01/01/2220'
 
-    this.versions = [];
-    this.repUnit = new RepUnit();
-    this.roles = [];
+    this.versions = []
+    this.repUnit = new RepUnit()
+    this.roles = []
 
-    this.returnVersions = [];
+    this.returnVersions = []
   }
 
   addVersion (version) {
-    this.versions.push(version);
-    version.setLicence(this);
-    return this;
+    this.versions.push(version)
+    version.setLicence(this)
+    return this
   }
 
   setStartDate (date) {
-    this.startDate = date;
+    this.startDate = date
   }
 
   setExpiryDate (date) {
-    this.expiryDate = date;
+    this.expiryDate = date
   }
 
   addRole (role) {
-    this.roles.push(role);
-    role.setLicence(this);
-    return this;
+    this.roles.push(role)
+    role.setLicence(this)
+    return this
   }
 
   addReturnVersion (returnVersion) {
-    returnVersion.setLicence(this);
-    this.returnVersions.push(returnVersion);
-    return this;
+    returnVersion.setLicence(this)
+    this.returnVersions.push(returnVersion)
+    return this
   }
 
   exportAll () {
-    const NALD_ABS_LIC_VERSIONS = this.versions.map(version => version.export());
+    const NALD_ABS_LIC_VERSIONS = this.versions.map(version => version.export())
 
-    const NALD_WA_LIC_TYPES = this.versions.map(version => version.waLicenceType.export());
+    const NALD_WA_LIC_TYPES = this.versions.map(version => version.waLicenceType.export())
 
     // Parties
-    const NALD_PARTIES = this.versions.map(version => version.party.export());
+    const NALD_PARTIES = this.versions.map(version => version.party.export())
 
     // Contacts
     const NALD_CONTACTS = this.versions.reduce((memo, version) => {
-      return [...memo, ...version.party.contacts.map(contact => contact.export())];
-    }, []);
+      return [...memo, ...version.party.contacts.map(contact => contact.export())]
+    }, [])
 
     // Addresses
     const NALD_ADDRESSES = this.versions.reduce((memo, version) => {
-      memo = [...memo, ...version.party.contacts.map(contact => contact.address.export())];
-      return memo;
-    }, []);
+      memo = [...memo, ...version.party.contacts.map(contact => contact.address.export())]
+      return memo
+    }, [])
 
     // Rep unit
-    const NALD_REP_UNITS = [this.repUnit.export()];
+    const NALD_REP_UNITS = [this.repUnit.export()]
 
     // Roles
-    const NALD_LIC_ROLES = this.roles.map(role => role.export());
+    const NALD_LIC_ROLES = this.roles.map(role => role.export())
 
     // Role types
-    const NALD_LIC_ROLE_TYPES = this.roles.map(role => role.roleType.export());
+    const NALD_LIC_ROLE_TYPES = this.roles.map(role => role.roleType.export())
 
     // Contact Nos
     const NALD_CONT_NOS = this.roles.reduce((memo, role) => {
-      return [...memo, ...role.contactNos.map(contactNo => contactNo.export())];
-    }, []);
+      return [...memo, ...role.contactNos.map(contactNo => contactNo.export())]
+    }, [])
 
     // Contact no types
     const NALD_CONT_NO_TYPES = this.roles.reduce((memo, role) => {
-      return [...memo, ...role.contactNos.map(contactNo => contactNo.contactNoType.export())];
-    }, []);
+      return [...memo, ...role.contactNos.map(contactNo => contactNo.contactNoType.export())]
+    }, [])
 
     // Purposes
     const NALD_ABS_LIC_PURPOSES = this.versions.reduce((memo, version) => {
-      return [...memo, ...version.purposes.map(purpose => purpose.export())];
-    }, []);
+      return [...memo, ...version.purposes.map(purpose => purpose.export())]
+    }, [])
 
     // Primary purposes
     const NALD_PURP_PRIMS = this.versions.reduce((memo, version) => {
-      return [...memo, ...version.purposes.map(purpose => purpose.primary.export())];
-    }, []);
+      return [...memo, ...version.purposes.map(purpose => purpose.primary.export())]
+    }, [])
 
     // Secondary purposes
     const NALD_PURP_SECS = this.versions.reduce((memo, version) => {
-      return [...memo, ...version.purposes.map(purpose => purpose.secondary.export())];
-    }, []);
+      return [...memo, ...version.purposes.map(purpose => purpose.secondary.export())]
+    }, [])
 
     // Tertiary purposes
     const NALD_PURP_USES = this.versions.reduce((memo, version) => {
-      return [...memo, ...version.purposes.map(purpose => purpose.tertiary.export())];
-    }, []);
+      return [...memo, ...version.purposes.map(purpose => purpose.tertiary.export())]
+    }, [])
 
     // Conditions
     const NALD_LIC_CONDITIONS = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.conditions.map(condition => condition.export());
-      }, [])];
-    }, []);
+        return purpose.conditions.map(condition => condition.export())
+      }, [])]
+    }, [])
 
     // Condition type
     const NALD_LIC_COND_TYPES = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.conditions.map(condition => condition.type.export());
-      }, [])];
-    }, []);
+        return purpose.conditions.map(condition => condition.type.export())
+      }, [])]
+    }, [])
 
     // Agreements
     const NALD_LIC_AGRMNTS = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.agreements.map(agreement => agreement.export());
-      }, [])];
-    }, []);
+        return purpose.agreements.map(agreement => agreement.export())
+      }, [])]
+    }, [])
 
     // Purpose points
     const NALD_ABS_PURP_POINTS = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.purposePoints.map(purposePoint => purposePoint.export());
-      }, [])];
-    }, []);
+        return purpose.purposePoints.map(purposePoint => purposePoint.export())
+      }, [])]
+    }, [])
 
     // Means of abs
     const NALD_MEANS_OF_ABS = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.purposePoints.map(purposePoint => purposePoint.means.export());
-      }, [])];
-    }, []);
+        return purpose.purposePoints.map(purposePoint => purposePoint.means.export())
+      }, [])]
+    }, [])
 
     // Points
     const NALD_POINTS = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.purposePoints.map(purposePoint => purposePoint.point.export());
-      }, [])];
-    }, []);
+        return purpose.purposePoints.map(purposePoint => purposePoint.point.export())
+      }, [])]
+    }, [])
 
     // Sources
     const NALD_SOURCES = this.versions.reduce((memo, version) => {
       return [...memo, ...version.purposes.reduce((memo2, purpose) => {
-        return purpose.purposePoints.map(purposePoint => purposePoint.point.source.export());
-      }, [])];
-    }, []);
+        return purpose.purposePoints.map(purposePoint => purposePoint.point.source.export())
+      }, [])]
+    }, [])
 
     // Return version
-    const NALD_RET_VERSIONS = this.returnVersions.map(returnVersion => returnVersion.export());
+    const NALD_RET_VERSIONS = this.returnVersions.map(returnVersion => returnVersion.export())
 
     // Return formats
     const NALD_RET_FORMATS = this.returnVersions.reduce((memo, rv) => {
-      const formats = rv.formats.map(row => row.export());
-      return [...memo, ...formats];
-    }, []);
+      const formats = rv.formats.map(row => row.export())
+      return [...memo, ...formats]
+    }, [])
 
     // Format points
     const NALD_RET_FMT_POINTS = this.returnVersions.reduce((memo, rv) => {
       for (const format of rv.formats) {
-        memo.push(...format.points.map(point => point.export()));
+        memo.push(...format.points.map(point => point.export()))
       }
-      return memo;
-    }, []);
+      return memo
+    }, [])
 
     // Format purposes
     const NALD_RET_FMT_PURPOSES = this.returnVersions.reduce((memo, rv) => {
       for (const format of rv.formats) {
-        memo.push(...format.purposes.map(purpose => purpose.export()));
+        memo.push(...format.purposes.map(purpose => purpose.export()))
       }
-      return memo;
-    }, []);
+      return memo
+    }, [])
 
     return {
       NALD_ABS_LICENCES: [this.export()],
@@ -205,7 +205,7 @@ class Licence {
       NALD_RET_FORMATS,
       NALD_RET_FMT_POINTS,
       NALD_RET_FMT_PURPOSES
-    };
+    }
   }
 
   /**
@@ -236,8 +236,8 @@ class Licence {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   };
 }
 
-module.exports = Licence;
+module.exports = Licence

--- a/scripts/licence-creator/means-of-abstraction.js
+++ b/scripts/licence-creator/means-of-abstraction.js
@@ -1,7 +1,7 @@
 class MeansOfAbstraction {
   constructor (code, description) {
-    this.code = code;
-    this.description = description;
+    this.code = code
+    this.description = description
   }
 
   export () {
@@ -13,8 +13,8 @@ class MeansOfAbstraction {
       NOTES: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = MeansOfAbstraction;
+module.exports = MeansOfAbstraction

--- a/scripts/licence-creator/next-id.js
+++ b/scripts/licence-creator/next-id.js
@@ -1,8 +1,8 @@
-let idCounter = 1000000000;
+let idCounter = 1000000000
 
 function getNextId () {
-  idCounter++;
-  return idCounter;
+  idCounter++
+  return idCounter
 }
 
-module.exports = getNextId;
+module.exports = getNextId

--- a/scripts/licence-creator/party.js
+++ b/scripts/licence-creator/party.js
@@ -1,20 +1,20 @@
-const moment = require('moment');
-const getNextId = require('./next-id');
+const moment = require('moment')
+const getNextId = require('./next-id')
 
 class Party {
   constructor () {
-    this.id = getNextId();
-    this.isOrg = false;
-    this.name = 'Doe';
-    this.foreName = 'John';
-    this.initials = 'H';
-    this.salutation = 'Mr';
-    this.contacts = [];
+    this.id = getNextId()
+    this.isOrg = false
+    this.name = 'Doe'
+    this.foreName = 'John'
+    this.initials = 'H'
+    this.salutation = 'Mr'
+    this.contacts = []
   }
 
   addContact (contact) {
-    this.contacts.push(contact);
-    return this;
+    this.contacts.push(contact)
+    return this
   }
 
   export () {
@@ -37,8 +37,8 @@ class Party {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Party;
+module.exports = Party

--- a/scripts/licence-creator/point.js
+++ b/scripts/licence-creator/point.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const common = require('./common');
+const common = require('./common')
 
 const gridRef = (index, sheet = null, east = null, north = null, cartEast = null, cartNorth = null) => ({
   [`NGR${index}_SHEET`]: sheet,
@@ -8,20 +8,20 @@ const gridRef = (index, sheet = null, east = null, north = null, cartEast = null
   [`NGR${index}_NORTH`]: north,
   [`CART${index}_EAST`]: cartEast,
   [`CART${index}_NORTH`]: cartNorth
-});
+})
 
-const getHydro = () => common.createNullKeys('HYDRO_REF', 'HYDRO_INTERCEPT_DIST', 'HYDRO_GW_OFFSET_DIST');
+const getHydro = () => common.createNullKeys('HYDRO_REF', 'HYDRO_INTERCEPT_DIST', 'HYDRO_GW_OFFSET_DIST')
 
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
 class Point {
   constructor () {
-    this.id = getNextId();
-    this.source = null;
+    this.id = getNextId()
+    this.source = null
   }
 
   setSource (source) {
-    this.source = source;
+    this.source = source
   }
 
   export () {
@@ -41,8 +41,8 @@ class Point {
       ...common.createNullKeys('WRB_NO', 'BGS_NO', 'REG_WELL_INDEX_REF', 'NOTES'),
       ...getHydro(),
       ...common.getCommonObject('FGAC_REGION_CODE', 'SOURCE_CODE', 'BATCH_RUN_DATE')
-    };
+    }
   }
 }
 
-module.exports = Point;
+module.exports = Point

--- a/scripts/licence-creator/purpose-point.js
+++ b/scripts/licence-creator/purpose-point.js
@@ -1,23 +1,23 @@
 class PurposePoint {
   constructor () {
-    this.purpose = null;
-    this.point = null;
-    this.means = null;
+    this.purpose = null
+    this.point = null
+    this.means = null
   }
 
   setPurpose (purpose) {
-    this.purpose = purpose;
-    return this;
+    this.purpose = purpose
+    return this
   }
 
   setPoint (point) {
-    this.point = point;
-    return this;
+    this.point = point
+    return this
   }
 
   setMeansOfAbstraction (means) {
-    this.means = means;
-    return this;
+    this.means = means
+    return this
   }
 
   export () {
@@ -29,8 +29,8 @@ class PurposePoint {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = PurposePoint;
+module.exports = PurposePoint

--- a/scripts/licence-creator/purpose-primary.js
+++ b/scripts/licence-creator/purpose-primary.js
@@ -1,7 +1,7 @@
 class PurposePrimary {
   constructor () {
-    this.code = 'A';
-    this.description = 'Agriculture';
+    this.code = 'A'
+    this.description = 'Agriculture'
   }
 
   export () {
@@ -12,8 +12,8 @@ class PurposePrimary {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:05:59'
-    };
+    }
   }
 }
 
-module.exports = PurposePrimary;
+module.exports = PurposePrimary

--- a/scripts/licence-creator/purpose-secondary.js
+++ b/scripts/licence-creator/purpose-secondary.js
@@ -1,7 +1,7 @@
 class PurposeSecondary {
   constructor () {
-    this.code = 'AGR';
-    this.description = 'General Agriculture';
+    this.code = 'AGR'
+    this.description = 'General Agriculture'
   }
 
   export () {
@@ -12,8 +12,8 @@ class PurposeSecondary {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:05:59'
-    };
+    }
   }
 }
 
-module.exports = PurposeSecondary;
+module.exports = PurposeSecondary

--- a/scripts/licence-creator/purpose-tertiary.js
+++ b/scripts/licence-creator/purpose-tertiary.js
@@ -1,7 +1,7 @@
 class PurposeTertiary {
   constructor () {
-    this.code = '140';
-    this.description = 'General Farming & Domestic';
+    this.code = '140'
+    this.description = 'General Farming & Domestic'
   }
 
   export () {
@@ -13,8 +13,8 @@ class PurposeTertiary {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:05:59'
-    };
+    }
   }
 }
 
-module.exports = PurposeTertiary;
+module.exports = PurposeTertiary

--- a/scripts/licence-creator/purpose.js
+++ b/scripts/licence-creator/purpose.js
@@ -1,69 +1,69 @@
-'use strict';
+'use strict'
 
-const getNextId = require('./next-id.js');
-const common = require('./common');
+const getNextId = require('./next-id.js')
+const common = require('./common')
 
 class Purpose {
   constructor () {
-    this.id = getNextId();
+    this.id = getNextId()
 
-    this.licence = null;
+    this.licence = null
 
-    this.primary = null;
-    this.secondary = null;
-    this.tertiary = null;
+    this.primary = null
+    this.secondary = null
+    this.tertiary = null
 
-    this.periodStartDay = 1;
-    this.periodStartMonth = 3;
-    this.periodEndDay = 30;
-    this.periodEndMonth = 9;
+    this.periodStartDay = 1
+    this.periodStartMonth = 3
+    this.periodEndDay = 30
+    this.periodEndMonth = 9
 
-    this.annualQty = 105000;
-    this.dailyQty = 15.2;
-    this.hourlyQty = 3.5;
-    this.instantQty = 0.15;
+    this.annualQty = 105000
+    this.dailyQty = 15.2
+    this.hourlyQty = 3.5
+    this.instantQty = 0.15
 
-    this.conditions = [];
-    this.agreements = [];
-    this.purposePoints = [];
+    this.conditions = []
+    this.agreements = []
+    this.purposePoints = []
   }
 
   setLicence (licence) {
-    this.licence = licence;
-    return this;
+    this.licence = licence
+    return this
   }
 
   setPrimaryPurpose (primaryPurpose) {
-    this.primary = primaryPurpose;
-    return this;
+    this.primary = primaryPurpose
+    return this
   }
 
   setSecondaryPurpose (secondaryPurpose) {
-    this.secondary = secondaryPurpose;
-    return this;
+    this.secondary = secondaryPurpose
+    return this
   }
 
   setTertiaryPurpose (tertiaryPurpose) {
-    this.tertiary = tertiaryPurpose;
-    return this;
+    this.tertiary = tertiaryPurpose
+    return this
   }
 
   addCondition (condition) {
-    this.conditions.push(condition);
-    condition.setPurpose(this);
-    return this;
+    this.conditions.push(condition)
+    condition.setPurpose(this)
+    return this
   }
 
   addAggreement (agreement) {
-    this.agreements.push(agreement);
-    agreement.setPurpose(this);
-    return this;
+    this.agreements.push(agreement)
+    agreement.setPurpose(this)
+    return this
   }
 
   addPurposePoint (purposePoint) {
-    this.purposePoints.push(purposePoint);
-    purposePoint.setPurpose(this);
-    return this;
+    this.purposePoints.push(purposePoint)
+    purposePoint.setPurpose(this)
+    return this
   }
 
   getQuantities () {
@@ -76,7 +76,7 @@ class Purpose {
       HOURLY_QTY_USABILITY: 'L',
       INST_QTY: this.instantQty,
       INST_QTY_USABILITY: 'L'
-    };
+    }
   }
 
   getPurposeCodes () {
@@ -84,7 +84,7 @@ class Purpose {
       APUR_APPR_CODE: this.primary.code,
       APUR_APSE_CODE: this.secondary.code,
       APUR_APUS_CODE: this.tertiary.code
-    };
+    }
   }
 
   getTimePeriod () {
@@ -93,7 +93,7 @@ class Purpose {
       PERIOD_ST_MONTH: this.periodStartMonth,
       PERIOD_END_DAY: this.periodEndDay,
       PERIOD_END_MONTH: this.periodEndMonth
-    };
+    }
   }
 
   export () {
@@ -109,8 +109,8 @@ class Purpose {
       ...common.createNullKeys('TIMELTD_START_DATE', 'LANDS', 'AREC_CODE', 'DISP_ORD'),
       NOTES: 'Licence notes here, could include long NGR code SJ 1234 5678',
       ...common.getCommonObject('FGAC_REGION_CODE', 'SOURCE_CODE', 'BATCH_RUN_DATE')
-    };
+    }
   }
 }
 
-module.exports = Purpose;
+module.exports = Purpose

--- a/scripts/licence-creator/rep-unit.js
+++ b/scripts/licence-creator/rep-unit.js
@@ -1,8 +1,8 @@
 
 class RepUnit {
   constructor () {
-    this.code = 100;
-    this.name = 'PARISH OF TESTINGSHIRE (ESSEX)';
+    this.code = 100
+    this.name = 'PARISH OF TESTINGSHIRE (ESSEX)'
   }
 
   export () {
@@ -23,8 +23,8 @@ class RepUnit {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = RepUnit;
+module.exports = RepUnit

--- a/scripts/licence-creator/return-format-point.js
+++ b/scripts/licence-creator/return-format-point.js
@@ -1,12 +1,12 @@
 class ReturnFormatPoint {
   setFormat (format) {
-    this.format = format;
-    return this;
+    this.format = format
+    return this
   }
 
   setPoint (point) {
-    this.point = point;
-    return this;
+    this.point = point
+    return this
   }
 
   export () {
@@ -16,8 +16,8 @@ class ReturnFormatPoint {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = ReturnFormatPoint;
+module.exports = ReturnFormatPoint

--- a/scripts/licence-creator/return-format-purpose.js
+++ b/scripts/licence-creator/return-format-purpose.js
@@ -1,7 +1,7 @@
 class ReturnFormatPurpose {
   setFormat (format) {
-    this.format = format;
-    return this;
+    this.format = format
+    return this
   }
 
   export () {
@@ -15,8 +15,8 @@ class ReturnFormatPurpose {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = ReturnFormatPurpose;
+module.exports = ReturnFormatPurpose

--- a/scripts/licence-creator/return-format.js
+++ b/scripts/licence-creator/return-format.js
@@ -1,36 +1,36 @@
-'use strict';
+'use strict'
 
-const common = require('./common');
+const common = require('./common')
 
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
 class ReturnFormat {
   constructor () {
-    this.id = getNextId();
-    this.points = [];
-    this.purposes = [];
+    this.id = getNextId()
+    this.points = []
+    this.purposes = []
   }
 
   setLicence (licence) {
-    this.licence = licence;
-    return this;
+    this.licence = licence
+    return this
   }
 
   setReturnVersion (returnVersion) {
-    this.returnVersion = returnVersion;
-    return this;
+    this.returnVersion = returnVersion
+    return this
   }
 
   addPoint (point) {
-    point.setFormat(this);
-    this.points.push(point);
-    return this;
+    point.setFormat(this)
+    this.points.push(point)
+    return this
   }
 
   addPurpose (purpose) {
-    purpose.setFormat(this);
-    this.purposes.push(purpose);
-    return this;
+    purpose.setFormat(this)
+    this.purposes.push(purpose)
+    return this
   }
 
   getAbstractionPeriod () {
@@ -41,7 +41,7 @@ class ReturnFormat {
       ABS_PERIOD_END_MONTH: '12',
       TIMELTD_ST_DATE: null,
       TIMELTD_END_DATE: null
-    };
+    }
   }
 
   export () {
@@ -64,8 +64,8 @@ class ReturnFormat {
       ANNUAL_QTY_USABILITY: null,
       CC_IND: null,
       ...common.getCommonObject('FGAC_REGION_CODE', 'SOURCE_CODE', 'BATCH_RUN_DATE')
-    };
+    }
   }
 }
 
-module.exports = ReturnFormat;
+module.exports = ReturnFormat

--- a/scripts/licence-creator/return-version.js
+++ b/scripts/licence-creator/return-version.js
@@ -1,24 +1,24 @@
 
 class ReturnVersion {
   constructor () {
-    this.startDate = '01/01/2018';
-    this.formats = [];
-    this.versionNumber = 100;
+    this.startDate = '01/01/2018'
+    this.formats = []
+    this.versionNumber = 100
   }
 
   setLicence (licence) {
-    this.licence = licence;
-    return this;
+    this.licence = licence
+    return this
   }
 
   addFormat (format) {
-    format.setReturnVersion(this);
-    this.formats.push(format);
-    return this;
+    format.setReturnVersion(this)
+    this.formats.push(format)
+    return this
   }
 
   getVersionNumber () {
-    return this.versionNumber;
+    return this.versionNumber
   }
 
   export () {
@@ -32,8 +32,8 @@ class ReturnVersion {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = ReturnVersion;
+module.exports = ReturnVersion

--- a/scripts/licence-creator/role-type.js
+++ b/scripts/licence-creator/role-type.js
@@ -1,10 +1,10 @@
 class RoleType {
   constructor () {
-    this.code = 'LC';
-    this.description = 'Licence contact';
-    this.affectsAbs = true;
-    this.affectsImp = true;
-    this.isAgency = false;
+    this.code = 'LC'
+    this.description = 'Licence contact'
+    this.affectsAbs = true
+    this.affectsImp = true
+    this.isAgency = false
   }
 
   export () {
@@ -19,8 +19,8 @@ class RoleType {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = RoleType;
+module.exports = RoleType

--- a/scripts/licence-creator/role.js
+++ b/scripts/licence-creator/role.js
@@ -1,45 +1,45 @@
-const moment = require('moment');
-const getNextId = require('./next-id.js');
+const moment = require('moment')
+const getNextId = require('./next-id.js')
 
 class Role {
   constructor () {
-    this.id = getNextId();
+    this.id = getNextId()
 
-    this.licence = null;
-    this.party = null;
-    this.address = null;
+    this.licence = null
+    this.party = null
+    this.address = null
 
-    this.startDate = moment().format('DD/MM/YYYY');
-    this.endDate = moment().add(1, 'year').format('DD/MM/YYYY');
+    this.startDate = moment().format('DD/MM/YYYY')
+    this.endDate = moment().add(1, 'year').format('DD/MM/YYYY')
 
-    this.contactNos = [];
+    this.contactNos = []
 
-    this.roleType = null;
+    this.roleType = null
   }
 
   setRoleType (roleType) {
-    this.roleType = roleType;
-    return this;
+    this.roleType = roleType
+    return this
   }
 
   setLicence (licence) {
-    this.licence = licence;
-    return this;
+    this.licence = licence
+    return this
   }
 
   setParty (party) {
-    this.party = party;
-    return this;
+    this.party = party
+    return this
   }
 
   setAddress (address) {
-    this.address = address;
-    return this;
+    this.address = address
+    return this
   }
 
   addContactNo (contactNo) {
-    this.contactNos.push(contactNo);
-    return this;
+    this.contactNos.push(contactNo)
+    return this
   }
 
   export () {
@@ -55,8 +55,8 @@ class Role {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Role;
+module.exports = Role

--- a/scripts/licence-creator/source.js
+++ b/scripts/licence-creator/source.js
@@ -1,9 +1,9 @@
 class Source {
   constructor () {
-    this.code = 'GWSOS';
-    this.name = 'GROUND WATER SOURCE OF SUPPLY';
-    this.localName = 'GROUND WATER';
-    this.sourceType = 'GW';
+    this.code = 'GWSOS'
+    this.name = 'GROUND WATER SOURCE OF SUPPLY'
+    this.localName = 'GROUND WATER'
+    this.sourceType = 'GW'
   }
 
   export () {
@@ -23,8 +23,8 @@ class Source {
       FGAC_REGION_CODE: 1,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = Source;
+module.exports = Source

--- a/scripts/licence-creator/version.js
+++ b/scripts/licence-creator/version.js
@@ -1,49 +1,49 @@
-'use strict';
+'use strict'
 
-const common = require('./common');
+const common = require('./common')
 
-const getNextId = require('./next-id.js');
+const getNextId = require('./next-id.js')
 
 class Version {
   constructor () {
-    this.id = getNextId();
-    this.startDate = '01/01/2018';
+    this.id = getNextId()
+    this.startDate = '01/01/2018'
 
-    this.address = null;
-    this.licence = null;
-    this.party = null;
-    this.purposes = [];
+    this.address = null
+    this.licence = null
+    this.party = null
+    this.purposes = []
 
-    this.waLicenceType = null;
+    this.waLicenceType = null
   }
 
   setLicence (licence) {
-    this.licence = licence;
-    return this;
+    this.licence = licence
+    return this
   }
 
   setWALicenceType (waLicenceType) {
-    this.waLicenceType = waLicenceType;
-    return this;
+    this.waLicenceType = waLicenceType
+    return this
   }
 
   setParty (party) {
-    this.party = party;
-    return this;
+    this.party = party
+    return this
   }
 
   setAddress (address) {
-    this.address = address;
-    return this;
+    this.address = address
+    return this
   }
 
   addPurpose (purpose) {
-    this.purposes.push(purpose);
-    return this;
+    this.purposes.push(purpose)
+    return this
   }
 
   setStartDate (date) {
-    this.startDate = date;
+    this.startDate = date
   }
 
   export () {
@@ -68,8 +68,8 @@ class Version {
       WRT_CODE: 'N',
       DEREG_CODE: 'CONF',
       FGAC_REGION_CODE: 1
-    };
+    }
   }
 }
 
-module.exports = Version;
+module.exports = Version

--- a/scripts/licence-creator/wa-licence-type.js
+++ b/scripts/licence-creator/wa-licence-type.js
@@ -1,7 +1,7 @@
 class WALicenceType {
   constructor (code, description) {
-    this.code = code;
-    this.description = description;
+    this.code = code
+    this.description = description
   }
 
   export () {
@@ -12,8 +12,8 @@ class WALicenceType {
       DISP_ORD: null,
       SOURCE_CODE: 'NALD',
       BATCH_RUN_DATE: '12/02/2018 20:02:11'
-    };
+    }
   }
 }
 
-module.exports = WALicenceType;
+module.exports = WALicenceType

--- a/server.js
+++ b/server.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-require('dotenv').config();
+require('dotenv').config()
 
-const Hapi = require('@hapi/hapi');
-const CatboxRedis = require('@hapi/catbox-redis');
+const Hapi = require('@hapi/hapi')
+const CatboxRedis = require('@hapi/catbox-redis')
 
-const config = require('./config');
+const config = require('./config')
 
 const server = Hapi.server({
   ...config.server,
@@ -17,6 +17,6 @@ const server = Hapi.server({
       }
     }
   ]
-});
+})
 
-module.exports = server;
+module.exports = server

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
-require('dotenv').config();
+require('dotenv').config()
 
-const pg = require('pg');
-const config = require('../../../config.js');
-const helpers = require('@envage/water-abstraction-helpers');
-const { logger } = require('../../logger');
+const pg = require('pg')
+const config = require('../../../config.js')
+const helpers = require('@envage/water-abstraction-helpers')
+const { logger } = require('../../logger')
 
 // Set date parser
-const moment = require('moment');
-const DATE_FORMAT = 'YYYY-MM-DD';
-const dateMapper = str => moment(str).format(DATE_FORMAT);
-pg.types.setTypeParser(pg.types.builtins.DATE, dateMapper);
+const moment = require('moment')
+const DATE_FORMAT = 'YYYY-MM-DD'
+const dateMapper = str => moment(str).format(DATE_FORMAT)
+pg.types.setTypeParser(pg.types.builtins.DATE, dateMapper)
 
-const pool = helpers.db.createPool(config.pg, logger);
+const pool = helpers.db.createPool(config.pg, logger)
 
 module.exports = {
   pool
-};
+}

--- a/src/lib/connectors/import.js
+++ b/src/lib/connectors/import.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const { pool } = require('./db');
+const { pool } = require('./db')
 
 const getLicenceNumbersQuery = `
   select "LIC_NO"
   from import."NALD_ABS_LICENCES";
-`;
+`
 
 const deleteCrmV1DocumentsQuery = `
   update crm.document_header
@@ -16,18 +16,18 @@ const deleteCrmV1DocumentsQuery = `
   )
   and date_deleted is null
   and regime_entity_id = '0434dc31-a34e-7158-5775-4694af7a60cf';
-`;
+`
 
 const getLicenceNumbers = async () => {
-  const response = await pool.query(getLicenceNumbersQuery);
-  return response.rows || [];
-};
+  const response = await pool.query(getLicenceNumbersQuery)
+  return response.rows || []
+}
 
 const deleteRemovedDocuments = () => {
-  return pool.query(deleteCrmV1DocumentsQuery);
-};
+  return pool.query(deleteCrmV1DocumentsQuery)
+}
 
 module.exports = {
   getLicenceNumbers,
   deleteRemovedDocuments
-};
+}

--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -1,35 +1,35 @@
-'use strict';
+'use strict'
 
-const { APIClient } = require('@envage/hapi-pg-rest-api');
-const { serviceRequest } = require('@envage/water-abstraction-helpers');
-const { pool } = require('./db');
-const config = require('../../../config');
+const { APIClient } = require('@envage/hapi-pg-rest-api')
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { pool } = require('./db')
+const config = require('../../../config')
 
 const rp = require('request-promise-native').defaults({
   proxy: null,
   strictSSL: false
-});
+})
 
 const versions = new APIClient(rp, {
   endpoint: `${process.env.RETURNS_URI}/versions`,
   headers: {
     Authorization: process.env.JWT_TOKEN
   }
-});
+})
 
 const lines = new APIClient(rp, {
   endpoint: `${process.env.RETURNS_URI}/lines`,
   headers: {
     Authorization: process.env.JWT_TOKEN
   }
-});
+})
 
 const returns = new APIClient(rp, {
   endpoint: `${process.env.RETURNS_URI}/returns`,
   headers: {
     Authorization: process.env.JWT_TOKEN
   }
-});
+})
 
 /**
  * Makes a POST request to the returns service that causes any
@@ -42,45 +42,45 @@ const returns = new APIClient(rp, {
  */
 const voidReturns = (licenceNumber, validReturnIds = []) => {
   if (!validReturnIds.length) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
 
-  const url = `${config.services.returns}/void-returns`;
+  const url = `${config.services.returns}/void-returns`
   const body = {
     regime: 'water',
     licenceType: 'abstraction',
     licenceNumber,
     validReturnIds
-  };
+  }
 
-  return serviceRequest.patch(url, { body });
-};
+  return serviceRequest.patch(url, { body })
+}
 
 const deleteAllReturnsData = async returnId => {
-  const deleteLinesQuery = 'delete from returns.lines where version_id in (select version_id from returns.versions where return_id=$1);';
+  const deleteLinesQuery = 'delete from returns.lines where version_id in (select version_id from returns.versions where return_id=$1);'
 
-  const deleteVersionsQuery = 'delete from returns.versions where return_id = $1;';
+  const deleteVersionsQuery = 'delete from returns.versions where return_id = $1;'
 
-  const deleteReturnsQuery = 'delete from returns.returns where return_id = $1;';
+  const deleteReturnsQuery = 'delete from returns.returns where return_id = $1;'
 
   const deleteReturnRequirementPurposesQuery = `delete from water.return_requirement_purposes 
     where return_requirement_id::varchar in (SELECT return_requirement_id::varchar FROM water.return_requirements 
-    where return_version_id = (SELECT return_version_id from returns.versions where return_id = $1))`;
+    where return_version_id = (SELECT return_version_id from returns.versions where return_id = $1))`
 
   const deleteReturnVersionsQuery = `delete from water.return_versions 
-    where return_version_id::varchar in (SELECT version_id::varchar from returns.versions where return_id = $1)`;
+    where return_version_id::varchar in (SELECT version_id::varchar from returns.versions where return_id = $1)`
 
   const deleteReturnRequirementsQuery = `delete from water.return_requirements 
-    where return_version_id::varchar in (SELECT version_id::varchar from returns.versions where return_id = $1)`;
+    where return_version_id::varchar in (SELECT version_id::varchar from returns.versions where return_id = $1)`
 
-  await pool.query(deleteReturnVersionsQuery, [returnId]);
-  await pool.query(deleteReturnRequirementPurposesQuery, [returnId]);
-  await pool.query(deleteReturnRequirementsQuery, [returnId]);
+  await pool.query(deleteReturnVersionsQuery, [returnId])
+  await pool.query(deleteReturnRequirementPurposesQuery, [returnId])
+  await pool.query(deleteReturnRequirementsQuery, [returnId])
 
-  await pool.query(deleteLinesQuery, [returnId]);
-  await pool.query(deleteVersionsQuery, [returnId]);
-  await pool.query(deleteReturnsQuery, [returnId]);
-};
+  await pool.query(deleteLinesQuery, [returnId])
+  await pool.query(deleteVersionsQuery, [returnId])
+  await pool.query(deleteReturnsQuery, [returnId])
+}
 
 module.exports = {
   versions,
@@ -88,4 +88,4 @@ module.exports = {
   returns,
   voidReturns,
   deleteAllReturnsData
-};
+}

--- a/src/lib/connectors/s3.js
+++ b/src/lib/connectors/s3.js
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-const aws = require('aws-sdk');
-const proxyAgent = require('proxy-agent');
+const aws = require('aws-sdk')
+const proxyAgent = require('proxy-agent')
 
-const config = require('../../../config.js');
+const config = require('../../../config.js')
 
 const _getS3Options = () => {
-  const { bucket, ...credentials } = config.s3;
-  const { proxy } = config;
+  const { bucket, ...credentials } = config.s3
+  const { proxy } = config
   return {
     ...credentials,
     ...proxy && {
@@ -15,12 +15,12 @@ const _getS3Options = () => {
         agent: proxyAgent(proxy)
       }
     }
-  };
-};
+  }
+}
 
-const getS3 = () => new aws.S3(_getS3Options());
+const getS3 = () => new aws.S3(_getS3Options())
 
 module.exports = {
   _getS3Options,
   getS3
-};
+}

--- a/src/lib/connectors/water-import/jobs.js
+++ b/src/lib/connectors/water-import/jobs.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../db');
-const { get } = require('lodash');
-const { pgBossJobOverview, pgBossFailedJobs } = require('./queries');
-const moment = require('moment');
+const { pool } = require('../db')
+const { get } = require('lodash')
+const { pgBossJobOverview, pgBossFailedJobs } = require('./queries')
+const moment = require('moment')
 
 const getJobSummary = () => {
   /**
@@ -26,15 +26,15 @@ const getJobSummary = () => {
     { id: 'import.charging-data', displayName: 'Charging data' },
     { id: 'import.companies', displayName: 'Companies' },
     { id: 'import.company', displayName: 'Company' }
-  ];
+  ]
 
   return Promise.all(pgBossJobsArray.map(async eachJob => {
-    const { rows: status } = await pool.query(pgBossJobOverview, [eachJob.id]);
+    const { rows: status } = await pool.query(pgBossJobOverview, [eachJob.id])
 
-    const failedCount = parseInt(get(status.find(row => row.state === 'failed'), 'count', 0));
-    const completedCount = parseInt(get(status.find(row => row.state === 'completed'), 'count', 0));
-    const isActive = !!status.find(row => row.state === 'active') || !!status.find(row => row.state === 'created');
-    const lastUpdated = get(status.find(row => row.state === 'completed'), 'max_completed_date', null);
+    const failedCount = parseInt(get(status.find(row => row.state === 'failed'), 'count', 0))
+    const completedCount = parseInt(get(status.find(row => row.state === 'completed'), 'count', 0))
+    const isActive = !!status.find(row => row.state === 'active') || !!status.find(row => row.state === 'created')
+    const lastUpdated = get(status.find(row => row.state === 'completed'), 'max_completed_date', null)
 
     return {
       displayName: eachJob.displayName,
@@ -42,23 +42,23 @@ const getJobSummary = () => {
       completedCount,
       isActive,
       lastUpdated
-    };
-  }));
-};
+    }
+  }))
+}
 
 const getFailedJobs = async () => {
-  const { rows } = await pool.query(pgBossFailedJobs);
+  const { rows } = await pool.query(pgBossFailedJobs)
   return rows.map(row => {
     return {
       jobName: row.name,
       total: row.count,
       dateCreated: row.max_created_date ? moment(row.max_created_date).format('DD MMM YYYY HH:mm:ss') : '',
       dateCompleted: row.max_completed_date ? moment(row.max_completed_date).format('DD MMM YYYY HH:mm:ss') : ''
-    };
-  });
-};
+    }
+  })
+}
 
 module.exports = {
   getFailedJobs,
   getJobSummary
-};
+}

--- a/src/lib/connectors/water-import/queries.js
+++ b/src/lib/connectors/water-import/queries.js
@@ -21,7 +21,7 @@ where
     and (a.createdon > now() - interval '3 days' or a.completedon > now() - interval '3 days')
     and a.name = $1
     group by a.state) cte 
-    group by state`;
+    group by state`
 
 const pgBossFailedJobs = `select name, sum(count) as count, max(max_completed_date) as max_completed_date, max(max_created_date) as max_created_date from (select
         name,
@@ -46,9 +46,9 @@ const pgBossFailedJobs = `select name, sum(count) as count, max(max_completed_da
         a.state = 'failed'
         and (a.createdon > now() - interval '12 hours' or a.completedon > now() - interval '12 hours')        
         group by a.name) cte 
-        group by name`;
+        group by name`
 
 module.exports = {
   pgBossFailedJobs,
   pgBossJobOverview
-};
+}

--- a/src/lib/connectors/water/application-state.js
+++ b/src/lib/connectors/water/application-state.js
@@ -1,24 +1,24 @@
-'use strict';
+'use strict'
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers');
-const urlJoin = require('url-join');
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const urlJoin = require('url-join')
 
-const config = require('../../../../config');
+const config = require('../../../../config')
 
 const getUrl = key => {
-  return urlJoin(config.services.water, 'application-state', key);
-};
+  return urlJoin(config.services.water, 'application-state', key)
+}
 
-const getState = key => serviceRequest.get(getUrl(key));
+const getState = key => serviceRequest.get(getUrl(key))
 
 const postState = (key, data) => {
-  const url = getUrl(key);
+  const url = getUrl(key)
   return serviceRequest.post(url, {
     body: data
-  });
-};
+  })
+}
 
 module.exports = {
   getState,
   postState
-};
+}

--- a/src/lib/connectors/water/events.js
+++ b/src/lib/connectors/water/events.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-const { APIClient } = require('@envage/hapi-pg-rest-api');
+const { APIClient } = require('@envage/hapi-pg-rest-api')
 
 const rp = require('request-promise-native').defaults({
   proxy: null,
   strictSSL: false
-});
+})
 
 const events = new APIClient(rp, {
   endpoint: `${process.env.WATER_URI}/event`,
   headers: {
     Authorization: process.env.JWT_TOKEN
   }
-});
+})
 
 module.exports = {
   events
-};
+}

--- a/src/lib/connectors/water/notify.js
+++ b/src/lib/connectors/water/notify.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers');
-const urlJoin = require('url-join');
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const urlJoin = require('url-join')
 
-const config = require('../../../../config');
+const config = require('../../../../config')
 
-const getUrl = key => urlJoin(config.services.water, 'notify', key);
+const getUrl = key => urlJoin(config.services.water, 'notify', key)
 
 const postSendNotify = (key, data) => {
-  const url = getUrl(key);
+  const url = getUrl(key)
   return serviceRequest.post(url, {
     body: data
-  });
-};
+  })
+}
 
 module.exports = {
   postSendNotify
-};
+}

--- a/src/lib/date-helpers.js
+++ b/src/lib/date-helpers.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const moment = require('moment');
-const { sortBy, first, last, identity } = require('lodash');
+const moment = require('moment')
+const { sortBy, first, last, identity } = require('lodash')
 
 /**
  * Given an array of dates which can be parsed by Moment,
@@ -15,12 +15,12 @@ const getSortedDates = arr => sortBy(
     .filter(identity)
     .map(value => moment(value)),
   m => m.unix()
-);
+)
 
-const getMinDate = arr => first(getSortedDates(arr));
-const getMaxDate = arr => last(getSortedDates(arr));
+const getMinDate = arr => first(getSortedDates(arr))
+const getMaxDate = arr => last(getSortedDates(arr))
 
 module.exports = {
   getMinDate,
   getMaxDate
-};
+}

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
 /**
  * There is a database problem
  */
 class DBError extends Error {
   constructor (message) {
-    super(message);
-    this.name = 'DBError';
+    super(message)
+    this.name = 'DBError'
   }
 }
 
 module.exports = {
   DBError
-};
+}

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const { logger } = require('../logger');
+const { logger } = require('../logger')
 
 /**
  * Registers subscribers in relevant environments
@@ -9,12 +9,12 @@ const { logger } = require('../logger');
  */
 const createRegister = (server, registerSubscribers) => {
   if (process.env.TRAVIS) {
-    logger.info('Abort register of subscribers in Travis environment');
-    return;
+    logger.info('Abort register of subscribers in Travis environment')
+    return
   }
-  return registerSubscribers(server);
-};
+  return registerSubscribers(server)
+}
 
 module.exports = {
   createRegister
-};
+}

--- a/src/lib/services/application-state-service.js
+++ b/src/lib/services/application-state-service.js
@@ -1,16 +1,16 @@
-'use strict';
+'use strict'
 
-const applicationStateConnector = require('../connectors/water/application-state');
-const constants = require('../../modules/nald-import/lib/constants');
+const applicationStateConnector = require('../connectors/water/application-state')
+const constants = require('../../modules/nald-import/lib/constants')
 
 const get = async identifier => {
-  const state = await applicationStateConnector.getState(identifier);
-  return state.data;
-};
+  const state = await applicationStateConnector.getState(identifier)
+  return state.data
+}
 
-const save = (key = constants.APPLICATION_STATE_KEY, data = {}) => applicationStateConnector.postState(key, data);
+const save = (key = constants.APPLICATION_STATE_KEY, data = {}) => applicationStateConnector.postState(key, data)
 
 module.exports = {
   get,
   save
-};
+}

--- a/src/lib/services/import.js
+++ b/src/lib/services/import.js
@@ -1,18 +1,18 @@
 
-'use strict';
+'use strict'
 
-const importConnector = require('../connectors/import');
+const importConnector = require('../connectors/import')
 
 const getLicenceNumbers = async () => {
-  const licenceNumbers = await importConnector.getLicenceNumbers();
-  return licenceNumbers.map(licenceNumber => licenceNumber.LIC_NO);
-};
+  const licenceNumbers = await importConnector.getLicenceNumbers()
+  return licenceNumbers.map(licenceNumber => licenceNumber.LIC_NO)
+}
 
 const deleteRemovedDocuments = async () => {
-  return importConnector.deleteRemovedDocuments();
-};
+  return importConnector.deleteRemovedDocuments()
+}
 
 module.exports = {
   deleteRemovedDocuments,
   getLicenceNumbers
-};
+}

--- a/src/lib/services/notify.js
+++ b/src/lib/services/notify.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const notifyConnector = require('../connectors/water/notify');
-const { get } = require('lodash');
-const config = require('../../../config');
+const notifyConnector = require('../connectors/water/notify')
+const { get } = require('lodash')
+const config = require('../../../config')
 
 /**
  * Gets the notify template ID to use by inspecting the application config
  * @param  {Object} scheduledNotification - row from scheduled_notification table
  * @return {String}                       - Notify template ID
  */
-const getNotifyTemplate = messageRef => get(config, `notify.templates.${messageRef}`);
+const getNotifyTemplate = messageRef => get(config, `notify.templates.${messageRef}`)
 
 /**
  * Sends an email via Water Service to Notify API
@@ -18,10 +18,10 @@ const getNotifyTemplate = messageRef => get(config, `notify.templates.${messageR
  * @return {Promise}           - resolves when message sent
  */
 const sendEmail = async (recipient, messageRef, personalisation) => {
-  const templateId = getNotifyTemplate(messageRef);
-  return notifyConnector.postSendNotify('email', { templateId, recipient, personalisation });
-};
+  const templateId = getNotifyTemplate(messageRef)
+  return notifyConnector.postSendNotify('email', { templateId, recipient, personalisation })
+}
 
 module.exports = {
   sendEmail
-};
+}

--- a/src/lib/services/s3.js
+++ b/src/lib/services/s3.js
@@ -1,14 +1,14 @@
-const fs = require('fs');
+const fs = require('fs')
 
-const config = require('../../../config.js');
+const config = require('../../../config.js')
 
-const s3Connector = require('../connectors/s3');
+const s3Connector = require('../connectors/s3')
 
 const getOptions = (key, options = {}) => ({
   Bucket: config.s3.bucket,
   Key: key,
   ...options
-});
+})
 
 /**
  * Uploads specified file to s3
@@ -17,21 +17,21 @@ const getOptions = (key, options = {}) => ({
  * @return {Promise}
  */
 const upload = async (filename, buffer) => {
-  const options = getOptions(filename, { Body: buffer });
-  return s3Connector.getS3().upload(options).promise();
-};
+  const options = getOptions(filename, { Body: buffer })
+  return s3Connector.getS3().upload(options).promise()
+}
 
 const callS3MethodWithKey = (method, key) => {
-  const options = getOptions(key);
-  return s3Connector.getS3()[method](options).promise();
-};
+  const options = getOptions(key)
+  return s3Connector.getS3()[method](options).promise()
+}
 
 /**
  * Wraps the call to getObject from the sdk returning a Promise.
  * @param {Sting} key - on s3 bucket
  * @return {Promise}
  */
-const getObject = key => callS3MethodWithKey('getObject', key);
+const getObject = key => callS3MethodWithKey('getObject', key)
 
 /**
  * Downloads file with key 'key' from bucket and places
@@ -42,28 +42,28 @@ const getObject = key => callS3MethodWithKey('getObject', key);
  */
 const download = async (key, destination) => {
   return new Promise((resolve, reject) => {
-    const options = getOptions(key);
-    const file = fs.createWriteStream(destination);
+    const options = getOptions(key)
+    const file = fs.createWriteStream(destination)
 
-    file.on('close', () => resolve());
+    file.on('close', () => resolve())
 
     return s3Connector.getS3().getObject(options)
       .createReadStream()
       .on('error', err => reject(err))
-      .pipe(file);
-  });
-};
+      .pipe(file)
+  })
+}
 
 /**
  * Gets header information about specified file
  * @param {String} key
  * @return {Promise}
  */
-const getHead = key => callS3MethodWithKey('headObject', key);
+const getHead = key => callS3MethodWithKey('headObject', key)
 
 module.exports = {
   upload,
   getObject,
   download,
   getHead
-};
+}

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -1,35 +1,35 @@
-'use strict';
+'use strict'
 
-const os = require('os');
-const hostname = os.hostname();
-const { logger } = require('../logger');
+const os = require('os')
+const hostname = os.hostname()
+const { logger } = require('../logger')
 
 // contains generic functions unrelated to a specific component
 const rp = require('request-promise-native').defaults({
   strictSSL: false
-});
+})
 
 function post (message) {
   if (!process.env.SLACK_HOOK) {
-    return;
+    return
   }
 
-  const msg = message + ' - ' + hostname + ' - ' + process.env.NODE_ENV;
-  logger.info(`Slack: ${msg}`);
-  const uri = 'https://hooks.slack.com/services/' + process.env.SLACK_HOOK;
+  const msg = message + ' - ' + hostname + ' - ' + process.env.NODE_ENV
+  logger.info(`Slack: ${msg}`)
+  const uri = 'https://hooks.slack.com/services/' + process.env.SLACK_HOOK
   const options = {
     method: 'POST',
     url: uri,
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     form: { payload: '{"channel": "#beta-activity", "username": "Gerald The Water Buffalo", "text": "' + msg + '", "icon_emoji": ":water_buffalo:"}' }
-  };
+  }
 
   return rp(options)
     .catch((err) => {
-      logger.error('Slack error', err);
-    });
+      logger.error('Slack error', err)
+    })
 }
 
 module.exports = {
   post
-};
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,8 +1,8 @@
-const config = require('../config');
-const { createLogger } = require('@envage/water-abstraction-helpers').logger;
+const config = require('../config')
+const { createLogger } = require('@envage/water-abstraction-helpers').logger
 
-const logger = createLogger(config.logger);
+const logger = createLogger(config.logger)
 
 module.exports = {
   logger
-};
+}

--- a/src/modules/bill-runs-import/controller.js
+++ b/src/modules/bill-runs-import/controller.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const constants = require('./lib/constants');
+const constants = require('./lib/constants')
 
 const postImportBillRuns = async request => {
-  await request.messageQueue.publish(constants.IMPORT_BILL_RUNS);
+  await request.messageQueue.publish(constants.IMPORT_BILL_RUNS)
   return {
     error: null
-  };
-};
+  }
+}
 
 module.exports = {
   postImportBillRuns
-};
+}

--- a/src/modules/bill-runs-import/lib/constants.js
+++ b/src/modules/bill-runs-import/lib/constants.js
@@ -1,5 +1,5 @@
-'use strict';
+'use strict'
 
 module.exports = {
   IMPORT_BILL_RUNS: 'import.bill-runs'
-};
+}

--- a/src/modules/bill-runs-import/lib/import.js
+++ b/src/modules/bill-runs-import/lib/import.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const queries = require('./queries');
-const slack = require('../../../lib/slack');
-const { pool } = require('../../../lib/connectors/db');
-const { logger } = require('../../../logger');
+const queries = require('./queries')
+const slack = require('../../../lib/slack')
+const { pool } = require('../../../lib/connectors/db')
+const { logger } = require('../../../logger')
 
 const createRow = (tableName, query) => ({
   tableName,
   query
-});
+})
 
 const importQueries = [
   createRow('remove_constraints', queries.removeConstraints),
@@ -21,17 +21,17 @@ const importQueries = [
   createRow('billing_volumes', queries.importBillingVolumes),
   createRow('billing_batch_charge_version_years', queries.importBillingBatchChargeVersionYears),
   createRow('add_constraints', queries.addConstraints)
-];
+]
 
 /**
  * Logs a message and posts to Slack
  * @param {String} str - the message
  */
 const log = str => {
-  const message = `Bill run import: ${str}`;
-  logger.info(message);
-  slack.post(message);
-};
+  const message = `Bill run import: ${str}`
+  logger.info(message)
+  slack.post(message)
+}
 
 /**
  * Run SQL queries to import bill runs to the water
@@ -42,21 +42,21 @@ const log = str => {
  */
 const importBillRuns = async () => {
   try {
-    log('Starting...');
+    log('Starting...')
 
     for (const { tableName, query } of importQueries) {
-      log(`Importing ${tableName}...`);
-      await pool.query(query);
-      log(`Imported ${tableName}.`);
+      log(`Importing ${tableName}...`)
+      await pool.query(query)
+      log(`Imported ${tableName}.`)
     }
 
-    log('Complete.');
+    log('Complete.')
   } catch (err) {
-    log(err.message);
-    throw err;
+    log(err.message)
+    throw err
   }
-};
+}
 
 module.exports = {
   importBillRuns
-};
+}

--- a/src/modules/bill-runs-import/lib/queries.js
+++ b/src/modules/bill-runs-import/lib/queries.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const importNaldBillRuns = `
 insert into water.billing_batches (
@@ -95,7 +95,7 @@ nbr."BILL_RUN_TYPE" in ('A', 'S', 'R')
 and nbr."IAS_XFER_DATE"<>'null'
 and nbr."FIN_YEAR"::integer>=2015
 on conflict (legacy_id) do nothing;
-`;
+`
 
 const importNaldBillHeaders = `
 insert into water.billing_invoices (
@@ -121,7 +121,7 @@ from import."NALD_BILL_HEADERS" nbh
 left join crm_v2.invoice_accounts ia on nbh."IAS_CUST_REF"=ia.invoice_account_number
 join water.billing_batches b on b.legacy_id=concat_ws(':', nbh."FGAC_REGION_CODE", nbh."ABRN_BILL_RUN_NO")
 on conflict (legacy_id) do nothing;
-`;
+`
 
 const importInvoiceLicences = `
 insert into water.billing_invoice_licences (
@@ -139,17 +139,17 @@ left join import."NALD_BILL_TRANS" nbt on nbh."FGAC_REGION_CODE"=nbt."FGAC_REGIO
 join import."NALD_ABS_LICENCES" nl on nbt."FGAC_REGION_CODE"=nl."FGAC_REGION_CODE" and nbt."LIC_ID"=nl."ID"
 left join water.licences l on nl."LIC_NO"=l.licence_ref
 on conflict (billing_invoice_id, licence_id) do nothing;
-`;
+`
 
 const resetIsSecondPartChargeFlag = `
 update water.billing_transactions 
 set is_two_part_second_part_charge = false;
-`;
+`
 const setIsSecondPartChargeFlag = `
 update water.billing_transactions 
 set is_two_part_second_part_charge = true
 where description ilike 'second%';
-`;
+`
 
 const importTransactions = `
 insert into water.billing_transactions ( 
@@ -319,7 +319,7 @@ left join(
   where not (nbt."FINAL_A2_BILLABLE_AMOUNT"::numeric=0 and nl.is_water_undertaker=true)
 ) nbt2 on nbt2."FGAC_REGION_CODE"=nbt."FGAC_REGION_CODE" and nbt2."ID"=nbt."ID"
 on conflict (legacy_id) do nothing;
-`;
+`
 
 const importBillingVolumes = `
 insert into water.billing_volumes (
@@ -374,7 +374,7 @@ join (
   ) ntr
 ) ntr on ntr.external_id=ce.external_id and i.financial_year_ending=ntr."FIN_YEAR"
 where b.source='nald' and b.batch_type='two_part_tariff';
-`;
+`
 
 const importBillingBatchChargeVersionYears = `
 insert into water.billing_batch_charge_version_years (
@@ -402,7 +402,6 @@ join water.charge_elements ce on t.charge_element_id=ce.charge_element_id
 where b.source='nald'
 on conflict do nothing;
 `
-;
 
 const removeConstraints = `
 alter table water.billing_invoices 
@@ -410,7 +409,7 @@ drop constraint fk_original_billing_invoice_id;
 
 alter table water.billing_transactions
 drop constraint billing_transactions_billing_invoice_licence_id_fkey,
-drop constraint billing_transactions_billing_transactions_fk_source_transaction_id;`;
+drop constraint billing_transactions_billing_transactions_fk_source_transaction_id;`
 
 const addConstraints = `               
 alter table water.billing_invoices 
@@ -424,7 +423,7 @@ ADD constraint billing_transactions_billing_invoice_licence_id_fkey
   references water.billing_invoice_licences (billing_invoice_licence_id),
 ADD constraint billing_transactions_billing_transactions_fk_source_transaction_id
   foreign key (source_transaction_id) 
-  references water.billing_transactions (billing_transaction_id);`;
+  references water.billing_transactions (billing_transaction_id);`
 
 module.exports = {
   addConstraints,
@@ -437,4 +436,4 @@ module.exports = {
   importInvoiceLicences,
   importNaldBillHeaders,
   importNaldBillRuns
-};
+}

--- a/src/modules/bill-runs-import/plugin.js
+++ b/src/modules/bill-runs-import/plugin.js
@@ -1,21 +1,21 @@
-'use strict';
+'use strict'
 
-const routes = require('./routes');
-const importer = require('./lib/import');
-const constants = require('./lib/constants');
+const routes = require('./routes')
+const importer = require('./lib/import')
+const constants = require('./lib/constants')
 
 const plugin = {
   name: 'importBillRunData',
   dependencies: ['pgBoss'],
   register: async server => {
     // Register routes
-    server.route(routes);
+    server.route(routes)
 
     // Register PG boss job
-    await server.messageQueue.subscribe(constants.IMPORT_BILL_RUNS, {}, importer.importBillRuns);
+    await server.messageQueue.subscribe(constants.IMPORT_BILL_RUNS, {}, importer.importBillRuns)
   }
-};
+}
 
 module.exports = {
   plugin
-};
+}

--- a/src/modules/bill-runs-import/routes.js
+++ b/src/modules/bill-runs-import/routes.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 module.exports = [
   {
@@ -8,4 +8,4 @@ module.exports = [
     handler: controller.postImportBillRuns,
     path: '/import/1.0/bill-runs'
   }
-];
+]

--- a/src/modules/charging-import/controller.js
+++ b/src/modules/charging-import/controller.js
@@ -1,24 +1,24 @@
-'use strict';
+'use strict'
 
-const { partial } = require('lodash');
+const { partial } = require('lodash')
 
-const chargeVersionsJob = require('./jobs/charge-versions');
+const chargeVersionsJob = require('./jobs/charge-versions')
 
 const createPostHandler = async (createMessage, request) => {
-  await request.messageQueue.publish(createMessage());
+  await request.messageQueue.publish(createMessage())
 
   return {
     error: null
-  };
-};
+  }
+}
 
 /**
  * Run SQL queries to import charge versions / elements into
  * water service tables from NALD import tables
  * @return {Promise}
  */
-const postImportChargingData = partial(createPostHandler, chargeVersionsJob.createMessage);
+const postImportChargingData = partial(createPostHandler, chargeVersionsJob.createMessage)
 
 module.exports = {
   postImportChargingData
-};
+}

--- a/src/modules/charging-import/jobs/charge-versions.js
+++ b/src/modules/charging-import/jobs/charge-versions.js
@@ -1,26 +1,26 @@
-'use strict';
+'use strict'
 
 /**
  * @note: this can be removed following go live and migration to service
  */
 
-const job = require('../lib/job');
-const queryLoader = require('../lib/query-loader');
-const chargingQueries = require('../lib/queries/charging');
+const job = require('../lib/job')
+const queryLoader = require('../lib/query-loader')
+const chargingQueries = require('../lib/queries/charging')
 
-const jobName = 'import.charge-versions';
+const jobName = 'import.charge-versions'
 
-const createMessage = () => job.createMessage(jobName);
+const createMessage = () => job.createMessage(jobName)
 
 const handler = () => queryLoader.loadQueries('Import charge versions', [
   chargingQueries.importChargeVersions,
   chargingQueries.importChargeElements,
   chargingQueries.cleanupChargeElements,
   chargingQueries.cleanupChargeVersions
-]);
+])
 
 module.exports = {
   jobName,
   createMessage,
   handler
-};
+}

--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -1,18 +1,18 @@
-'use strict';
+'use strict'
 
 /**
  * @note: this needs to remain and should not be deleted
  */
 
-const job = require('../lib/job');
-const queryLoader = require('../lib/query-loader');
-const purposesQueries = require('../lib/queries/purposes');
-const returnVersionQueries = require('../lib/queries/return-versions');
-const financialAgreementTypeQueries = require('../lib/queries/financial-agreement-types');
+const job = require('../lib/job')
+const queryLoader = require('../lib/query-loader')
+const purposesQueries = require('../lib/queries/purposes')
+const returnVersionQueries = require('../lib/queries/return-versions')
+const financialAgreementTypeQueries = require('../lib/queries/financial-agreement-types')
 
-const jobName = 'import.charging-data';
+const jobName = 'import.charging-data'
 
-const createMessage = () => job.createMessage(jobName);
+const createMessage = () => job.createMessage(jobName)
 
 const handler = () => queryLoader.loadQueries('Import charging data', [
   financialAgreementTypeQueries.importFinancialAgreementTypes,
@@ -23,10 +23,10 @@ const handler = () => queryLoader.loadQueries('Import charging data', [
   returnVersionQueries.importReturnVersions,
   returnVersionQueries.importReturnRequirements,
   returnVersionQueries.importReturnRequirementPurposes
-]);
+])
 
 module.exports = {
   jobName,
   createMessage,
   handler
-};
+}

--- a/src/modules/charging-import/lib/import-charge-version-metadata.js
+++ b/src/modules/charging-import/lib/import-charge-version-metadata.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const { logger } = require('../../../logger');
-const chargeVersionImportService = require('../services/charge-version-metadata-import');
+const { logger } = require('../../../logger')
+const chargeVersionImportService = require('../services/charge-version-metadata-import')
 
 /**
  * Run SQL queries to import charge versions / elements into
@@ -10,17 +10,17 @@ const chargeVersionImportService = require('../services/charge-version-metadata-
  */
 const importChargeVersionMetadata = async () => {
   try {
-    logger.info('Starting charge version metadata import');
+    logger.info('Starting charge version metadata import')
 
-    await chargeVersionImportService.importChargeVersionMetadata();
+    await chargeVersionImportService.importChargeVersionMetadata()
 
-    logger.info('Charge version metadata import complete');
+    logger.info('Charge version metadata import complete')
   } catch (err) {
-    logger.error(err);
-    throw err;
+    logger.error(err)
+    throw err
   }
-};
+}
 
 module.exports = {
   importChargeVersionMetadata
-};
+}

--- a/src/modules/charging-import/lib/job.js
+++ b/src/modules/charging-import/lib/job.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
 const createMessage = jobName => ({
   name: jobName,
   options: {
     singletonKey: jobName
   }
-});
+})
 
 module.exports = {
   createMessage
-};
+}

--- a/src/modules/charging-import/lib/queries/charging.js
+++ b/src/modules/charging-import/lib/queries/charging.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const importChargeElements = `INSERT INTO water.charge_elements
 (charge_version_id, external_id, abstraction_period_start_day, abstraction_period_start_month,
@@ -92,7 +92,7 @@ time_limited_start_date=EXCLUDED.time_limited_start_date,
 time_limited_end_date=EXCLUDED.time_limited_end_date,
 description=EXCLUDED.description, 
 date_updated=EXCLUDED.date_updated,
-is_section_127_agreement_enabled=EXCLUDED.is_section_127_agreement_enabled;`;
+is_section_127_agreement_enabled=EXCLUDED.is_section_127_agreement_enabled;`
 
 // Deletes charge elements that are no longer present in the NALD import
 const cleanupChargeElements = `DELETE FROM water.charge_elements
@@ -106,7 +106,7 @@ WHERE charge_element_id IN (
     and nce."ID" is null 
     and t.billing_transaction_id is null
     and bv.billing_volume_id is null 
-);`;
+);`
 
 const insertChargeVersion = `
 insert into water.charge_versions
@@ -129,7 +129,7 @@ on conflict (external_id) do update set
   apportionment=EXCLUDED.apportionment,
   change_reason_id=EXCLUDED.change_reason_id,
   date_updated=NOW();
-`;
+`
 
 const importChargeVersions = `INSERT INTO water.charge_versions (licence_ref, scheme, external_id, version_number, start_date, status, apportionment,
 error, end_date, billed_upto_date, region_code, date_created, date_updated, source, invoice_account_id, company_id, licence_id, change_reason_id)
@@ -180,7 +180,7 @@ error=EXCLUDED.error, end_date=EXCLUDED.end_date,
 billed_upto_date=EXCLUDED.billed_upto_date,
 region_code=EXCLUDED.region_code, date_updated=EXCLUDED.date_updated,
 source=EXCLUDED.source, invoice_account_id=EXCLUDED.invoice_account_id, company_id=EXCLUDED.company_id,
-licence_Id=EXCLUDED.licence_id, change_reason_id=EXCLUDED.change_reason_id;`;
+licence_Id=EXCLUDED.licence_id, change_reason_id=EXCLUDED.change_reason_id;`
 
 // Deletes charge versions that are no longer present in the NALD import
 const cleanupChargeVersions = `
@@ -192,7 +192,7 @@ DELETE FROM water.charge_versions WHERE charge_version_id IN (
     where cv.source='nald'
       and cvm.external_id is null
     and billing_batch_charge_version_year_id is null
-);`;
+);`
 
 module.exports = {
   importChargeElements,
@@ -200,4 +200,4 @@ module.exports = {
   insertChargeVersion,
   importChargeVersions,
   cleanupChargeVersions
-};
+}

--- a/src/modules/charging-import/lib/queries/financial-agreement-types.js
+++ b/src/modules/charging-import/lib/queries/financial-agreement-types.js
@@ -9,8 +9,8 @@ DO
     description = excluded.description,
     disabled = excluded.disabled,
     date_updated = now();
-`;
+`
 
 module.exports = {
   importFinancialAgreementTypes
-};
+}

--- a/src/modules/charging-import/lib/queries/purposes.js
+++ b/src/modules/charging-import/lib/queries/purposes.js
@@ -1,16 +1,16 @@
-'use strict';
+'use strict'
 
 const importPrimaryPurposes = `insert into water.purposes_primary (legacy_id, description, date_created, date_updated)
   select p."CODE", p."DESCR", now(), now()
   from import."NALD_PURP_PRIMS" p on conflict (legacy_id) do update set
     description= excluded.description,
-    date_updated = now();`;
+    date_updated = now();`
 
 const importSecondaryPurposes = `
   insert into water.purposes_secondary (legacy_id, description, date_created, date_updated)
   select p."CODE", p."DESCR", now(), now()
   from import."NALD_PURP_SECS" p on conflict (legacy_id) do update set
-  description= excluded.description, date_updated = now();`;
+  description= excluded.description, date_updated = now();`
 
 const importUses = `insert into water.purposes_uses (
     legacy_id,
@@ -38,7 +38,7 @@ const importUses = `insert into water.purposes_uses (
     description= excluded.description,
     date_updated = now(),
     loss_factor = excluded.loss_factor,
-    is_two_part_tariff = excluded.is_two_part_tariff;`;
+    is_two_part_tariff = excluded.is_two_part_tariff;`
 
 const importValidPurposeCombinations = `INSERT INTO water.purposes as prps (purpose_primary_id, purpose_secondary_id, purpose_use_id, date_created)
 SELECT pp.purpose_primary_id,
@@ -49,11 +49,11 @@ FROM import."NALD_PURPOSES" as NALD_P
 JOIN water.purposes_primary as pp ON NALD_P."APPR_CODE" = pp."legacy_id"
 JOIN water.purposes_secondary as ps ON NALD_P."APSE_CODE" = ps."legacy_id"
 JOIN water.purposes_uses as pu ON NALD_P."APUS_CODE" = pu."legacy_id"
-WHERE NALD_P."DISABLED" = 'N' ON CONFLICT DO NOTHING;`;
+WHERE NALD_P."DISABLED" = 'N' ON CONFLICT DO NOTHING;`
 
 module.exports = {
   importPrimaryPurposes,
   importSecondaryPurposes,
   importUses,
   importValidPurposeCombinations
-};
+}

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const importReturnVersions = `insert into water.return_versions (licence_id, version_number, start_date, end_date, status, external_id, date_created, date_updated) select 
       l.licence_id, 
@@ -20,7 +20,7 @@ const importReturnVersions = `insert into water.return_versions (licence_id, ver
       end_date=excluded.end_date,
       status=excluded.status,
       date_updated=excluded.date_updated;
-`;
+`
 
 const importReturnRequirements = `insert into water.return_requirements  ( return_version_id, legacy_id,  abstraction_period_start_day, abstraction_period_start_month,
   abstraction_period_end_day,
@@ -64,7 +64,7 @@ const importReturnRequirements = `insert into water.return_requirements  ( retur
   is_summer=excluded.is_summer,
   is_upload=excluded.is_upload,
   returns_frequency=excluded.returns_frequency,
-  date_updated=excluded.date_updated;`;
+  date_updated=excluded.date_updated;`
 
 const importReturnRequirementPurposes = `insert into water.return_requirement_purposes (
   return_requirement_id,
@@ -87,10 +87,10 @@ join water.purposes_primary p on nrp."APUR_APPR_CODE"=p.legacy_id
 join water.purposes_secondary s on nrp."APUR_APSE_CODE"=s.legacy_id
 join water.purposes_uses u on nrp."APUR_APUS_CODE"=u.legacy_id
 join water.return_requirements r on r.external_id = concat_ws(':', nrp."FGAC_REGION_CODE", nrp."ARTY_ID") on conflict(external_id) do update set  purpose_alias=excluded.purpose_alias, date_updated=excluded.date_updated;
-`;
+`
 
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
   importReturnRequirementPurposes
-};
+}

--- a/src/modules/charging-import/lib/query-loader.js
+++ b/src/modules/charging-import/lib/query-loader.js
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../../../lib/connectors/db');
-const { logger } = require('../../../logger');
-const slack = require('../../../lib/slack');
+const { pool } = require('../../../lib/connectors/db')
+const { logger } = require('../../../logger')
+const slack = require('../../../lib/slack')
 
 const log = msg => {
-  logger.info(msg);
-  slack.post(msg);
-};
+  logger.info(msg)
+  slack.post(msg)
+}
 
 /**
  * Generic means of running a sequence of queries in series,
@@ -19,20 +19,20 @@ const log = msg => {
  */
 const loadQueries = async (name, queries) => {
   try {
-    log(`Starting ${name}`);
+    log(`Starting ${name}`)
 
     for (const index in queries) {
-      log(`Running ${name} query ${parseInt(index) + 1} of ${queries.length}`);
-      await pool.query(queries[index]);
+      log(`Running ${name} query ${parseInt(index) + 1} of ${queries.length}`)
+      await pool.query(queries[index])
     }
 
-    log(`Finished ${name}`);
+    log(`Finished ${name}`)
   } catch (err) {
-    log(`Error: ${err.message}`);
-    throw err;
+    log(`Error: ${err.message}`)
+    throw err
   }
-};
+}
 
 module.exports = {
   loadQueries
-};
+}

--- a/src/modules/charging-import/plugin.js
+++ b/src/modules/charging-import/plugin.js
@@ -1,30 +1,30 @@
-'use strict';
+'use strict'
 
-const cron = require('node-cron');
+const cron = require('node-cron')
 
-const chargeVersionsJob = require('./jobs/charge-versions');
-const chargingDataJob = require('./jobs/charging-data');
+const chargeVersionsJob = require('./jobs/charge-versions')
+const chargingDataJob = require('./jobs/charging-data')
 
-const { createRegister } = require('../../lib/plugin');
-const config = require('../../../config');
+const { createRegister } = require('../../lib/plugin')
+const config = require('../../../config')
 
 const registerSubscribers = async server => {
   // Register handlers
-  await server.messageQueue.subscribe(chargeVersionsJob.jobName, chargeVersionsJob.handler);
-  await server.messageQueue.subscribe(chargingDataJob.jobName, chargingDataJob.handler);
+  await server.messageQueue.subscribe(chargeVersionsJob.jobName, chargeVersionsJob.handler)
+  await server.messageQueue.subscribe(chargingDataJob.jobName, chargingDataJob.handler)
 
   // Set up import of charge data on cron job
   cron.schedule(config.import.charging.schedule,
     () => server.messageQueue.publish(chargingDataJob.createMessage())
-  );
-};
+  )
+}
 
 const plugin = {
   name: 'importChargingData',
   dependencies: ['pgBoss'],
   register: server => createRegister(server, registerSubscribers)
-};
+}
 
 module.exports = {
   plugin
-};
+}

--- a/src/modules/charging-import/routes.js
+++ b/src/modules/charging-import/routes.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 module.exports = [
   {
@@ -8,4 +8,4 @@ module.exports = [
     handler: controller.postImportChargingData,
     path: '/import/1.0/charging'
   }
-];
+]

--- a/src/modules/core/controller.js
+++ b/src/modules/core/controller.js
@@ -1,10 +1,10 @@
-const pkg = require('../../../package.json');
-const { pick } = require('lodash');
+const pkg = require('../../../package.json')
+const { pick } = require('lodash')
 
-const statusResponse = pick(pkg, 'version');
+const statusResponse = pick(pkg, 'version')
 
-const getStatus = () => statusResponse;
+const getStatus = () => statusResponse
 
 module.exports = {
   getStatus
-};
+}

--- a/src/modules/core/jobs/import-tracker.js
+++ b/src/modules/core/jobs/import-tracker.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-const { logger } = require('../../../logger');
-const JOB_NAME = 'import.tracker';
-const PREPROD = 'preprod';
-const PRODUCTION = 'production';
-const slack = require('../../../lib/slack');
-const jobsConnector = require('../../../lib/connectors/water-import/jobs');
-const notifyService = require('../../../lib/services/notify');
+const { logger } = require('../../../logger')
+const JOB_NAME = 'import.tracker'
+const PREPROD = 'preprod'
+const PRODUCTION = 'production'
+const slack = require('../../../lib/slack')
+const jobsConnector = require('../../../lib/connectors/water-import/jobs')
+const notifyService = require('../../../lib/services/notify')
 
 const createMessage = () => ({
   name: JOB_NAME,
   options: {
     singletonKey: JOB_NAME
   }
-});
+})
 
 /**
  * Imports a single licence
@@ -21,32 +21,32 @@ const createMessage = () => ({
  * @param {String} job.data.licenceNumber
  */
 const handler = async job => {
-  logger.info(`Handling job: ${job.name}`);
+  logger.info(`Handling job: ${job.name}`)
 
   try {
-    const jobs = await jobsConnector.getFailedJobs();
+    const jobs = await jobsConnector.getFailedJobs()
     // if there are any jobs that have failed in the last 12 hours
     if (jobs.length > 0) {
-      const subTitle = jobs.length > 1 ? `There are ${jobs.length} failed import jobs in the` : 'There is 1 failed import job in the';
+      const subTitle = jobs.length > 1 ? `There are ${jobs.length} failed import jobs in the` : 'There is 1 failed import job in the'
       const content = `${subTitle} ${process.env.NODE_ENV} environment.\n\n` +
       jobs.reduce((acc, row) => {
-        acc = acc + `Job Name: ${row.jobName} \nTotal Errors: ${row.total} \nDate created: ${row.dateCreated} \nDate completed: ${row.dateCompleted}\n\n`;
-        return acc;
-      }, '');
-      const environment = process.env.NODE_ENV;
+        acc = acc + `Job Name: ${row.jobName} \nTotal Errors: ${row.total} \nDate created: ${row.dateCreated} \nDate completed: ${row.dateCompleted}\n\n`
+        return acc
+      }, '')
+      const environment = process.env.NODE_ENV
       if (environment === PRODUCTION || environment === PREPROD) {
-        notifyService.sendEmail(process.env.WATER_SERVICE_MAILBOX, 'service_status_alert', { content });
+        notifyService.sendEmail(process.env.WATER_SERVICE_MAILBOX, 'service_status_alert', { content })
       }
-      slack.post(content);
+      slack.post(content)
     }
   } catch (err) {
-    logger.error(`Error handling job ${job.name}`, err);
-    throw err;
+    logger.error(`Error handling job ${job.name}`, err)
+    throw err
   }
-};
+}
 
 module.exports = {
   createMessage,
   handler,
   jobName: JOB_NAME
-};
+}

--- a/src/modules/core/plugin.js
+++ b/src/modules/core/plugin.js
@@ -1,42 +1,42 @@
-'use strict';
+'use strict'
 
-const cron = require('node-cron');
-const config = require('../../../config');
-const importTrackerJob = require('./jobs/import-tracker');
-const moment = require('moment');
+const cron = require('node-cron')
+const config = require('../../../config')
+const importTrackerJob = require('./jobs/import-tracker')
+const moment = require('moment')
 
-const getSchedule = () => config.isProduction ? '0 10 * * 1,2,3,4,5' : '0 15 * * 1,2,3,4,5';
+const getSchedule = () => config.isProduction ? '0 10 * * 1,2,3,4,5' : '0 15 * * 1,2,3,4,5'
 
 const publishJob = messageQueue => {
-  const timeStamp = moment().toISOString();
-  messageQueue.publish(importTrackerJob.createMessage(timeStamp));
-};
+  const timeStamp = moment().toISOString()
+  messageQueue.publish(importTrackerJob.createMessage(timeStamp))
+}
 
 const subscribe = async (server, job) => {
-  const { jobName, handler, options = {} } = job;
+  const { jobName, handler, options = {} } = job
 
-  await server.messageQueue.subscribe(jobName, options, handler);
+  await server.messageQueue.subscribe(jobName, options, handler)
 
   if (job.onCompleteHandler) {
-    await server.messageQueue.onComplete(jobName, executedJob => job.onCompleteHandler(executedJob, server.messageQueue));
+    await server.messageQueue.onComplete(jobName, executedJob => job.onCompleteHandler(executedJob, server.messageQueue))
   }
-};
+}
 
 const registerSubscribers = async server => {
-  await subscribe(server, importTrackerJob);
+  await subscribe(server, importTrackerJob)
 
   // Schedule the import process every day at 10am / 3pm depending on environment
   if (process.env.NODE_ENV !== 'test') {
-    cron.schedule(getSchedule(), () => publishJob(server.messageQueue));
+    cron.schedule(getSchedule(), () => publishJob(server.messageQueue))
   }
-};
+}
 
 const plugin = {
   name: 'importTracker',
   dependencies: ['pgBoss'],
   register: registerSubscribers
-};
+}
 
 module.exports = {
   plugin
-};
+}

--- a/src/modules/core/routes.js
+++ b/src/modules/core/routes.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 const status = {
   method: 'GET',
@@ -10,7 +10,7 @@ const status = {
     description: 'Checks if the service is alive'
   },
   path: '/status'
-};
+}
 
 const testing = {
   method: 'GET',
@@ -20,6 +20,6 @@ const testing = {
     description: 'For testing etl path mapping'
   },
   path: '/etl/testing'
-};
+}
 
-module.exports = [status, testing];
+module.exports = [status, testing]

--- a/src/modules/jobs/controller.js
+++ b/src/modules/jobs/controller.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const jobsConnector = require('../../lib/connectors/water-import/jobs');
+const jobsConnector = require('../../lib/connectors/water-import/jobs')
 
-const getJobSummary = () => jobsConnector.getJobSummary();
+const getJobSummary = () => jobsConnector.getJobSummary()
 
 module.exports = {
   getJobSummary
-};
+}

--- a/src/modules/jobs/routes.js
+++ b/src/modules/jobs/routes.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 const getJobSummary = {
   method: 'GET',
   path: '/import/1.0/jobs/summary',
   handler: controller.getJobSummary
-};
+}
 
-module.exports = [getJobSummary];
+module.exports = [getJobSummary]

--- a/src/modules/licence-import/connectors/documents.js
+++ b/src/modules/licence-import/connectors/documents.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../../../lib/connectors/db');
-const queries = require('./queries/documents');
+const { pool } = require('../../../lib/connectors/db')
+const queries = require('./queries/documents')
 
 /**
  * Mark any documents in crm_v2.documents as deleted if the licence
  * numbers no longer exist in import.NALD_ABS_LICENCES
  */
-const deleteRemovedDocuments = () => pool.query(queries.deleteCrmV2Documents);
+const deleteRemovedDocuments = () => pool.query(queries.deleteCrmV2Documents)
 
 module.exports = {
   deleteRemovedDocuments
-};
+}

--- a/src/modules/licence-import/connectors/import-companies.js
+++ b/src/modules/licence-import/connectors/import-companies.js
@@ -1,12 +1,12 @@
-const queries = require('./queries/import-companies');
-const { pool } = require('../../../lib/connectors/db');
+const queries = require('./queries/import-companies')
+const { pool } = require('../../../lib/connectors/db')
 
 /**
  * Clear the water_import.import_companies table ready for a new import
  * @return {Promise}
  */
 const clear = () =>
-  pool.query(queries.clear);
+  pool.query(queries.clear)
 
 /**
  * Initialise the water_import.import_companies table by copying a list
@@ -14,9 +14,9 @@ const clear = () =>
  * @return {Promise}
  */
 const initialise = async () => {
-  const { rows } = await pool.query(queries.initialise);
-  return rows;
-};
+  const { rows } = await pool.query(queries.initialise)
+  return rows
+}
 
 /**
  * Sets the specified party as imported in the water_import.import_companies table
@@ -25,20 +25,20 @@ const initialise = async () => {
  * @return {Promise}
  */
 const setImportedStatus = (regionCode, partyId) =>
-  pool.query(queries.setImportedStatus, [regionCode, partyId]);
+  pool.query(queries.setImportedStatus, [regionCode, partyId])
 
 /**
  * Gets the number of parties which still need importing as companies
  * @return {Promise<Number>}
  */
 const getPendingCount = async () => {
-  const { rows: [{ count }] } = await pool.query(queries.getPendingCount);
-  return parseInt(count);
-};
+  const { rows: [{ count }] } = await pool.query(queries.getPendingCount)
+  return parseInt(count)
+}
 
 module.exports = {
   clear,
   initialise,
   setImportedStatus,
   getPendingCount
-};
+}

--- a/src/modules/licence-import/connectors/purpose-conditions-types.js
+++ b/src/modules/licence-import/connectors/purpose-conditions-types.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../../../lib/connectors/db');
-const queries = require('./queries/purpose-condition-types');
+const { pool } = require('../../../lib/connectors/db')
+const queries = require('./queries/purpose-condition-types')
 
 /**
  * Create purpose condition types
  * If they exist update the existing records
  */
-const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes);
+const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes)
 
 module.exports = {
   createPurposeConditionTypes
-};
+}

--- a/src/modules/licence-import/connectors/queries/documents.js
+++ b/src/modules/licence-import/connectors/queries/documents.js
@@ -8,8 +8,8 @@ const deleteCrmV2Documents = `
   and date_deleted is null
   and regime = 'water'
   and document_type = 'abstraction_licence';
-`;
+`
 
 module.exports = {
   deleteCrmV2Documents
-};
+}

--- a/src/modules/licence-import/connectors/queries/import-companies.js
+++ b/src/modules/licence-import/connectors/queries/import-companies.js
@@ -1,17 +1,17 @@
-const clear = 'DELETE FROM water_import.import_companies;';
+const clear = 'DELETE FROM water_import.import_companies;'
 
 const initialise = `INSERT INTO water_import.import_companies 
 (region_code, party_id, date_created, date_updated)
 SELECT p."FGAC_REGION_CODE"::integer, p."ID"::integer, NOW(), NOW()
-FROM import."NALD_PARTIES" p ON CONFLICT (region_code, party_id) DO NOTHING RETURNING *;`;
+FROM import."NALD_PARTIES" p ON CONFLICT (region_code, party_id) DO NOTHING RETURNING *;`
 
-const setImportedStatus = 'UPDATE water_import.import_companies  SET imported=true, date_updated=NOW() WHERE region_code=$1 AND party_id=$2;';
+const setImportedStatus = 'UPDATE water_import.import_companies  SET imported=true, date_updated=NOW() WHERE region_code=$1 AND party_id=$2;'
 
-const getPendingCount = 'SELECT COUNT(*) FROM water_import.import_companies WHERE imported=false;';
+const getPendingCount = 'SELECT COUNT(*) FROM water_import.import_companies WHERE imported=false;'
 
 module.exports = {
   clear,
   initialise,
   setImportedStatus,
   getPendingCount
-};
+}

--- a/src/modules/licence-import/connectors/queries/purpose-condition-types.js
+++ b/src/modules/licence-import/connectors/queries/purpose-condition-types.js
@@ -13,8 +13,8 @@ INSERT INTO water.licence_version_purpose_condition_types (
     description = excluded.description,
     subcode_description = excluded.subcode_description,
     date_updated = now();
-`;
+`
 
 module.exports = {
   createPurposeConditionTypes
-};
+}

--- a/src/modules/licence-import/controller.js
+++ b/src/modules/licence-import/controller.js
@@ -1,50 +1,50 @@
-'use strict';
+'use strict'
 
 /**
  * @module request handlers to import all companies/licences, or selected licence or company.
  * Not used by the system (these jobs are kicked off by cron), these are used for test only.
  */
 
-const { partialRight } = require('lodash');
+const { partialRight } = require('lodash')
 
-const jobs = require('./jobs');
-const { logger } = require('../../logger');
-const Boom = require('@hapi/boom');
+const jobs = require('./jobs')
+const { logger } = require('../../logger')
+const Boom = require('@hapi/boom')
 
 const postImportHandler = async (request, h, jobCreator, errorMessage) => {
   try {
-    await request.messageQueue.publish(jobCreator(request));
-    return h.response({ error: null }).code(202);
+    await request.messageQueue.publish(jobCreator(request))
+    return h.response({ error: null }).code(202)
   } catch (err) {
-    logger.error(errorMessage, request.query);
-    return Boom.badImplementation(errorMessage);
+    logger.error(errorMessage, request.query)
+    return Boom.badImplementation(errorMessage)
   };
-};
+}
 
-const createImportJob = () => jobs.deleteDocuments();
-const createImportCompanyJob = request => jobs.importCompany(request.query.regionCode, request.query.partyId);
-const createImportLicenceJob = request => jobs.importLicence(request.query.licenceNumber);
+const createImportJob = () => jobs.deleteDocuments()
+const createImportCompanyJob = request => jobs.importCompany(request.query.regionCode, request.query.partyId)
+const createImportLicenceJob = request => jobs.importLicence(request.query.licenceNumber)
 
 /**
  * Import all companies/licences
  */
-const postImport = partialRight(postImportHandler, createImportJob, 'Error importing companies');
+const postImport = partialRight(postImportHandler, createImportJob, 'Error importing companies')
 
 /**
  * Import single licence
  * @param {String} request.query.licenceNumber
  */
-const postImportLicence = partialRight(postImportHandler, createImportLicenceJob, 'Error importing licence');
+const postImportLicence = partialRight(postImportHandler, createImportLicenceJob, 'Error importing licence')
 
 /**
  * Import single company
  * @param {Number} request.query.regionCode
  * @param {Number} request.query.partyId
  */
-const postImportCompany = partialRight(postImportHandler, createImportCompanyJob, 'Error importing company');
+const postImportCompany = partialRight(postImportHandler, createImportCompanyJob, 'Error importing company')
 
 module.exports = {
   postImport,
   postImportLicence,
   postImportCompany
-};
+}

--- a/src/modules/licence-import/extract/connectors/index.js
+++ b/src/modules/licence-import/extract/connectors/index.js
@@ -1,66 +1,66 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../../../../lib/connectors/db');
-const queries = require('./queries');
+const { pool } = require('../../../../lib/connectors/db')
+const queries = require('./queries')
 
 const findOne = async (query, params) => {
-  const { rows: [row] } = await pool.query(query, params);
-  return row;
-};
+  const { rows: [row] } = await pool.query(query, params)
+  return row
+}
 
 const findMany = async (query, params) => {
-  const { rows } = await pool.query(query, params);
-  return rows;
-};
+  const { rows } = await pool.query(query, params)
+  return rows
+}
 
 const getLicence = licenceNumber =>
-  findOne(queries.getLicence, [licenceNumber]);
+  findOne(queries.getLicence, [licenceNumber])
 
 const getLicenceVersions = (regionCode, licenceId) =>
-  findMany(queries.getLicenceVersions, [regionCode, licenceId]);
+  findMany(queries.getLicenceVersions, [regionCode, licenceId])
 
-const getAllParties = () => findMany(queries.getAllParties);
+const getAllParties = () => findMany(queries.getAllParties)
 
-const getAllAddresses = () => findMany(queries.getAllAddresses);
+const getAllAddresses = () => findMany(queries.getAllAddresses)
 
 const getChargeVersions = (regionCode, licenceId) =>
-  findMany(queries.getChargeVersions, [regionCode, licenceId]);
+  findMany(queries.getChargeVersions, [regionCode, licenceId])
 
 const getTwoPartTariffAgreements = (regionCode, licenceId) =>
-  findMany(queries.getTwoPartTariffAgreements, [regionCode, licenceId]);
+  findMany(queries.getTwoPartTariffAgreements, [regionCode, licenceId])
 
 const getSection130Agreements = (regionCode, licenceId) =>
-  findMany(queries.getSection130Agreements, [regionCode, licenceId]);
+  findMany(queries.getSection130Agreements, [regionCode, licenceId])
 
 const getInvoiceAccounts = (regionCode, partyId) =>
-  findMany(queries.getInvoiceAccounts, [regionCode, partyId]);
+  findMany(queries.getInvoiceAccounts, [regionCode, partyId])
 
 const getPartyLicenceVersions = (regionCode, partyId) =>
-  findMany(queries.getPartyLicenceVersions, [regionCode, partyId]);
+  findMany(queries.getPartyLicenceVersions, [regionCode, partyId])
 
 const getParties = (regionCode, partyIds = []) =>
-  findMany(queries.getParties, [regionCode, partyIds.join(',')]);
+  findMany(queries.getParties, [regionCode, partyIds.join(',')])
 
 const getAddresses = (regionCode, addressIds = []) =>
-  findMany(queries.getAddresses, [regionCode, addressIds.join(',')]);
+  findMany(queries.getAddresses, [regionCode, addressIds.join(',')])
 
 const getAllLicenceNumbers = () =>
-  findMany(queries.getAllLicenceNumbers);
+  findMany(queries.getAllLicenceNumbers)
 
 const getParty = (regionCode, partyId) =>
-  findOne(queries.getParty, [regionCode, partyId]);
+  findOne(queries.getParty, [regionCode, partyId])
 
 const getLicencePurposes = (regionCode, licenceId) =>
-  findMany(queries.getLicencePurposes, [regionCode, licenceId]);
+  findMany(queries.getLicencePurposes, [regionCode, licenceId])
 
 const getPurposeConditions = (regionCode, purposeId) =>
-  findMany(queries.getPurposeConditions, [regionCode, purposeId]);
+  findMany(queries.getPurposeConditions, [regionCode, purposeId])
 
 const getLicenceRoles = (regionCode, licenceId) =>
-  findMany(queries.getLicenceRoles, [regionCode, licenceId]);
+  findMany(queries.getLicenceRoles, [regionCode, licenceId])
 
 const getPartyLicenceRoles = (regionCode, partyId) =>
-  findMany(queries.getPartyLicenceRoles, [regionCode, partyId]);
+  findMany(queries.getPartyLicenceRoles, [regionCode, partyId])
 
 module.exports = {
   getPurposeConditions,
@@ -80,4 +80,4 @@ module.exports = {
   getTwoPartTariffAgreements,
   getLicenceRoles,
   getPartyLicenceRoles
-};
+}

--- a/src/modules/licence-import/extract/connectors/queries.js
+++ b/src/modules/licence-import/extract/connectors/queries.js
@@ -2,7 +2,7 @@ const getLicence = `
   SELECT *
   FROM import."NALD_ABS_LICENCES" l
   WHERE l."LIC_NO"=$1;
-`;
+`
 
 const getLicenceVersions = `
   SELECT *
@@ -10,7 +10,7 @@ const getLicenceVersions = `
   WHERE v."FGAC_REGION_CODE"=$1
   AND v."AABL_ID"=$2
   AND v."STATUS"<>'DRAFT';
-`;
+`
 
 const getLicencePurposes = `
   select purposes.*
@@ -22,7 +22,7 @@ const getLicencePurposes = `
       and versions."FGAC_REGION_CODE" = purposes."FGAC_REGION_CODE"
   where versions."FGAC_REGION_CODE" = $1
   and versions."AABL_ID" = $2;
-`;
+`
 
 const getPurposeConditions = `
 select conditions.*
@@ -37,19 +37,19 @@ from import."NALD_ABS_LIC_VERSIONS" versions
   and purposes."ID" = conditions."AABP_ID"
 where versions."FGAC_REGION_CODE" = $1
 and versions."AABL_ID" = $2
-`;
+`
 
 const getParty = `SELECT * FROM import."NALD_PARTIES" p
   WHERE p."FGAC_REGION_CODE"=$1
-  AND p."ID" = $2`;
+  AND p."ID" = $2`
 
 const getAddress = `SELECT * FROM import."NALD_ADDRESSES" a
   WHERE a."FGAC_REGION_CODE"=$1
-  AND a."ID" = $2`;
+  AND a."ID" = $2`
 
-const getAllAddresses = 'SELECT * FROM import."NALD_ADDRESSES"';
+const getAllAddresses = 'SELECT * FROM import."NALD_ADDRESSES"'
 
-const getAllParties = 'SELECT "FGAC_REGION_CODE", "ID" FROM import."NALD_PARTIES"';
+const getAllParties = 'SELECT "FGAC_REGION_CODE", "ID" FROM import."NALD_PARTIES"'
 
 const getChargeVersions = `
   SELECT *
@@ -62,7 +62,7 @@ const getChargeVersions = `
     AND cv."AABL_ID"=$2 AND cv."STATUS"<>'DRAFT'
     AND ia."IAS_XFER_DATE"<>'null'
   ORDER BY cv."VERS_NO"::integer;
-`;
+`
 
 const getTwoPartTariffAgreements = `
 SELECT 
@@ -94,7 +94,7 @@ WHERE
     group by ncv."FGAC_REGION_CODE", ncv."AABL_ID", ncv."EFF_ST_DATE"
   )
 ORDER BY cv."VERS_NO"::integer;
-`;
+`
 
 const getSection130Agreements = `SELECT * FROM import."NALD_LH_AGRMNTS" ag
 JOIN (
@@ -103,7 +103,7 @@ JOIN (
   WHERE cv."FGAC_REGION_CODE"=$1 AND cv."AABL_ID"=$2 AND cv."STATUS"<>'DRAFT'
 ) cv ON ag."FGAC_REGION_CODE"=cv."FGAC_REGION_CODE" AND ag."ALHA_ACC_NO"=cv."AIIA_ALHA_ACC_NO"
 AND ag."AFSA_CODE" IN ('S127', 'S130S', 'S130T', 'S130U', 'S130W')
-`;
+`
 
 const getInvoiceAccounts = `
 select a."ACON_APAR_ID" AS licence_holder_party_id, p."NAME" AS licence_holder_party_name,
@@ -129,36 +129,36 @@ where
   i."IAS_XFER_DATE"<>'null'
   and a."FGAC_REGION_CODE"=$1
   and a."ACON_APAR_ID"=$2
-`;
+`
 
 const getPartyLicenceVersions = `SELECT lv.*, l."REV_DATE", l."LAPSED_DATE", l."EXPIRY_DATE" FROM import."NALD_ABS_LIC_VERSIONS" lv
 JOIN import."NALD_ABS_LICENCES" l ON lv."AABL_ID"=l."ID" AND lv."FGAC_REGION_CODE"=l."FGAC_REGION_CODE"
 WHERE lv."FGAC_REGION_CODE"=$1 AND lv."ACON_APAR_ID"=$2
-AND lv."STATUS"<>'DRAFT'`;
+AND lv."STATUS"<>'DRAFT'`
 
 const getParties = `SELECT * FROM import."NALD_PARTIES" p
 WHERE p."FGAC_REGION_CODE"=$1
-AND p."ID" =  any (string_to_array($2, ',')::text[])`;
+AND p."ID" =  any (string_to_array($2, ',')::text[])`
 
 const getAddresses = `SELECT * FROM import."NALD_ADDRESSES" a
 WHERE a."FGAC_REGION_CODE"=$1
-AND a."ID" =  any (string_to_array($2, ',')::text[])`;
+AND a."ID" =  any (string_to_array($2, ',')::text[])`
 
 const getAllLicenceNumbers = `
   SELECT l."LIC_NO"
   FROM import."NALD_ABS_LICENCES" l;
-`;
+`
 
 const getLicenceRoles = `
 select * from import."NALD_LIC_ROLES" r
 where r."FGAC_REGION_CODE"=$1 and r."AABL_ID"=$2
 order by to_date(r."EFF_ST_DATE", 'DD/MM/YYYY')
-`;
+`
 
 const getPartyLicenceRoles = `
 select * from import."NALD_LIC_ROLES" r
   where r."FGAC_REGION_CODE"=$1 and r."ACON_APAR_ID"=$2
-`;
+`
 
 module.exports = {
   getLicence,
@@ -179,4 +179,4 @@ module.exports = {
   getAllLicenceNumbers,
   getLicenceRoles,
   getPartyLicenceRoles
-};
+}

--- a/src/modules/licence-import/extract/index.js
+++ b/src/modules/licence-import/extract/index.js
@@ -1,26 +1,26 @@
-'use strict';
-const { flatMap, uniq } = require('lodash');
+'use strict'
+const { flatMap, uniq } = require('lodash')
 
-const importConnector = require('./connectors');
+const importConnector = require('./connectors')
 
 const getIds = (idProperty, ...args) => {
-  const ids = flatMap(args).map(row => row[idProperty]);
-  return uniq(ids);
-};
+  const ids = flatMap(args).map(row => row[idProperty])
+  return uniq(ids)
+}
 
 const getLicenceParties = (regionCode, versions, chargeVersions, roles) => {
-  const partyIds = getIds('ACON_APAR_ID', versions, chargeVersions, roles);
-  return importConnector.getParties(regionCode, partyIds);
-};
+  const partyIds = getIds('ACON_APAR_ID', versions, chargeVersions, roles)
+  return importConnector.getParties(regionCode, partyIds)
+}
 
 const getLicenceAddresses = (regionCode, versions, chargeVersions, roles) => {
-  const addressIds = getIds('ACON_AADD_ID', versions, chargeVersions, roles);
-  return importConnector.getAddresses(regionCode, addressIds);
-};
+  const addressIds = getIds('ACON_AADD_ID', versions, chargeVersions, roles)
+  return importConnector.getAddresses(regionCode, addressIds)
+}
 
 const getLicenceData = async licenceNumber => {
-  const licence = await importConnector.getLicence(licenceNumber);
-  const { ID: id, FGAC_REGION_CODE: regionCode } = licence;
+  const licence = await importConnector.getLicence(licenceNumber)
+  const { ID: id, FGAC_REGION_CODE: regionCode } = licence
 
   const [versions, chargeVersions, tptAgreements, section130Agreements, purposes, conditions, roles] = await Promise.all([
     importConnector.getLicenceVersions(regionCode, id),
@@ -30,12 +30,12 @@ const getLicenceData = async licenceNumber => {
     importConnector.getLicencePurposes(regionCode, id),
     importConnector.getPurposeConditions(regionCode, id),
     importConnector.getLicenceRoles(regionCode, id)
-  ]);
+  ])
 
   const [parties, addresses] = await Promise.all([
     getLicenceParties(regionCode, versions, chargeVersions, roles),
     getLicenceAddresses(regionCode, versions, chargeVersions, roles)
-  ]);
+  ])
 
   return {
     addresses,
@@ -48,13 +48,13 @@ const getLicenceData = async licenceNumber => {
     tptAgreements,
     versions,
     roles
-  };
-};
+  }
+}
 
 const getCompanyAddresses = (regionCode, ...args) => {
-  const addressIds = flatMap(args).map(row => row.ACON_AADD_ID);
-  return importConnector.getAddresses(regionCode, uniq(addressIds));
-};
+  const addressIds = flatMap(args).map(row => row.ACON_AADD_ID)
+  return importConnector.getAddresses(regionCode, uniq(addressIds))
+}
 
 const getCompanyData = async (regionCode, partyId) => {
   const [party, invoiceAccounts, licenceVersions, licenceRoles] = await Promise.all([
@@ -62,9 +62,9 @@ const getCompanyData = async (regionCode, partyId) => {
     importConnector.getInvoiceAccounts(regionCode, partyId),
     importConnector.getPartyLicenceVersions(regionCode, partyId),
     importConnector.getPartyLicenceRoles(regionCode, partyId)
-  ]);
+  ])
 
-  const addresses = await getCompanyAddresses(regionCode, licenceVersions, invoiceAccounts, licenceRoles);
+  const addresses = await getCompanyAddresses(regionCode, licenceVersions, invoiceAccounts, licenceRoles)
 
   return {
     party,
@@ -72,12 +72,12 @@ const getCompanyData = async (regionCode, partyId) => {
     invoiceAccounts,
     licenceVersions,
     licenceRoles
-  };
-};
+  }
+}
 
 module.exports = {
   getLicenceData,
   getCompanyData,
   getAllParties: importConnector.getAllParties,
   getAllLicenceNumbers: importConnector.getAllLicenceNumbers
-};
+}

--- a/src/modules/licence-import/handlers/delete-documents.js
+++ b/src/modules/licence-import/handlers/delete-documents.js
@@ -1,12 +1,12 @@
-const { logger } = require('../../../logger');
-const documentsConnector = require('../connectors/documents');
+const { logger } = require('../../../logger')
+const documentsConnector = require('../connectors/documents')
 
 module.exports = async job => {
   try {
-    logger.info('Deleting removed documents');
-    return documentsConnector.deleteRemovedDocuments();
+    logger.info('Deleting removed documents')
+    return documentsConnector.deleteRemovedDocuments()
   } catch (err) {
-    logger.error('Failed to delete removed documents', err);
-    throw err;
+    logger.error('Failed to delete removed documents', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/import-companies.js
+++ b/src/modules/licence-import/handlers/import-companies.js
@@ -1,19 +1,19 @@
-const { logger } = require('../../../logger');
-const importCompanies = require('../connectors/import-companies');
+const { logger } = require('../../../logger')
+const importCompanies = require('../connectors/import-companies')
 
 const mapRow = row => ({
   regionCode: parseInt(row.region_code),
   partyId: parseInt(row.party_id)
-});
+})
 
 module.exports = async job => {
   try {
-    logger.info('Import companies');
-    await importCompanies.clear();
-    const data = await importCompanies.initialise();
-    return data.map(mapRow);
+    logger.info('Import companies')
+    await importCompanies.clear()
+    const data = await importCompanies.initialise()
+    return data.map(mapRow)
   } catch (err) {
-    logger.error('Import companies error', err);
-    throw err;
+    logger.error('Import companies error', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/import-company.js
+++ b/src/modules/licence-import/handlers/import-company.js
@@ -1,28 +1,28 @@
-'use strict';
+'use strict'
 
-const extract = require('../extract');
-const transform = require('../transform');
-const load = require('../load');
-const { logger } = require('../../../logger');
-const importCompanies = require('../connectors/import-companies');
+const extract = require('../extract')
+const transform = require('../transform')
+const load = require('../load')
+const { logger } = require('../../../logger')
+const importCompanies = require('../connectors/import-companies')
 
 module.exports = async job => {
   try {
-    const { regionCode, partyId } = job.data;
-    logger.info(`Import company ${regionCode} ${partyId}`);
+    const { regionCode, partyId } = job.data
+    logger.info(`Import company ${regionCode} ${partyId}`)
 
     // Extract data
-    const data = await extract.getCompanyData(regionCode, partyId);
+    const data = await extract.getCompanyData(regionCode, partyId)
 
     // Transform to new structure
-    const mapped = transform.company.transformCompany(data);
+    const mapped = transform.company.transformCompany(data)
 
     // Load to CRM database
-    await load.company.loadCompany(mapped);
+    await load.company.loadCompany(mapped)
 
-    await importCompanies.setImportedStatus(regionCode, partyId);
+    await importCompanies.setImportedStatus(regionCode, partyId)
   } catch (err) {
-    logger.error('Import company error', err);
-    throw err;
+    logger.error('Import company error', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/import-licence.js
+++ b/src/modules/licence-import/handlers/import-licence.js
@@ -1,22 +1,22 @@
-const extract = require('../extract');
-const transform = require('../transform');
-const load = require('../load');
-const { logger } = require('../../../logger');
+const extract = require('../extract')
+const transform = require('../transform')
+const load = require('../load')
+const { logger } = require('../../../logger')
 
 module.exports = async job => {
   try {
-    logger.info(`Import licence ${job.data.licenceNumber}`);
+    logger.info(`Import licence ${job.data.licenceNumber}`)
 
     // Extract data
-    const data = await extract.getLicenceData(job.data.licenceNumber);
+    const data = await extract.getLicenceData(job.data.licenceNumber)
 
     // Transform to new structure
-    const mapped = transform.licence.transformLicence(data);
+    const mapped = transform.licence.transformLicence(data)
 
     // Load licence to DB
-    await load.licence.loadLicence(mapped);
+    await load.licence.loadLicence(mapped)
   } catch (err) {
-    logger.error('Import licence error', err);
-    throw err;
+    logger.error('Import licence error', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/import-licences.js
+++ b/src/modules/licence-import/handlers/import-licences.js
@@ -1,13 +1,13 @@
-const extract = require('../extract');
-const { logger } = require('../../../logger');
+const extract = require('../extract')
+const { logger } = require('../../../logger')
 
 module.exports = async job => {
   try {
-    logger.info('Importing licences');
-    const rows = await extract.getAllLicenceNumbers();
-    return rows;
+    logger.info('Importing licences')
+    const rows = await extract.getAllLicenceNumbers()
+    return rows
   } catch (err) {
-    logger.error('Import licences error', err);
-    throw err;
+    logger.error('Import licences error', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/import-purpose-condition-types.js
+++ b/src/modules/licence-import/handlers/import-purpose-condition-types.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const { logger } = require('../../../logger');
-const purposeConditionsConnector = require('../connectors/purpose-conditions-types');
+const { logger } = require('../../../logger')
+const purposeConditionsConnector = require('../connectors/purpose-conditions-types')
 
 module.exports = async () => {
   try {
-    logger.info('Import purpose condition types');
+    logger.info('Import purpose condition types')
     // Load to data in to database
-    return purposeConditionsConnector.createPurposeConditionTypes();
+    return purposeConditionsConnector.createPurposeConditionTypes()
   } catch (err) {
-    logger.error('Import purpose condition types error', err);
-    throw err;
+    logger.error('Import purpose condition types error', err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/index.js
+++ b/src/modules/licence-import/handlers/index.js
@@ -15,4 +15,4 @@ module.exports = {
 
   importPurposeConditionTypes: require('./import-purpose-condition-types'),
   onCompleteImportPurposeConditionTypes: require('./on-complete-import-purpose-condition-types')
-};
+}

--- a/src/modules/licence-import/handlers/on-complete-delete-documents.js
+++ b/src/modules/licence-import/handlers/on-complete-delete-documents.js
@@ -1,5 +1,5 @@
-'use strict';
+'use strict'
 
-const jobs = require('../jobs');
+const jobs = require('../jobs')
 
-module.exports = async messageQueue => messageQueue.publish(jobs.importPurposeConditionTypes());
+module.exports = async messageQueue => messageQueue.publish(jobs.importPurposeConditionTypes())

--- a/src/modules/licence-import/handlers/on-complete-import-companies.js
+++ b/src/modules/licence-import/handlers/on-complete-import-companies.js
@@ -1,8 +1,8 @@
-const jobs = require('../jobs');
+const jobs = require('../jobs')
 
 module.exports = async (messageQueue, job) => {
-  const { value: parties } = job.data.response;
+  const { value: parties } = job.data.response
   for (const row of parties) {
-    await messageQueue.publish(jobs.importCompany(row.regionCode, row.partyId));
+    await messageQueue.publish(jobs.importCompany(row.regionCode, row.partyId))
   }
-};
+}

--- a/src/modules/licence-import/handlers/on-complete-import-company.js
+++ b/src/modules/licence-import/handlers/on-complete-import-company.js
@@ -1,10 +1,10 @@
-const jobs = require('../jobs');
-const importCompanies = require('../connectors/import-companies');
+const jobs = require('../jobs')
+const importCompanies = require('../connectors/import-companies')
 
 module.exports = async messageQueue => {
-  const count = await importCompanies.getPendingCount();
+  const count = await importCompanies.getPendingCount()
   if (count === 0) {
-    await messageQueue.deleteQueue('__state__completed__import.company');
-    await messageQueue.publish(jobs.importLicences());
+    await messageQueue.deleteQueue('__state__completed__import.company')
+    await messageQueue.publish(jobs.importLicences())
   }
-};
+}

--- a/src/modules/licence-import/handlers/on-complete-import-licences.js
+++ b/src/modules/licence-import/handlers/on-complete-import-licences.js
@@ -1,16 +1,16 @@
-const { logger } = require('../../../logger');
-const jobs = require('../jobs');
+const { logger } = require('../../../logger')
+const jobs = require('../jobs')
 
 module.exports = async (messageQueue, job) => {
-  logger.info(`Handling onComplete ${job.data.request.name}`);
+  logger.info(`Handling onComplete ${job.data.request.name}`)
 
   try {
-    const licenceRows = job.data.response.value;
+    const licenceRows = job.data.response.value
     for (const row of licenceRows) {
-      await messageQueue.publish(jobs.importLicence(row.LIC_NO));
+      await messageQueue.publish(jobs.importLicence(row.LIC_NO))
     }
   } catch (err) {
-    logger.error(`Error handling onComplete ${job.data.request.name}`, err);
-    throw err;
+    logger.error(`Error handling onComplete ${job.data.request.name}`, err)
+    throw err
   }
-};
+}

--- a/src/modules/licence-import/handlers/on-complete-import-purpose-condition-types.js
+++ b/src/modules/licence-import/handlers/on-complete-import-purpose-condition-types.js
@@ -1,5 +1,5 @@
-'use strict';
+'use strict'
 
-const jobs = require('../jobs');
+const jobs = require('../jobs')
 
-module.exports = async messageQueue => messageQueue.publish(jobs.importCompanies());
+module.exports = async messageQueue => messageQueue.publish(jobs.importCompanies())

--- a/src/modules/licence-import/jobs/index.js
+++ b/src/modules/licence-import/jobs/index.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const IMPORT_COMPANIES_JOB = 'import.companies';
-const IMPORT_COMPANY_JOB = 'import.company';
-const IMPORT_LICENCES_JOB = 'import.licences';
-const IMPORT_LICENCE_JOB = 'import.licence';
-const DELETE_DOCUMENTS_JOB = 'import.delete-documents';
-const IMPORT_PURPOSE_CONDITION_TYPES_JOB = 'import.purpose-condition-types';
+const IMPORT_COMPANIES_JOB = 'import.companies'
+const IMPORT_COMPANY_JOB = 'import.company'
+const IMPORT_LICENCES_JOB = 'import.licences'
+const IMPORT_LICENCE_JOB = 'import.licence'
+const DELETE_DOCUMENTS_JOB = 'import.delete-documents'
+const IMPORT_PURPOSE_CONDITION_TYPES_JOB = 'import.purpose-condition-types'
 
 /**
  * Formats arguments to publish a PG boss event to import all companies
@@ -18,7 +18,7 @@ const importCompanies = () => ({
     singletonHours: 1,
     expireIn: '4 hour'
   }
-});
+})
 
 /**
  * Formats arguments to publish a PG boss event to import company
@@ -36,7 +36,7 @@ const importCompany = (regionCode, partyId) => ({
     singletonKey: `${IMPORT_COMPANY_JOB}.${regionCode}.${partyId}`,
     expireIn: '4 hour'
   }
-});
+})
 
 /**
  * Formats arguments to publish a PG boss event to start company import
@@ -49,7 +49,7 @@ const importLicences = () => ({
     singletonHours: 1,
     expireIn: '4 hour'
   }
-});
+})
 
 /**
  * Formats arguments to publish a PG boss event to import licence
@@ -65,15 +65,15 @@ const importLicence = licenceNumber => ({
   options: {
     singletonKey: `${IMPORT_LICENCE_JOB}.${licenceNumber}`
   }
-});
+})
 
 const deleteDocuments = () => ({
   name: DELETE_DOCUMENTS_JOB
-});
+})
 
 const importPurposeConditionTypes = () => ({
   name: IMPORT_PURPOSE_CONDITION_TYPES_JOB
-});
+})
 
 module.exports = {
   IMPORT_PURPOSE_CONDITION_TYPES_JOB,
@@ -88,4 +88,4 @@ module.exports = {
   importLicences,
   importLicence,
   deleteDocuments
-};
+}

--- a/src/modules/licence-import/load/company.js
+++ b/src/modules/licence-import/load/company.js
@@ -1,85 +1,85 @@
-const { uniqBy } = require('lodash');
-const connectors = require('./connectors');
-const config = require('../../../../config');
+const { uniqBy } = require('lodash')
+const connectors = require('./connectors')
+const config = require('../../../../config')
 
 const getAddresses = company => {
-  const companyAddresses = company.addresses.map(row => row.address);
+  const companyAddresses = company.addresses.map(row => row.address)
 
   const invoiceAccountAddresses = company.invoiceAccounts.reduce((acc, invoiceAccount) => {
-    const addresses = invoiceAccount.addresses.map(row => row.address);
-    return [...acc, ...addresses];
-  }, []);
+    const addresses = invoiceAccount.addresses.map(row => row.address)
+    return [...acc, ...addresses]
+  }, [])
 
   // Allow import of invoice accounts to be disabled for charging go live
   const addresses = config.import.licences.isInvoiceAccountImportEnabled
     ? [...companyAddresses, ...invoiceAccountAddresses]
-    : companyAddresses;
+    : companyAddresses
 
-  return uniqBy(addresses, row => row.externalId);
-};
+  return uniqBy(addresses, row => row.externalId)
+}
 
 const loadAddresses = async company => {
-  const addresses = getAddresses(company);
-  const tasks = addresses.map(connectors.createAddress);
-  return Promise.all(tasks);
-};
+  const addresses = getAddresses(company)
+  const tasks = addresses.map(connectors.createAddress)
+  return Promise.all(tasks)
+}
 
 const loadContacts = async company => {
-  const contacts = company.contacts.map(row => row.contact);
-  const tasks = contacts.map(connectors.createContact);
-  return Promise.all(tasks);
-};
+  const contacts = company.contacts.map(row => row.contact)
+  const tasks = contacts.map(connectors.createContact)
+  return Promise.all(tasks)
+}
 
 const loadInvoiceAccount = async (company, invoiceAccount) => {
-  await connectors.createInvoiceAccount(company, invoiceAccount);
+  await connectors.createInvoiceAccount(company, invoiceAccount)
   const tasks = invoiceAccount.addresses.map(address =>
     connectors.createInvoiceAccountAddress(invoiceAccount, address)
-  );
-  return Promise.all(tasks);
-};
+  )
+  return Promise.all(tasks)
+}
 
 const loadInvoiceAccounts = async company => {
   // Allow import of invoice accounts to be disabled for charging go live
   if (!config.import.licences.isInvoiceAccountImportEnabled) {
-    return [];
+    return []
   }
 
   const tasks = company.invoiceAccounts.map(invoiceAccount =>
     loadInvoiceAccount(company, invoiceAccount)
-  );
-  return Promise.all(tasks);
-};
+  )
+  return Promise.all(tasks)
+}
 
 const loadCompanyContacts = async company => {
   const tasks = company.contacts.map(contact =>
     connectors.createCompanyContact(company, contact)
-  );
-  return Promise.all(tasks);
-};
+  )
+  return Promise.all(tasks)
+}
 
 const loadCompanyAddresses = async company => {
   const tasks = company.addresses.map(address => {
-    connectors.createCompanyAddress(company, address);
-  });
-  return Promise.all(tasks);
-};
+    connectors.createCompanyAddress(company, address)
+  })
+  return Promise.all(tasks)
+}
 
 const loadCompany = async company => {
   const entities = await Promise.all([
     connectors.createCompany(company),
     loadAddresses(company),
     loadContacts(company)
-  ]);
+  ])
 
   const relationships = await Promise.all([
     loadInvoiceAccounts(company),
     loadCompanyContacts(company),
     loadCompanyAddresses(company)
-  ]);
+  ])
 
-  return { entities, relationships };
-};
+  return { entities, relationships }
+}
 
 module.exports = {
   loadCompany
-};
+}

--- a/src/modules/licence-import/load/company.js
+++ b/src/modules/licence-import/load/company.js
@@ -58,9 +58,9 @@ const loadCompanyContacts = async company => {
 }
 
 const loadCompanyAddresses = async company => {
-  const tasks = company.addresses.map(address => {
+  const tasks = company.addresses.map(address =>
     connectors.createCompanyAddress(company, address)
-  })
+  )
   return Promise.all(tasks)
 }
 

--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -1,39 +1,39 @@
-const { pool } = require('../../../../lib/connectors/db');
-const { get } = require('lodash');
-const queries = require('./queries');
+const { pool } = require('../../../../lib/connectors/db')
+const { get } = require('lodash')
+const queries = require('./queries')
 
 const createDocument = async doc => {
-  const params = [doc.documentRef, doc.startDate, doc.endDate, doc.externalId];
-  return pool.query(queries.createDocument, params);
-};
+  const params = [doc.documentRef, doc.startDate, doc.endDate, doc.externalId]
+  return pool.query(queries.createDocument, params)
+}
 
 const createDocumentRole = async (doc, role) => {
   const params = [doc.documentRef, role.role, get(role, 'company.externalId', null),
     get(role, 'contact.externalId', null), get(role, 'address.externalId', null),
-    get(role, 'invoiceAccount.invoiceAccountNumber', null), role.startDate, role.endDate];
-  return pool.query(queries.createDocumentRole, params);
-};
+    get(role, 'invoiceAccount.invoiceAccountNumber', null), role.startDate, role.endDate]
+  return pool.query(queries.createDocumentRole, params)
+}
 
 const createCompany = company => {
-  const params = [company.name, company.type, company.externalId];
-  return pool.query(queries.createCompany, params);
-};
+  const params = [company.name, company.type, company.externalId]
+  return pool.query(queries.createCompany, params)
+}
 
 const createAddress = address => {
   const params = [address.address1, address.address2, address.address3, address.address4,
-    address.town, address.county, address.postcode, address.country, address.externalId];
-  return pool.query(queries.createAddress, params);
-};
+    address.town, address.county, address.postcode, address.country, address.externalId]
+  return pool.query(queries.createAddress, params)
+}
 
 const createContact = contact => {
-  const params = [contact.salutation, contact.initials, contact.firstName, contact.lastName, contact.externalId];
-  return pool.query(queries.createContact, params);
-};
+  const params = [contact.salutation, contact.initials, contact.firstName, contact.lastName, contact.externalId]
+  return pool.query(queries.createContact, params)
+}
 
 const createInvoiceAccount = (company, invoiceAccount) => {
-  const params = [invoiceAccount.invoiceAccountNumber, invoiceAccount.startDate, invoiceAccount.endDate, company.externalId];
-  return pool.query(queries.createInvoiceAccount, params);
-};
+  const params = [invoiceAccount.invoiceAccountNumber, invoiceAccount.startDate, invoiceAccount.endDate, company.externalId]
+  return pool.query(queries.createInvoiceAccount, params)
+}
 
 const createInvoiceAccountAddress = (invoiceAccount, invoiceAccountAddress) => {
   const params = [
@@ -42,24 +42,24 @@ const createInvoiceAccountAddress = (invoiceAccount, invoiceAccountAddress) => {
     invoiceAccountAddress.startDate,
     invoiceAccountAddress.endDate,
     get(invoiceAccountAddress, 'agentCompany.externalId', null)
-  ];
-  return pool.query(queries.createInvoiceAccountAddress, params);
-};
+  ]
+  return pool.query(queries.createInvoiceAccountAddress, params)
+}
 
 const createCompanyContact = (company, contact) => {
-  const params = [company.externalId, contact.contact.externalId, contact.role, contact.startDate, contact.endDate];
-  return pool.query(queries.createCompanyContact, params);
-};
+  const params = [company.externalId, contact.contact.externalId, contact.role, contact.startDate, contact.endDate]
+  return pool.query(queries.createCompanyContact, params)
+}
 
 const createCompanyAddress = (company, address) => {
-  const params = [company.externalId, address.address.externalId, address.role, address.startDate, address.endDate];
-  return pool.query(queries.createCompanyAddress, params);
-};
+  const params = [company.externalId, address.address.externalId, address.role, address.startDate, address.endDate]
+  return pool.query(queries.createCompanyAddress, params)
+}
 
 const createAgreement = (licence, agreement) => {
-  const params = [licence.licenceNumber, agreement.agreementCode, agreement.startDate, agreement.endDate];
-  return pool.query(queries.createAgreement, params);
-};
+  const params = [licence.licenceNumber, agreement.agreementCode, agreement.startDate, agreement.endDate]
+  return pool.query(queries.createAgreement, params)
+}
 
 const createLicenceVersion = async (version, licenceId) => {
   const params = [
@@ -70,11 +70,11 @@ const createLicenceVersion = async (version, licenceId) => {
     version.startDate,
     version.endDate,
     version.externalId
-  ];
+  ]
 
-  const result = await pool.query(queries.createLicenceVersion, params);
-  return result.rows[0];
-};
+  const result = await pool.query(queries.createLicenceVersion, params)
+  return result.rows[0]
+}
 
 const createLicence = async licence => {
   const result = await pool.query(queries.createLicence, [
@@ -86,10 +86,10 @@ const createLicence = async licence => {
     licence.expiredDate,
     licence.lapsedDate,
     licence.revokedDate
-  ]);
+  ])
 
-  return result.rows[0];
-};
+  return result.rows[0]
+}
 
 const createLicenceVersionPurpose = async (purpose, licenceVersionId) => {
   const params = [
@@ -106,27 +106,27 @@ const createLicenceVersionPurpose = async (purpose, licenceVersionId) => {
     purpose.notes,
     purpose.annualQuantity,
     purpose.externalId
-  ];
-  const result = await pool.query(queries.createLicenceVersionPurpose, params);
-  return result.rows[0];
-};
+  ]
+  const result = await pool.query(queries.createLicenceVersionPurpose, params)
+  return result.rows[0]
+}
 
 const getLicenceByRef = async licenceRef => {
-  const result = await pool.query(queries.getLicenceByRef, [licenceRef]);
-  return result.rows[0];
-};
+  const result = await pool.query(queries.getLicenceByRef, [licenceRef])
+  return result.rows[0]
+}
 
-const flagLicenceForSupplementaryBilling = async licenceId => pool.query(queries.flagLicenceForSupplementaryBilling, [licenceId]);
+const flagLicenceForSupplementaryBilling = async licenceId => pool.query(queries.flagLicenceForSupplementaryBilling, [licenceId])
 
 const cleanUpAgreements = licence => {
   // Create keys for the agreements we wish to keep
   const keys = licence.agreements.map(agreement =>
-    `${agreement.agreementCode}:${agreement.startDate}`);
+    `${agreement.agreementCode}:${agreement.startDate}`)
 
-  return pool.query(queries.cleanUpAgreements, [licence.licenceNumber, keys]);
-};
+  return pool.query(queries.cleanUpAgreements, [licence.licenceNumber, keys])
+}
 
-const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes);
+const createPurposeConditionTypes = async () => pool.query(queries.createPurposeConditionTypes)
 
 const createPurposeCondition = (condition, purposeId) =>
   pool.query(queries.createPurposeCondition, [
@@ -137,7 +137,7 @@ const createPurposeCondition = (condition, purposeId) =>
     condition.param2,
     condition.notes,
     condition.externalId
-  ]);
+  ])
 
 module.exports = {
   createPurposeCondition,
@@ -158,4 +158,4 @@ module.exports = {
   getLicenceByRef,
   flagLicenceForSupplementaryBilling,
   cleanUpAgreements
-};
+}

--- a/src/modules/licence-import/load/connectors/queries.js
+++ b/src/modules/licence-import/load/connectors/queries.js
@@ -7,7 +7,7 @@ const createDocument = `
     end_date=EXCLUDED.end_date,
     external_id=EXCLUDED.external_id,
     date_updated=EXCLUDED.date_updated,
-    date_deleted=EXCLUDED.date_deleted;`;
+    date_deleted=EXCLUDED.date_deleted;`
 
 const createDocumentRole = `INSERT INTO crm_v2.document_roles (document_id, role_id, company_id, contact_id, address_id, start_date, end_date, date_created, date_updated, invoice_account_id)
 SELECT d.document_id, r.role_id, c.company_id, co.contact_id, a.address_id, $7, $8, NOW(), NOW(), ia.invoice_account_id
@@ -25,11 +25,11 @@ ON CONFLICT (document_id, role_id, start_date)
     address_id=EXCLUDED.address_id,
     invoice_account_id=EXCLUDED.invoice_account_id,
     end_date=EXCLUDED.end_date,
-    date_updated=EXCLUDED.date_updated;`;
+    date_updated=EXCLUDED.date_updated;`
 
 const createCompany = `INSERT INTO crm_v2.companies (name, type, external_id, date_created, date_updated, current_hash)
 VALUES ($1, $2, $3, NOW(), NOW(), md5(CONCAT($1::varchar, $2::varchar)::varchar)) ON CONFLICT (external_id) DO UPDATE SET name=EXCLUDED.name,
-date_updated=EXCLUDED.date_updated, type=EXCLUDED.type, last_hash=EXCLUDED.current_hash, current_hash=md5(CONCAT(EXCLUDED.name::varchar,EXCLUDED.type::varchar)::varchar);`;
+date_updated=EXCLUDED.date_updated, type=EXCLUDED.type, last_hash=EXCLUDED.current_hash, current_hash=md5(CONCAT(EXCLUDED.name::varchar,EXCLUDED.type::varchar)::varchar);`
 
 const createAddress = `INSERT INTO crm_v2.addresses (address_1, address_2, address_3, address_4,
 town, county, postcode, country, external_id, data_source, date_created, date_updated, current_hash)
@@ -56,7 +56,7 @@ EXCLUDED.town::varchar,
 EXCLUDED.county::varchar,
 EXCLUDED.postcode::varchar
 )::varchar),
-date_updated=EXCLUDED.date_updated;`;
+date_updated=EXCLUDED.date_updated;`
 
 const createContact = `INSERT INTO crm_v2.contacts (salutation, initials, first_name, last_name, external_id, data_source, date_created, date_updated, current_hash)
 VALUES ($1, $2, $3, $4, $5, 'nald', NOW(), NOW(), md5(CONCAT($1::varchar,$3::varchar,$4::varchar)::varchar)) ON CONFLICT (external_id) DO UPDATE SET
@@ -71,7 +71,7 @@ VALUES ($1, $2, $3, $4, $5, 'nald', NOW(), NOW(), md5(CONCAT($1::varchar,$3::var
   EXCLUDED.salutation::varchar,
   EXCLUDED.first_name::varchar,
   EXCLUDED.last_name::varchar
-  )::varchar);`;
+  )::varchar);`
 
 const createInvoiceAccount = `INSERT INTO crm_v2.invoice_accounts (company_id, invoice_account_number, start_date, end_date, date_created, date_updated)
 SELECT company_id, $1, $2, $3, NOW(), NOW() FROM crm_v2.companies WHERE external_id=$4
@@ -79,7 +79,7 @@ ON CONFLICT (invoice_account_number) DO UPDATE SET
   company_id=EXCLUDED.company_id,
   start_date=EXCLUDED.start_date,
   end_date=EXCLUDED.end_date,
-  date_updated=EXCLUDED.date_updated;`;
+  date_updated=EXCLUDED.date_updated;`
 
 const createInvoiceAccountAddress = `INSERT INTO crm_v2.invoice_account_addresses (invoice_account_id, address_id, agent_company_id, start_date, end_date, date_updated, date_created)
 SELECT ia.invoice_account_id, a.address_id, c.company_id, $3, $4, NOW(), NOW()
@@ -89,7 +89,7 @@ LEFT JOIN crm_v2.companies c ON c.external_id=$5
 WHERE ia.invoice_account_number=$1 ON CONFLICT (invoice_account_id, start_date) DO UPDATE SET
   address_id=EXCLUDED.address_id,
   date_updated=EXCLUDED.date_updated,
-  agent_company_id=EXCLUDED.agent_company_id;`;
+  agent_company_id=EXCLUDED.agent_company_id;`
 
 const createCompanyContact = `INSERT INTO crm_v2.company_contacts (company_id, contact_id, role_id, start_date, end_date, is_default, date_created, date_updated)
 SELECT c.company_id, o.contact_id, r.role_id, $4, $5, true, NOW(), NOW()
@@ -100,7 +100,7 @@ WHERE c.external_id=$1 ON CONFLICT (company_id, contact_id, role_id, start_date)
   contact_id=EXCLUDED.contact_id,
   is_default=EXCLUDED.is_default,
   end_date=EXCLUDED.end_date,
-  date_updated=EXCLUDED.date_updated;`;
+  date_updated=EXCLUDED.date_updated;`
 
 const createCompanyAddress = `INSERT INTO crm_v2.company_addresses (company_id, address_id, role_id, start_date, end_date, is_default, date_created, date_updated)
 SELECT c.company_id, a.address_id, r.role_id, $4, $5, true, NOW(), NOW()
@@ -112,13 +112,13 @@ ON CONFLICT (company_id, address_id, role_id) DO UPDATE SET
   address_id=EXCLUDED.address_id,
   is_default=EXCLUDED.is_default,
   end_date=EXCLUDED.end_date,
-  date_updated=EXCLUDED.date_updated`;
+  date_updated=EXCLUDED.date_updated`
 
 const createAgreement = `insert into water.licence_agreements (licence_ref, financial_agreement_type_id, start_date, end_date, date_created, date_updated, source)
   select $1, t.financial_agreement_type_id, $3, $4, NOW(), NOW(), 'nald' 
     from water.financial_agreement_types t
     where t.financial_agreement_code=$2 on conflict (licence_ref, financial_agreement_type_id, start_date) WHERE date_deleted is null 
-    do update set end_date=EXCLUDED.end_date, date_updated=EXCLUDED.date_updated, source=EXCLUDED.source;`;
+    do update set end_date=EXCLUDED.end_date, date_updated=EXCLUDED.date_updated, source=EXCLUDED.source;`
 
 const createLicence = `insert into water.licences (region_id, licence_ref, is_water_undertaker, regions, start_date, expired_date, lapsed_date, revoked_date)
   values (
@@ -138,7 +138,7 @@ const createLicence = `insert into water.licences (region_id, licence_ref, is_wa
     lapsed_date=excluded.lapsed_date,
     revoked_date=excluded.revoked_date,
     date_updated=now()
-  returning licence_id;`;
+  returning licence_id;`
 
 const createLicenceVersion = `insert into water.licence_versions (
     licence_id,
@@ -156,7 +156,7 @@ const createLicenceVersion = `insert into water.licence_versions (
     start_date = excluded.start_date,
     end_date = excluded.end_date,
     date_updated = now()
-  returning licence_version_id;`;
+  returning licence_version_id;`
 
 const createLicenceVersionPurpose = `insert into water.licence_version_purposes (
     licence_version_id,
@@ -203,11 +203,11 @@ const createLicenceVersionPurpose = `insert into water.licence_version_purposes 
     notes = excluded.notes,
     annual_quantity = excluded.annual_quantity,
     date_updated = now()
-    returning licence_version_purpose_id;`;
+    returning licence_version_purpose_id;`
 
-const getLicenceByRef = 'SELECT * FROM water.licences WHERE licence_ref = $1';
+const getLicenceByRef = 'SELECT * FROM water.licences WHERE licence_ref = $1'
 
-const flagLicenceForSupplementaryBilling = 'UPDATE water.licences set include_in_supplementary_billing = \'yes\' WHERE licence_id = $1';
+const flagLicenceForSupplementaryBilling = 'UPDATE water.licences set include_in_supplementary_billing = \'yes\' WHERE licence_id = $1'
 
 const cleanUpAgreements = `
 delete 
@@ -218,7 +218,7 @@ delete
     and la.source='nald'
     and concat_ws(':', fat.financial_agreement_code, la.start_date) <> any ($2)
     and la.financial_agreement_type_id=fat.financial_agreement_type_id
-`;
+`
 
 const createPurposeConditionTypes = `
 INSERT INTO water.licence_version_purpose_condition_types (
@@ -234,7 +234,7 @@ INSERT INTO water.licence_version_purpose_condition_types (
     description = excluded.description,
     subcode_description = excluded.subcode_description,
     date_updated = now();
-`;
+`
 
 const createPurposeCondition = `
 INSERT INTO water.licence_version_purpose_conditions (
@@ -260,7 +260,7 @@ DO UPDATE SET
  param_2 = excluded.param_2,
  notes = excluded.notes,
  date_updated = now();
-`;
+`
 
 module.exports = {
   createDocument,
@@ -281,4 +281,4 @@ module.exports = {
   cleanUpAgreements,
   createPurposeConditionTypes,
   createPurposeCondition
-};
+}

--- a/src/modules/licence-import/load/index.js
+++ b/src/modules/licence-import/load/index.js
@@ -2,4 +2,4 @@ module.exports = {
   company: require('./company'),
   licence: require('./licence'),
   purposeConditionTypes: require('./purpose-condition-types')
-};
+}

--- a/src/modules/licence-import/load/licence.js
+++ b/src/modules/licence-import/load/licence.js
@@ -1,77 +1,77 @@
-'use strict';
+'use strict'
 
-const connectors = require('./connectors');
-const config = require('../../../../config');
-const roles = require('../transform/mappers/roles');
+const connectors = require('./connectors')
+const config = require('../../../../config')
+const roles = require('../transform/mappers/roles')
 
 const isImportableRole = role => {
   if (config.import.licences.isBillingDocumentRoleImportEnabled) {
-    return true;
+    return true
   }
 
   // Where the import of billing document roles is disabled via the
   // config flag, we will import any role where it does not have
   // a "billing" role
-  return role.role !== roles.ROLE_BILLING;
-};
+  return role.role !== roles.ROLE_BILLING
+}
 
 const loadDocumentRoles = async document => {
   const tasks = document.roles
     .filter(isImportableRole)
     .map(role =>
       connectors.createDocumentRole(document, role)
-    );
-  return Promise.all(tasks);
-};
+    )
+  return Promise.all(tasks)
+}
 
 const loadDocument = async document => {
-  await connectors.createDocument(document);
-  return loadDocumentRoles(document);
-};
+  await connectors.createDocument(document)
+  return loadDocumentRoles(document)
+}
 
 const loadAgreements = async licence => {
   // Allow import of licence agreements to be disabled for charging go live
   if (!config.import.licences.isLicenceAgreementImportEnabled) {
-    return Promise.resolve([]);
+    return Promise.resolve([])
   }
 
   // Deletes any "nald" agreements not found via the current import process
-  await connectors.cleanUpAgreements(licence);
+  await connectors.cleanUpAgreements(licence)
 
   const tasks = licence.agreements.map(agreement =>
     connectors.createAgreement(licence, agreement)
-  );
-  return Promise.all(tasks);
-};
+  )
+  return Promise.all(tasks)
+}
 
 const loadPurposeConditions = (purposeId, purpose) => {
   return Promise.all(purpose.conditions.map(condition => {
-    return connectors.createPurposeCondition(condition, purposeId);
-  }));
-};
+    return connectors.createPurposeCondition(condition, purposeId)
+  }))
+}
 
 const loadVersionPurposes = (licenceVersionId, version) => {
   return Promise.all(version.purposes.map(async purpose => {
-    const purposeResult = await connectors.createLicenceVersionPurpose(purpose, licenceVersionId);
-    return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose);
-  }));
-};
+    const purposeResult = await connectors.createLicenceVersionPurpose(purpose, licenceVersionId)
+    return loadPurposeConditions(purposeResult.licence_version_purpose_id, purpose)
+  }))
+}
 
 const loadVersions = (licenceData, licenceId) => {
   return Promise.all(licenceData.versions.map(async version => {
-    const versionResult = await connectors.createLicenceVersion(version, licenceId);
-    return loadVersionPurposes(versionResult.licence_version_id, version);
-  }));
-};
+    const versionResult = await connectors.createLicenceVersion(version, licenceId)
+    return loadVersionPurposes(versionResult.licence_version_id, version)
+  }))
+}
 
 const loadLicence = async licence => {
-  const licencePriorToImport = await connectors.getLicenceByRef(licence.licenceNumber);
+  const licencePriorToImport = await connectors.getLicenceByRef(licence.licenceNumber)
 
   const tasks = [
     connectors.createLicence(licence),
     loadDocument(licence.document),
     loadAgreements(licence)
-  ];
+  ]
 
   /*
     *  If the expired_date, lapsed_date or revoked_date are changed,
@@ -81,14 +81,14 @@ const loadLicence = async licence => {
       (licencePriorToImport.lapsed_date !== licence.lapsedDate) ||
       (licencePriorToImport.revoked_date !== licence.revokedDate)
   )) {
-    tasks.push(connectors.flagLicenceForSupplementaryBilling(licencePriorToImport.licence_id));
+    tasks.push(connectors.flagLicenceForSupplementaryBilling(licencePriorToImport.licence_id))
   }
 
-  const [savedLicence] = await Promise.all(tasks);
+  const [savedLicence] = await Promise.all(tasks)
 
-  return loadVersions(licence, savedLicence.licence_id);
-};
+  return loadVersions(licence, savedLicence.licence_id)
+}
 
 module.exports = {
   loadLicence
-};
+}

--- a/src/modules/licence-import/load/purpose-condition-types.js
+++ b/src/modules/licence-import/load/purpose-condition-types.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const connectors = require('./connectors');
+const connectors = require('./connectors')
 
-const createPurposeConditionTypes = () => connectors.createPurposeConditionTypes();
+const createPurposeConditionTypes = () => connectors.createPurposeConditionTypes()
 
 module.exports = {
   createPurposeConditionTypes
-};
+}

--- a/src/modules/licence-import/plugin.js
+++ b/src/modules/licence-import/plugin.js
@@ -1,58 +1,58 @@
-const cron = require('node-cron');
-const jobs = require('./jobs');
-const handlers = require('./handlers');
-const { createRegister } = require('../../lib/plugin');
-const config = require('../../../config');
+const cron = require('node-cron')
+const jobs = require('./jobs')
+const handlers = require('./handlers')
+const { createRegister } = require('../../lib/plugin')
+const config = require('../../../config')
 
 const getOptions = () => ({
   teamSize: 500,
   teamConcurrency: 1
-});
+})
 
 const registerSubscribers = async server => {
   // The first step is to remove any documents that no longer exist in NALD
-  await server.messageQueue.subscribe(jobs.DELETE_DOCUMENTS_JOB, handlers.deleteDocuments);
+  await server.messageQueue.subscribe(jobs.DELETE_DOCUMENTS_JOB, handlers.deleteDocuments)
 
   await server.messageQueue.onComplete(jobs.DELETE_DOCUMENTS_JOB,
-    job => handlers.onCompleteDeleteDocuments(server.messageQueue, job));
+    job => handlers.onCompleteDeleteDocuments(server.messageQueue, job))
 
   // When the documents have been marked as deleted
   // import a list of all companies into the water_import.company_import table
   await server.messageQueue.onComplete(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB,
     job => handlers.onCompleteImportPurposeConditionTypes(server.messageQueue, job)
-  );
+  )
 
   // When the water_import.company_import table is ready, jobs are scheduled to import each company
   await server.messageQueue.onComplete(jobs.IMPORT_COMPANIES_JOB,
     job => handlers.onCompleteImportCompanies(server.messageQueue, job)
-  );
+  )
 
   // Import licences when all companies are imported
   await server.messageQueue.onComplete(jobs.IMPORT_COMPANY_JOB,
     job => handlers.onCompleteImportCompany(server.messageQueue, job)
-  );
+  )
 
-  await server.messageQueue.subscribe(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB, handlers.importPurposeConditionTypes);
-  await server.messageQueue.subscribe(jobs.IMPORT_COMPANIES_JOB, handlers.importCompanies);
-  await server.messageQueue.subscribe(jobs.IMPORT_COMPANY_JOB, getOptions(), handlers.importCompany);
-  await server.messageQueue.subscribe(jobs.IMPORT_LICENCES_JOB, handlers.importLicences);
+  await server.messageQueue.subscribe(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB, handlers.importPurposeConditionTypes)
+  await server.messageQueue.subscribe(jobs.IMPORT_COMPANIES_JOB, handlers.importCompanies)
+  await server.messageQueue.subscribe(jobs.IMPORT_COMPANY_JOB, getOptions(), handlers.importCompany)
+  await server.messageQueue.subscribe(jobs.IMPORT_LICENCES_JOB, handlers.importLicences)
   await server.messageQueue.onComplete(jobs.IMPORT_LICENCES_JOB,
     job => handlers.onCompleteImportLicences(server.messageQueue, job)
-  );
+  )
 
-  await server.messageQueue.subscribe(jobs.IMPORT_LICENCE_JOB, getOptions(), handlers.importLicence);
+  await server.messageQueue.subscribe(jobs.IMPORT_LICENCE_JOB, getOptions(), handlers.importLicence)
 
   cron.schedule(config.import.licences.schedule, async () => {
-    await server.messageQueue.publish(jobs.deleteDocuments());
-  });
-};
+    await server.messageQueue.publish(jobs.deleteDocuments())
+  })
+}
 
 const plugin = {
   name: 'importLicenceData',
   dependencies: ['pgBoss'],
   register: server => createRegister(server, registerSubscribers)
-};
+}
 
 module.exports = {
   plugin
-};
+}

--- a/src/modules/licence-import/routes.js
+++ b/src/modules/licence-import/routes.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joi')
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 module.exports = [
   {
@@ -35,4 +35,4 @@ module.exports = [
       }
     }
   }
-];
+]

--- a/src/modules/licence-import/transform/company.js
+++ b/src/modules/licence-import/transform/company.js
@@ -4,26 +4,26 @@
  * @TODO
  * - write data to target tables
  */
-const mappers = require('./mappers');
+const mappers = require('./mappers')
 
 const mapContactData = data => ({
   parties: mappers.party.mapParties([data.party]),
   addresses: mappers.address.mapAddresses(data.addresses)
-});
+})
 
 const transformCompany = companyData => {
-  const contact = mappers.contact.mapContact(companyData.party);
-  const company = mappers.company.mapCompany(companyData.party);
+  const contact = mappers.contact.mapContact(companyData.party)
+  const company = mappers.company.mapCompany(companyData.party)
 
-  const context = mapContactData(companyData);
+  const context = mapContactData(companyData)
 
-  company.invoiceAccounts = mappers.invoiceAccount.mapInvoiceAccounts(companyData.invoiceAccounts, context);
-  company.addresses = mappers.companyAddress.mapCompanyAddresses(companyData.licenceVersions, companyData.invoiceAccounts, companyData.licenceRoles, context);
-  company.contacts = mappers.companyContact.mapCompanyContacts(contact, companyData.licenceVersions, companyData.invoiceAccounts);
+  company.invoiceAccounts = mappers.invoiceAccount.mapInvoiceAccounts(companyData.invoiceAccounts, context)
+  company.addresses = mappers.companyAddress.mapCompanyAddresses(companyData.licenceVersions, companyData.invoiceAccounts, companyData.licenceRoles, context)
+  company.contacts = mappers.companyContact.mapCompanyContacts(contact, companyData.licenceVersions, companyData.invoiceAccounts)
 
-  return mappers.licence.omitNaldData(company);
-};
+  return mappers.licence.omitNaldData(company)
+}
 
 module.exports = {
   transformCompany
-};
+}

--- a/src/modules/licence-import/transform/index.js
+++ b/src/modules/licence-import/transform/index.js
@@ -1,4 +1,4 @@
 module.exports = {
   company: require('./company'),
   licence: require('./licence')
-};
+}

--- a/src/modules/licence-import/transform/licence.js
+++ b/src/modules/licence-import/transform/licence.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const mappers = require('./mappers');
+const mappers = require('./mappers')
 
 const mapContactData = data => ({
   parties: mappers.party.mapParties(data.parties),
   addresses: mappers.address.mapAddresses(data.addresses)
-});
+})
 
 /**
  * Gets the CRM v2 licence model from data in the import database
@@ -14,34 +14,34 @@ const mapContactData = data => ({
  */
 const transformLicence = licenceData => {
   // Get licence
-  const licence = mappers.licence.mapLicence(licenceData.licence, licenceData.versions);
-  const purposes = licenceData.purposes.map(mappers.licencePurpose.mapLicencePurpose);
-  const conditions = licenceData.conditions.map(mappers.purposeCondition.mapPurposeConditionFromNALD);
+  const licence = mappers.licence.mapLicence(licenceData.licence, licenceData.versions)
+  const purposes = licenceData.purposes.map(mappers.licencePurpose.mapLicencePurpose)
+  const conditions = licenceData.conditions.map(mappers.purposeCondition.mapPurposeConditionFromNALD)
 
   // Get documents
-  licence.document = mappers.document.mapLicenceToDocument(licence);
+  licence.document = mappers.document.mapLicenceToDocument(licence)
 
   // Get party/address data
-  const context = mapContactData(licenceData);
+  const context = mapContactData(licenceData)
 
   // Get licence holder/billing document roles
   licence.document.roles = [
     ...mappers.role.mapLicenceHolderRoles(licence.document, licenceData.versions, context),
     ...mappers.role.mapLicenceRoles(licenceData.roles, context)
-  ];
+  ]
 
   // Agreements - section 127/130
-  licence.agreements = mappers.agreement.mapAgreements(licenceData.tptAgreements, licenceData.section130Agreements);
+  licence.agreements = mappers.agreement.mapAgreements(licenceData.tptAgreements, licenceData.section130Agreements)
 
   licence.versions = licenceData.versions.map(version => {
-    return mappers.licenceVersion.mapLicenceVersion(version, purposes, conditions);
-  });
+    return mappers.licenceVersion.mapLicenceVersion(version, purposes, conditions)
+  })
 
-  const finalLicence = mappers.licence.omitNaldData(licence);
+  const finalLicence = mappers.licence.omitNaldData(licence)
 
-  return finalLicence;
-};
+  return finalLicence
+}
 
 module.exports = {
   transformLicence
-};
+}

--- a/src/modules/licence-import/transform/mappers/address.js
+++ b/src/modules/licence-import/transform/mappers/address.js
@@ -1,6 +1,6 @@
-const { set } = require('lodash');
-const str = require('./str');
-const { createRegionSkeleton } = require('./region-skeleton');
+const { set } = require('lodash')
+const str = require('./str')
+const { createRegionSkeleton } = require('./region-skeleton')
 
 const mapAddress = address => ({
   address1: str.mapNull(address.ADDR_LINE1),
@@ -13,14 +13,14 @@ const mapAddress = address => ({
   country: str.mapNull(address.COUNTRY),
   externalId: `${address.FGAC_REGION_CODE}:${address.ID}`,
   _nald: address
-});
+})
 
 const mapAddresses = addresses => addresses.reduce((acc, address) => {
-  set(acc, `${address.FGAC_REGION_CODE}.${address.ID}`, mapAddress(address));
-  return acc;
-}, createRegionSkeleton());
+  set(acc, `${address.FGAC_REGION_CODE}.${address.ID}`, mapAddress(address))
+  return acc
+}, createRegionSkeleton())
 
 module.exports = {
   mapAddress,
   mapAddresses
-};
+}

--- a/src/modules/licence-import/transform/mappers/agreement.js
+++ b/src/modules/licence-import/transform/mappers/agreement.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const helpers = require('@envage/water-abstraction-helpers');
-const date = require('./date');
+const helpers = require('@envage/water-abstraction-helpers')
+const date = require('./date')
 
-const { groupBy, sortBy, flatMap, uniqBy, mapValues } = require('lodash');
+const { groupBy, sortBy, flatMap, uniqBy, mapValues } = require('lodash')
 
 const getUniqueKey = agreement =>
- `${agreement.startDate}:${agreement.endDate}:${agreement.agreementCode}`;
+ `${agreement.startDate}:${agreement.endDate}:${agreement.agreementCode}`
 
 const mapAgreement = chargeAgreement => {
   // Start date is the later of the agreement start date or the
@@ -14,21 +14,21 @@ const mapAgreement = chargeAgreement => {
   const startDate = date.getMaxDate([
     date.mapNaldDate(chargeAgreement.EFF_ST_DATE),
     date.mapNaldDate(chargeAgreement.charge_version_start_date)
-  ]);
+  ])
 
   // End date is the earlier of the agreement end date or the
   // charge version end date.  Either can be null.
   const endDate = date.getMinDate([
     date.mapNaldDate(chargeAgreement.EFF_END_DATE),
     date.mapNaldDate(chargeAgreement.charge_version_end_date)
-  ]);
+  ])
 
   return {
     agreementCode: chargeAgreement.AFSA_CODE,
     startDate,
     endDate
-  };
-};
+  }
+}
 
 /**
  * Maps element-level agreements to a single charge-level agreement
@@ -37,45 +37,45 @@ const mapAgreement = chargeAgreement => {
  * @returns {Object}
  */
 const mapElementLevelAgreements = tptAgreements => {
-  const startDates = tptAgreements.map(row => date.mapNaldDate(row.EFF_ST_DATE));
-  const endDates = tptAgreements.map(row => date.mapNaldDate(row.EFF_END_DATE));
+  const startDates = tptAgreements.map(row => date.mapNaldDate(row.EFF_ST_DATE))
+  const endDates = tptAgreements.map(row => date.mapNaldDate(row.EFF_END_DATE))
   return {
     ...tptAgreements[0],
     EFF_ST_DATE: date.mapIsoDateToNald(date.getMinDate(startDates)),
     EFF_END_DATE: date.mapIsoDateToNald(date.getMaxDate(endDates))
-  };
-};
+  }
+}
 
-const getVersionNumber = chargeAgreement => chargeAgreement.version_number;
+const getVersionNumber = chargeAgreement => chargeAgreement.version_number
 
 const mapTwoPartTariffAgreements = tptAgreements => {
-  const chargeVersionGroups = groupBy(tptAgreements, getVersionNumber);
-  const mappedGroups = mapValues(chargeVersionGroups, mapElementLevelAgreements);
-  return Object.values(mappedGroups);
-};
+  const chargeVersionGroups = groupBy(tptAgreements, getVersionNumber)
+  const mappedGroups = mapValues(chargeVersionGroups, mapElementLevelAgreements)
+  return Object.values(mappedGroups)
+}
 
 const mapAgreements = (tptAgreements, s130Agreements = []) => {
-  const mappedTptAgreements = mapTwoPartTariffAgreements(tptAgreements);
+  const mappedTptAgreements = mapTwoPartTariffAgreements(tptAgreements)
 
   // Map and de-duplicate identical agreements
   const mapped = uniqBy(
     [...mappedTptAgreements, ...s130Agreements].map(mapAgreement),
     getUniqueKey
-  );
+  )
 
   // Group by agreement code
-  const groups = groupBy(mapped, agreement => agreement.agreementCode);
+  const groups = groupBy(mapped, agreement => agreement.agreementCode)
 
   // For each group, merge history
   const merged = Object.values(groups).map(group =>
     helpers.charging.mergeHistory(
       sortBy(group, agreement => agreement.startDate)
     )
-  );
+  )
 
-  return flatMap(merged);
-};
+  return flatMap(merged)
+}
 
 module.exports = {
   mapAgreements
-};
+}

--- a/src/modules/licence-import/transform/mappers/company-address.js
+++ b/src/modules/licence-import/transform/mappers/company-address.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const { sortBy, get, identity, groupBy } = require('lodash');
-const date = require('./date');
-const roles = require('./roles');
+const { sortBy, get, identity, groupBy } = require('lodash')
+const date = require('./date')
+const roles = require('./roles')
 
 /**
  * Gets the end date for a company address from licence version data
@@ -13,66 +13,66 @@ const getEndDate = (row, currentEnd) => {
   // Get all end dates for this row
   const endDates = [row.EFF_END_DATE, row.EXPIRY_DATE, row.REV_DATE, row.LAPSED_DATE]
     .map(date.mapNaldDate)
-    .filter(identity);
+    .filter(identity)
 
-  const arr = [date.getMinDate(endDates), currentEnd];
+  const arr = [date.getMinDate(endDates), currentEnd]
 
-  return arr.includes(null) ? null : date.getMaxDate(arr);
-};
+  return arr.includes(null) ? null : date.getMaxDate(arr)
+}
 
 const getLicenceHolderAddresses = (licenceVersions, context) => {
   // Sort licence versions by start date
-  const sorted = sortBy(licenceVersions, row => date.mapNaldDate(row.EFF_ST_DATE));
+  const sorted = sortBy(licenceVersions, row => date.mapNaldDate(row.EFF_ST_DATE))
 
   // Get the widest date range for each address
   const mapped = sorted.reduce((acc, row) => {
-    const currentStart = get(acc, `${row.ACON_AADD_ID}.startDate`);
-    const currentEnd = get(acc, `${row.ACON_AADD_ID}.endDate`);
+    const currentStart = get(acc, `${row.ACON_AADD_ID}.startDate`)
+    const currentEnd = get(acc, `${row.ACON_AADD_ID}.endDate`)
 
     acc[row.ACON_AADD_ID] = {
       role: roles.ROLE_LICENCE_HOLDER,
       startDate: date.getMinDate([date.mapNaldDate(row.EFF_ST_DATE), currentStart]),
       endDate: getEndDate(row, currentEnd),
       address: context.addresses[row.FGAC_REGION_CODE][row.ACON_AADD_ID]
-    };
+    }
 
-    return acc;
-  }, {});
+    return acc
+  }, {})
 
-  return Object.values(mapped);
-};
+  return Object.values(mapped)
+}
 
 const getBillingAddresses = (chargeVersions, context) => {
-  const grouped = groupBy(chargeVersions, row => row.ACON_AADD_ID);
+  const grouped = groupBy(chargeVersions, row => row.ACON_AADD_ID)
   return Object.values(grouped).map(addressGroup => {
-    const { FGAC_REGION_CODE: regionCode, ACON_AADD_ID: addressId } = addressGroup[0];
-    const dates = addressGroup.map(row => date.mapTransferDate(row.IAS_XFER_DATE));
+    const { FGAC_REGION_CODE: regionCode, ACON_AADD_ID: addressId } = addressGroup[0]
+    const dates = addressGroup.map(row => date.mapTransferDate(row.IAS_XFER_DATE))
     return {
       role: roles.ROLE_BILLING,
       startDate: date.getMinDate(dates),
       endDate: null,
       address: context.addresses[regionCode][addressId]
-    };
-  });
-};
+    }
+  })
+}
 
-const getGroupingKey = row => `${row.FGAC_REGION_CODE}.${row.ACON_AADD_ID}.${row.ALRT_CODE}`;
+const getGroupingKey = row => `${row.FGAC_REGION_CODE}.${row.ACON_AADD_ID}.${row.ALRT_CODE}`
 
 const getLicenceRoleAddresses = (licenceRoles, context) => {
   // Group by roles with the same address and role
-  const grouped = groupBy(licenceRoles, getGroupingKey);
+  const grouped = groupBy(licenceRoles, getGroupingKey)
   return Object.values(grouped).map(addressGroup => {
-    const { FGAC_REGION_CODE: regionCode, ACON_AADD_ID: addressId, ALRT_CODE: roleCode } = addressGroup[0];
-    const startDates = addressGroup.map(row => date.mapNaldDate(row.EFF_ST_DATE));
-    const endDates = addressGroup.map(row => date.mapNaldDate(row.EFF_END_DATE));
+    const { FGAC_REGION_CODE: regionCode, ACON_AADD_ID: addressId, ALRT_CODE: roleCode } = addressGroup[0]
+    const startDates = addressGroup.map(row => date.mapNaldDate(row.EFF_ST_DATE))
+    const endDates = addressGroup.map(row => date.mapNaldDate(row.EFF_END_DATE))
     return {
       role: roles.naldRoles.get(roleCode),
       startDate: date.getMinDate(startDates),
       endDate: date.getMaxDate(endDates),
       address: context.addresses[regionCode][addressId]
-    };
-  });
-};
+    }
+  })
+}
 
 /**
  * Gets an array of the company addresses to import
@@ -86,9 +86,9 @@ const mapCompanyAddresses = (licenceVersions, chargeVersions, licenceRoles, cont
     ...getLicenceHolderAddresses(licenceVersions, context),
     ...getBillingAddresses(chargeVersions, context),
     ...getLicenceRoleAddresses(licenceRoles, context)
-  ];
-};
+  ]
+}
 
 module.exports = {
   mapCompanyAddresses
-};
+}

--- a/src/modules/licence-import/transform/mappers/company-contact.js
+++ b/src/modules/licence-import/transform/mappers/company-contact.js
@@ -1,44 +1,44 @@
-const date = require('./date');
-const roles = require('./roles');
+const date = require('./date')
+const roles = require('./roles')
 
 const getLicenceHolderContact = (contact, licenceVersions) => {
-  const startDates = licenceVersions.map(row => date.mapNaldDate(row.EFF_ST_DATE));
+  const startDates = licenceVersions.map(row => date.mapNaldDate(row.EFF_ST_DATE))
   return {
     role: roles.ROLE_LICENCE_HOLDER,
     startDate: date.getMinDate(startDates),
     endDate: null,
     contact
-  };
-};
+  }
+}
 
 const getBillingContact = (contact, chargeVersions) => {
-  const startDates = chargeVersions.map(row => date.mapTransferDate(row.IAS_XFER_DATE));
+  const startDates = chargeVersions.map(row => date.mapTransferDate(row.IAS_XFER_DATE))
   return {
     role: roles.ROLE_BILLING,
     startDate: date.getMinDate(startDates),
     endDate: null,
     contact
-  };
-};
+  }
+}
 
 const mapCompanyContacts = (contact, licenceVersions, chargeVersions) => {
   if (contact === null) {
-    return [];
+    return []
   }
 
-  const contacts = [];
+  const contacts = []
 
   if (licenceVersions.length > 0) {
-    contacts.push(getLicenceHolderContact(contact, licenceVersions));
+    contacts.push(getLicenceHolderContact(contact, licenceVersions))
   }
 
   if (chargeVersions.length > 0) {
-    contacts.push(getBillingContact(contact, chargeVersions));
+    contacts.push(getBillingContact(contact, chargeVersions))
   }
 
-  return contacts;
-};
+  return contacts
+}
 
 module.exports = {
   mapCompanyContacts
-};
+}

--- a/src/modules/licence-import/transform/mappers/company.js
+++ b/src/modules/licence-import/transform/mappers/company.js
@@ -1,5 +1,5 @@
-const { identity } = require('lodash');
-const str = require('./str');
+const { identity } = require('lodash')
+const str = require('./str')
 
 /**
  * Maps a party object to a full name for organisation/person
@@ -7,19 +7,19 @@ const str = require('./str');
  * @return {String}
  */
 const mapName = party => {
-  const firstNameKey = party.FORENAME === 'null' ? 'INITIALS' : 'FORENAME';
+  const firstNameKey = party.FORENAME === 'null' ? 'INITIALS' : 'FORENAME'
 
   const parts = [
     party.SALUTATION,
     party[firstNameKey],
     party.NAME
-  ];
+  ]
 
   return parts
     .map(str.mapNull)
     .filter(identity)
-    .join(' ');
-};
+    .join(' ')
+}
 
 /**
  * Maps NALD party to CRM company
@@ -31,8 +31,8 @@ const mapCompany = party => ({
   name: mapName(party),
   externalId: `${party.FGAC_REGION_CODE}:${party.ID}`,
   _nald: party
-});
+})
 
 module.exports = {
   mapCompany
-};
+}

--- a/src/modules/licence-import/transform/mappers/contact.js
+++ b/src/modules/licence-import/transform/mappers/contact.js
@@ -1,4 +1,4 @@
-const str = require('./str');
+const str = require('./str')
 
 /**
  * Maps NALD party to CRM contact
@@ -7,7 +7,7 @@ const str = require('./str');
  */
 const mapContact = party => {
   if (party.APAR_TYPE === 'ORG') {
-    return null;
+    return null
   }
   return {
     salutation: str.mapNull(party.SALUTATION),
@@ -16,9 +16,9 @@ const mapContact = party => {
     lastName: str.mapNull(party.NAME),
     externalId: `${party.FGAC_REGION_CODE}:${party.ID}`,
     _nald: party
-  };
-};
+  }
+}
 
 module.exports = {
   mapContact
-};
+}

--- a/src/modules/licence-import/transform/mappers/date.js
+++ b/src/modules/licence-import/transform/mappers/date.js
@@ -1,46 +1,46 @@
-const moment = require('moment');
-const { sortBy, isNull } = require('lodash');
-const DATE_FORMAT = 'YYYY-MM-DD';
-const NALD_FORMAT = 'DD/MM/YYYY';
-const NALD_TRANSFER_FORMAT = 'DD/MM/YYYY HH:mm:ss';
+const moment = require('moment')
+const { sortBy, isNull } = require('lodash')
+const DATE_FORMAT = 'YYYY-MM-DD'
+const NALD_FORMAT = 'DD/MM/YYYY'
+const NALD_TRANSFER_FORMAT = 'DD/MM/YYYY HH:mm:ss'
 
 const mapNaldDate = str => {
   if (str === 'null') {
-    return null;
+    return null
   }
-  return moment(str, NALD_FORMAT).format(DATE_FORMAT);
-};
+  return moment(str, NALD_FORMAT).format(DATE_FORMAT)
+}
 
 const mapIsoDateToNald = str => {
   if (isNull(str)) {
-    return 'null';
+    return 'null'
   }
-  return moment(str, DATE_FORMAT).format(NALD_FORMAT);
-};
+  return moment(str, DATE_FORMAT).format(NALD_FORMAT)
+}
 
 const getSortedDates = arr => {
   const moments = arr
     .map(str => moment(str, DATE_FORMAT))
-    .filter(m => m.isValid());
+    .filter(m => m.isValid())
 
-  return sortBy(moments, m => m.unix());
-};
+  return sortBy(moments, m => m.unix())
+}
 
 const getMinDate = arr => {
-  const sorted = getSortedDates(arr);
-  return sorted.length === 0 ? null : sorted.shift().format(DATE_FORMAT);
-};
+  const sorted = getSortedDates(arr)
+  return sorted.length === 0 ? null : sorted.shift().format(DATE_FORMAT)
+}
 
 const getMaxDate = arr => {
-  const sorted = getSortedDates(arr);
-  return sorted.length === 0 ? null : sorted.pop().format(DATE_FORMAT);
-};
+  const sorted = getSortedDates(arr)
+  return sorted.length === 0 ? null : sorted.pop().format(DATE_FORMAT)
+}
 
 const mapTransferDate = str =>
-  moment(str, NALD_TRANSFER_FORMAT).format(DATE_FORMAT);
+  moment(str, NALD_TRANSFER_FORMAT).format(DATE_FORMAT)
 
 const getPreviousDay = str =>
-  moment(str, DATE_FORMAT).subtract(1, 'day').format(DATE_FORMAT);
+  moment(str, DATE_FORMAT).subtract(1, 'day').format(DATE_FORMAT)
 
 module.exports = {
   mapNaldDate,
@@ -49,4 +49,4 @@ module.exports = {
   mapTransferDate,
   getPreviousDay,
   mapIsoDateToNald
-};
+}

--- a/src/modules/licence-import/transform/mappers/document.js
+++ b/src/modules/licence-import/transform/mappers/document.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const { pick } = require('lodash');
+const { pick } = require('lodash')
 
 const mapLicenceToDocument = licence => ({
   documentRef: licence.licenceNumber,
   ...pick(licence, ['startDate', 'endDate', 'externalId']),
   roles: [],
   _nald: licence._nald
-});
+})
 
 module.exports = {
   mapLicenceToDocument
-};
+}

--- a/src/modules/licence-import/transform/mappers/index.js
+++ b/src/modules/licence-import/transform/mappers/index.js
@@ -14,4 +14,4 @@ module.exports = {
   party: require('./party'),
   role: require('./role'),
   purposeCondition: require('./purpose-condition')
-};
+}

--- a/src/modules/licence-import/transform/mappers/invoice-account.js
+++ b/src/modules/licence-import/transform/mappers/invoice-account.js
@@ -1,15 +1,15 @@
-const { groupBy, sortBy } = require('lodash');
-const helpers = require('@envage/water-abstraction-helpers');
-const date = require('./date');
-const roles = require('./roles');
+const { groupBy, sortBy } = require('lodash')
+const helpers = require('@envage/water-abstraction-helpers')
+const date = require('./date')
+const roles = require('./roles')
 
 const mapInvoiceAccount = chargeVersion => ({
   invoiceAccountNumber: chargeVersion.IAS_CUST_REF
-});
+})
 
 const getNormalisedName = str => {
-  return str.trim().toLowerCase().replace(/ltd\.?$/, 'limited');
-};
+  return str.trim().toLowerCase().replace(/ltd\.?$/, 'limited')
+}
 
 /**
  * Gets the agent company ID for the invoice account row
@@ -23,17 +23,17 @@ const getAgentCompanyExternalId = row => {
     invoice_account_party_name: invoiceAccountPartyName,
     FGAC_REGION_CODE: regionCode,
     ACON_APAR_ID: invoiceAccountPartyId
-  } = row;
+  } = row
 
-  const isDifferentId = licenceHolderPartyId !== invoiceAccountPartyId;
-  const isDifferentName = getNormalisedName(licenceHolderPartyName) !== getNormalisedName(invoiceAccountPartyName);
+  const isDifferentId = licenceHolderPartyId !== invoiceAccountPartyId
+  const isDifferentName = getNormalisedName(licenceHolderPartyName) !== getNormalisedName(invoiceAccountPartyName)
 
-  return isDifferentId && isDifferentName ? `${regionCode}:${invoiceAccountPartyId}` : null;
-};
+  return isDifferentId && isDifferentName ? `${regionCode}:${invoiceAccountPartyId}` : null
+}
 
 const mapInvoiceAccountAddresses = (iasAccounts, context) => {
   // Sort group by transfer date
-  const sorted = sortBy(iasAccounts, row => date.mapTransferDate(row.IAS_XFER_DATE));
+  const sorted = sortBy(iasAccounts, row => date.mapTransferDate(row.IAS_XFER_DATE))
 
   // Map to new data structure
   const addresses = sorted.map((row, i, arr) => ({
@@ -44,28 +44,28 @@ const mapInvoiceAccountAddresses = (iasAccounts, context) => {
     agentCompany: {
       externalId: getAgentCompanyExternalId(row)
     }
-  }));
+  }))
 
   // Merge on date range
-  return helpers.charging.mergeHistory(addresses);
-};
+  return helpers.charging.mergeHistory(addresses)
+}
 
 const mapInvoiceAccounts = (iasAccounts, context) => {
   // Group by IAS customer ref (invoice account number)
-  const groups = groupBy(iasAccounts, row => row.IAS_CUST_REF);
+  const groups = groupBy(iasAccounts, row => row.IAS_CUST_REF)
   return Object.values(groups).map(group => {
-    const addresses = mapInvoiceAccountAddresses(group, context);
+    const addresses = mapInvoiceAccountAddresses(group, context)
 
     return {
       invoiceAccountNumber: group[0].IAS_CUST_REF,
       startDate: addresses[0].startDate,
       endDate: null,
       addresses
-    };
-  });
-};
+    }
+  })
+}
 
 module.exports = {
   mapInvoiceAccount,
   mapInvoiceAccounts
-};
+}

--- a/src/modules/licence-import/transform/mappers/licence-purpose.js
+++ b/src/modules/licence-import/transform/mappers/licence-purpose.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const dateMapper = require('./date');
-const nald = require('@envage/water-abstraction-helpers').nald;
+const dateMapper = require('./date')
+const nald = require('@envage/water-abstraction-helpers').nald
 
 const mapLicencePurpose = data => {
   const purpose = {
@@ -21,11 +21,11 @@ const mapLicencePurpose = data => {
       ? null
       : +data.ANNUAL_QTY,
     externalId: `${data.FGAC_REGION_CODE}:${data.ID}`
-  };
+  }
 
-  return purpose;
-};
+  return purpose
+}
 
 module.exports = {
   mapLicencePurpose
-};
+}

--- a/src/modules/licence-import/transform/mappers/licence-version.js
+++ b/src/modules/licence-import/transform/mappers/licence-version.js
@@ -1,17 +1,17 @@
-'use strict';
+'use strict'
 
-const dateMapper = require('./date');
+const dateMapper = require('./date')
 
 const statuses = {
   CURR: 'current',
   SUPER: 'superseded',
   DRAFT: 'draft'
-};
+}
 
 const createExternalId = licenceVersionData => {
-  const { FGAC_REGION_CODE, AABL_ID, ISSUE_NO, INCR_NO } = licenceVersionData;
-  return `${FGAC_REGION_CODE}:${AABL_ID}:${ISSUE_NO}:${INCR_NO}`;
-};
+  const { FGAC_REGION_CODE, AABL_ID, ISSUE_NO, INCR_NO } = licenceVersionData
+  return `${FGAC_REGION_CODE}:${AABL_ID}:${ISSUE_NO}:${INCR_NO}`
+}
 
 /**
  * Creates a mapped licence version object in a preferred format over
@@ -22,8 +22,8 @@ const createExternalId = licenceVersionData => {
  * @param {Array<Object>} mappedConditions An array of conditions
  */
 const mapLicenceVersion = (licenceVersionData, mappedPurposes = [], mappedConditions = []) => {
-  const issue = +licenceVersionData.ISSUE_NO;
-  const increment = +licenceVersionData.INCR_NO;
+  const issue = +licenceVersionData.ISSUE_NO
+  const increment = +licenceVersionData.INCR_NO
   return {
     issue,
     increment,
@@ -32,13 +32,13 @@ const mapLicenceVersion = (licenceVersionData, mappedPurposes = [], mappedCondit
     endDate: dateMapper.mapNaldDate(licenceVersionData.EFF_END_DATE),
     externalId: createExternalId(licenceVersionData),
     purposes: mappedPurposes.filter(p => {
-      return p.issue === issue && p.increment === increment;
+      return p.issue === issue && p.increment === increment
     }).map(p => {
-      return { ...p, conditions: mappedConditions.filter(c => c.purposeExternalId === p.externalId) };
+      return { ...p, conditions: mappedConditions.filter(c => c.purposeExternalId === p.externalId) }
     })
-  };
-};
+  }
+}
 
 module.exports = {
   mapLicenceVersion
-};
+}

--- a/src/modules/licence-import/transform/mappers/licence.js
+++ b/src/modules/licence-import/transform/mappers/licence.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const date = require('./date');
-const str = require('./str');
+const date = require('./date')
+const str = require('./str')
 const {
   endsWith,
   identity,
@@ -9,7 +9,7 @@ const {
   isArray,
   isObject,
   mapValues
-} = require('lodash');
+} = require('lodash')
 
 const regions = {
   AN: 'Anglian',
@@ -21,20 +21,20 @@ const regions = {
   TH: 'Thames',
   WL: 'Wales',
   YO: 'Yorkshire'
-};
+}
 
 const getRegionData = licenceData => {
-  const historicalAreaCode = licenceData.AREP_AREA_CODE;
-  const regionPrefix = licenceData.AREP_EIUC_CODE.substr(0, 2);
-  const regionalChargeArea = regions[regionPrefix];
-  const standardUnitChargeCode = licenceData.AREP_SUC_CODE;
-  const localEnvironmentAgencyPlanCode = licenceData.AREP_LEAP_CODE;
-  return { historicalAreaCode, regionalChargeArea, standardUnitChargeCode, localEnvironmentAgencyPlanCode };
-};
+  const historicalAreaCode = licenceData.AREP_AREA_CODE
+  const regionPrefix = licenceData.AREP_EIUC_CODE.substr(0, 2)
+  const regionalChargeArea = regions[regionPrefix]
+  const standardUnitChargeCode = licenceData.AREP_SUC_CODE
+  const localEnvironmentAgencyPlanCode = licenceData.AREP_LEAP_CODE
+  return { historicalAreaCode, regionalChargeArea, standardUnitChargeCode, localEnvironmentAgencyPlanCode }
+}
 
-const isNotDraftLicenceVersion = licenceVersion => licenceVersion.STATUS !== 'DRAFT';
+const isNotDraftLicenceVersion = licenceVersion => licenceVersion.STATUS !== 'DRAFT'
 
-const getLicenceVersionStartDate = licenceVersion => date.mapNaldDate(licenceVersion.EFF_ST_DATE);
+const getLicenceVersionStartDate = licenceVersion => date.mapNaldDate(licenceVersion.EFF_ST_DATE)
 
 /**
  * Maps the licence and licence versions to a start date.
@@ -48,15 +48,15 @@ const getLicenceVersionStartDate = licenceVersion => date.mapNaldDate(licenceVer
  */
 const mapStartDate = (licence, licenceVersions) => {
   if (licence.ORIG_EFF_DATE !== 'null') {
-    return date.mapNaldDate(licence.ORIG_EFF_DATE);
+    return date.mapNaldDate(licence.ORIG_EFF_DATE)
   }
 
   return licenceVersions
     .filter(isNotDraftLicenceVersion)
     .map(getLicenceVersionStartDate)
     .sort()
-    .shift();
-};
+    .shift()
+}
 
 const mapLicence = (licence, licenceVersions) => {
   const endDates = [
@@ -66,7 +66,7 @@ const mapLicence = (licence, licenceVersions) => {
   ]
     .map(str.mapNull)
     .filter(identity)
-    .map(date.mapNaldDate);
+    .map(date.mapNaldDate)
 
   return {
     licenceNumber: licence.LIC_NO,
@@ -82,8 +82,8 @@ const mapLicence = (licence, licenceVersions) => {
     lapsedDate: date.mapNaldDate(licence.LAPSED_DATE),
     revokedDate: date.mapNaldDate(licence.REV_DATE),
     _nald: licence
-  };
-};
+  }
+}
 
 /**
  * Deep cleans up any _nald keys in a deep object
@@ -92,16 +92,16 @@ const mapLicence = (licence, licenceVersions) => {
  */
 const omitNaldData = value => {
   if (isArray(value)) {
-    return value.map(omitNaldData);
+    return value.map(omitNaldData)
   }
   if (isObject(value)) {
-    const val = omit(value, '_nald');
-    return mapValues(val, omitNaldData);
+    const val = omit(value, '_nald')
+    return mapValues(val, omitNaldData)
   }
-  return value;
-};
+  return value
+}
 
 module.exports = {
   mapLicence,
   omitNaldData
-};
+}

--- a/src/modules/licence-import/transform/mappers/party.js
+++ b/src/modules/licence-import/transform/mappers/party.js
@@ -1,7 +1,7 @@
-const { set } = require('lodash');
-const contact = require('./contact');
-const company = require('./company');
-const { createRegionSkeleton } = require('./region-skeleton');
+const { set } = require('lodash')
+const contact = require('./contact')
+const company = require('./company')
+const { createRegionSkeleton } = require('./region-skeleton')
 
 /**
  * Maps parties to a hash containing companies and contacts
@@ -12,10 +12,10 @@ const mapParties = parties => parties.reduce((acc, party) => {
   set(acc, `${party.FGAC_REGION_CODE}.${party.ID}`, {
     company: company.mapCompany(party),
     contact: contact.mapContact(party)
-  });
-  return acc;
-}, createRegionSkeleton());
+  })
+  return acc
+}, createRegionSkeleton())
 
 module.exports = {
   mapParties
-};
+}

--- a/src/modules/licence-import/transform/mappers/purpose-condition.js
+++ b/src/modules/licence-import/transform/mappers/purpose-condition.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const mapPurposeConditionFromNALD = data => {
   return {
@@ -15,9 +15,9 @@ const mapPurposeConditionFromNALD = data => {
       : data.TEXT,
     purposeExternalId: `${data.FGAC_REGION_CODE}:${data.AABP_ID}`,
     externalId: `${data.ID}:${data.FGAC_REGION_CODE}:${data.AABP_ID}`
-  };
-};
+  }
+}
 
 module.exports = {
   mapPurposeConditionFromNALD
-};
+}

--- a/src/modules/licence-import/transform/mappers/region-skeleton.js
+++ b/src/modules/licence-import/transform/mappers/region-skeleton.js
@@ -7,8 +7,8 @@ const createRegionSkeleton = () => ({
   6: {},
   7: {},
   8: {}
-});
+})
 
 module.exports = {
   createRegionSkeleton
-};
+}

--- a/src/modules/licence-import/transform/mappers/role.js
+++ b/src/modules/licence-import/transform/mappers/role.js
@@ -1,41 +1,41 @@
-'use strict';
+'use strict'
 
-const date = require('./date');
-const roles = require('./roles');
+const date = require('./date')
+const roles = require('./roles')
 
 const mapLicenceHolderRoles = (document, licenceVersions, context) => licenceVersions
   .filter(licenceVersion => isLicenceVersionForImport(licenceVersion, licenceVersions))
-  .map(licenceVersion => mapLicenceHolderRole(document, licenceVersion, context));
+  .map(licenceVersion => mapLicenceHolderRole(document, licenceVersion, context))
 
 const isLicenceVersionForImport = (licenceVersion, licenceVersions) =>
   !isLicenceVersionDraft(licenceVersion) &&
-  !isLicenceVersionReplaced(licenceVersion, licenceVersions);
+  !isLicenceVersionReplaced(licenceVersion, licenceVersions)
 
-const isLicenceVersionDraft = licenceVersion => licenceVersion.STATUS === 'DRAFT';
+const isLicenceVersionDraft = licenceVersion => licenceVersion.STATUS === 'DRAFT'
 
 const isLicenceVersionReplaced = (licenceVersion, licenceVersions) =>
   licenceVersions.some(comparisonLicenceVersion => {
-    const isSameStartDate = comparisonLicenceVersion.EFF_ST_DATE === licenceVersion.EFF_ST_DATE;
-    const isFollowingVersion = compareLicenceVersions(licenceVersion, comparisonLicenceVersion) === 1;
-    return isSameStartDate && isFollowingVersion;
-  });
+    const isSameStartDate = comparisonLicenceVersion.EFF_ST_DATE === licenceVersion.EFF_ST_DATE
+    const isFollowingVersion = compareLicenceVersions(licenceVersion, comparisonLicenceVersion) === 1
+    return isSameStartDate && isFollowingVersion
+  })
 
 const compareLicenceVersions = (licenceVersionA, licenceVersionB) => {
-  const versionA = getVersion(licenceVersionA);
-  const versionB = getVersion(licenceVersionB);
+  const versionA = getVersion(licenceVersionA)
+  const versionB = getVersion(licenceVersionB)
   if (versionA.issue === versionB.issue) {
     if (versionA.increment === versionB.increment) {
-      return 0;
+      return 0
     }
-    return versionA.increment > versionB.increment ? -1 : +1;
+    return versionA.increment > versionB.increment ? -1 : +1
   }
-  return versionA.issue > versionB.issue ? -1 : +1;
-};
+  return versionA.issue > versionB.issue ? -1 : +1
+}
 
 const getVersion = licenceVersion => ({
   issue: parseInt(licenceVersion.ISSUE_NO),
   increment: parseInt(licenceVersion.INCR_NO)
-});
+})
 
 /**
  * Creates an initial document role for the licence holder
@@ -57,7 +57,7 @@ const mapLicenceHolderRole = (document, licenceVersion, context) => ({
   ]),
   ...context.parties[licenceVersion.FGAC_REGION_CODE][licenceVersion.ACON_APAR_ID],
   address: context.addresses[licenceVersion.FGAC_REGION_CODE][licenceVersion.ACON_AADD_ID]
-});
+})
 
 const mapLicenceRole = (row, context) => ({
   role: roles.naldRoles.get(row.ALRT_CODE),
@@ -67,14 +67,14 @@ const mapLicenceRole = (row, context) => ({
   contact: null,
   ...context.parties[row.FGAC_REGION_CODE][row.ACON_APAR_ID],
   address: context.addresses[row.FGAC_REGION_CODE][row.ACON_AADD_ID]
-});
+})
 
 /**
  * Whether this role should be imported
  * @param {Object} role - nald licence role row data
  * @return {Boolean}
  */
-const isRoleForImport = role => roles.naldRoles.get(role.ALRT_CODE) === roles.ROLE_RETURNS_TO;
+const isRoleForImport = role => roles.naldRoles.get(role.ALRT_CODE) === roles.ROLE_RETURNS_TO
 
 /**
  * Maps NALD roles (returns to contact)
@@ -83,9 +83,9 @@ const isRoleForImport = role => roles.naldRoles.get(role.ALRT_CODE) === roles.RO
  */
 const mapLicenceRoles = (licenceRoles, context) => licenceRoles
   .filter(isRoleForImport)
-  .map(role => mapLicenceRole(role, context));
+  .map(role => mapLicenceRole(role, context))
 
 module.exports = {
   mapLicenceHolderRoles,
   mapLicenceRoles
-};
+}

--- a/src/modules/licence-import/transform/mappers/roles.js
+++ b/src/modules/licence-import/transform/mappers/roles.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-const ROLE_LICENCE_HOLDER = 'licenceHolder';
-const ROLE_BILLING = 'billing';
-const ROLE_RETURNS_TO = 'returnsTo';
+const ROLE_LICENCE_HOLDER = 'licenceHolder'
+const ROLE_BILLING = 'billing'
+const ROLE_RETURNS_TO = 'returnsTo'
 
 /**
  * Maps the NALD role codes to the CRM v2 role name
  * @type {Map}
  */
-const naldRoles = new Map();
-naldRoles.set('RT', ROLE_RETURNS_TO);
+const naldRoles = new Map()
+naldRoles.set('RT', ROLE_RETURNS_TO)
 
 module.exports = {
   ROLE_LICENCE_HOLDER,
   ROLE_BILLING,
   ROLE_RETURNS_TO,
   naldRoles
-};
+}

--- a/src/modules/licence-import/transform/mappers/str.js
+++ b/src/modules/licence-import/transform/mappers/str.js
@@ -1,5 +1,5 @@
-const mapNull = str => str === 'null' ? null : str;
+const mapNull = str => str === 'null' ? null : str
 
 module.exports = {
   mapNull
-};
+}

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const Boom = require('@hapi/boom');
-const { getLicenceJson } = require('./transform-permit');
-const { buildReturnsPacket } = require('./transform-returns');
+const Boom = require('@hapi/boom')
+const { getLicenceJson } = require('./transform-permit')
+const { buildReturnsPacket } = require('./transform-returns')
 
-const jobs = require('./jobs');
-const { getFormats, getLogs, getLogLines } = require('./lib/nald-queries/returns');
+const jobs = require('./jobs')
+const { getFormats, getLogs, getLogLines } = require('./lib/nald-queries/returns')
 
 /**
  * For test purposes, builds licence from the data in the NALD import
@@ -14,17 +14,17 @@ const { getFormats, getLogs, getLogLines } = require('./lib/nald-queries/returns
  */
 const getLicence = async (request, h) => {
   try {
-    const filter = JSON.parse(request.query.filter);
-    const data = await getLicenceJson(filter.licenceNumber);
+    const filter = JSON.parse(request.query.filter)
+    const data = await getLicenceJson(filter.licenceNumber)
 
     if (data) {
-      return data;
+      return data
     }
-    return Boom.notFound('The requested licence number could not be found');
+    return Boom.notFound('The requested licence number could not be found')
   } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 });
+    throw Boom.boomify(err, { statusCode: 400 })
   }
-};
+}
 
 /**
  * For test purposes, builds returns data
@@ -32,17 +32,17 @@ const getLicence = async (request, h) => {
  */
 const getReturns = async (request, h) => {
   try {
-    const filter = JSON.parse(request.query.filter);
-    const data = await buildReturnsPacket(filter.licenceNumber);
+    const filter = JSON.parse(request.query.filter)
+    const data = await buildReturnsPacket(filter.licenceNumber)
 
     if (data) {
-      return data;
+      return data
     }
-    return Boom.notFound('The requested licence number could not be found');
+    return Boom.notFound('The requested licence number could not be found')
   } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 });
+    throw Boom.boomify(err, { statusCode: 400 })
   }
-};
+}
 
 /**
  * For test purposes, gets returns formats for given licence number
@@ -50,14 +50,14 @@ const getReturns = async (request, h) => {
  */
 const getReturnsFormats = async (request, h) => {
   try {
-    const filter = JSON.parse(request.query.filter);
-    const data = await getFormats(filter.licenceNumber);
+    const filter = JSON.parse(request.query.filter)
+    const data = await getFormats(filter.licenceNumber)
 
-    return data;
+    return data
   } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 });
+    throw Boom.boomify(err, { statusCode: 400 })
   }
-};
+}
 
 /**
  * For test purposes, gets returns formats for given licence number
@@ -65,14 +65,14 @@ const getReturnsFormats = async (request, h) => {
  */
 const getReturnsLogs = async (request, h) => {
   try {
-    const filter = JSON.parse(request.query.filter);
-    const { formatId, regionCode } = filter;
-    const data = await getLogs(formatId, regionCode);
-    return data;
+    const filter = JSON.parse(request.query.filter)
+    const { formatId, regionCode } = filter
+    const data = await getLogs(formatId, regionCode)
+    return data
   } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 });
+    throw Boom.boomify(err, { statusCode: 400 })
   }
-};
+}
 
 /**
  * For test purposes, gets returns formats for given licence number
@@ -80,27 +80,27 @@ const getReturnsLogs = async (request, h) => {
  */
 const getReturnsLogLines = async (request, h) => {
   try {
-    const filter = JSON.parse(request.query.filter);
-    const { formatId, regionCode, dateFrom } = filter;
-    const data = await getLogLines(formatId, regionCode, dateFrom);
-    return data;
+    const filter = JSON.parse(request.query.filter)
+    const { formatId, regionCode, dateFrom } = filter
+    const data = await getLogLines(formatId, regionCode, dateFrom)
+    return data
   } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 });
+    throw Boom.boomify(err, { statusCode: 400 })
   }
-};
+}
 
 const postImportLicence = async (request, h) => {
-  const { job } = jobs.importLicence;
-  const { licenceNumber } = request.payload;
-  const message = job.createMessage(licenceNumber);
+  const { job } = jobs.importLicence
+  const { licenceNumber } = request.payload
+  const message = job.createMessage(licenceNumber)
 
   try {
-    await request.server.messageQueue.publish(message);
-    return h.response(message).code(202);
+    await request.server.messageQueue.publish(message)
+    return h.response(message).code(202)
   } catch (err) {
-    throw Boom.boomify(err);
+    throw Boom.boomify(err)
   }
-};
+}
 
 module.exports = {
   getLicence,
@@ -109,4 +109,4 @@ module.exports = {
   getReturnsLogs,
   getReturnsLogLines,
   postImportLicence
-};
+}

--- a/src/modules/nald-import/jobs/delete-removed-documents-complete.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents-complete.js
@@ -1,23 +1,23 @@
-'use strict';
+'use strict'
 
-const logger = require('./lib/logger');
+const logger = require('./lib/logger')
 
-const populatePendingImportJob = require('./populate-pending-import');
+const populatePendingImportJob = require('./populate-pending-import')
 
 const deleteRemovedDocumentsComplete = async (job, messageQueue) => {
   if (job.failed) {
-    return logger.logFailedJob(job);
+    return logger.logFailedJob(job)
   }
 
-  logger.logHandlingOnCompleteJob(job);
+  logger.logHandlingOnCompleteJob(job)
 
   try {
     // Publish a new job to populate pending import table
-    await messageQueue.publish(populatePendingImportJob.createMessage());
+    await messageQueue.publish(populatePendingImportJob.createMessage())
   } catch (err) {
-    logger.logHandlingOnCompleteError(job, err);
-    throw err;
+    logger.logHandlingOnCompleteError(job, err)
+    throw err
   }
-};
+}
 
-module.exports = deleteRemovedDocumentsComplete;
+module.exports = deleteRemovedDocumentsComplete

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const logger = require('./lib/logger');
+const logger = require('./lib/logger')
 
-const JOB_NAME = 'nald-import.delete-removed-documents';
-const importService = require('../../../lib/services/import');
+const JOB_NAME = 'nald-import.delete-removed-documents'
+const importService = require('../../../lib/services/import')
 
 const createMessage = () => ({
   name: JOB_NAME,
@@ -11,21 +11,21 @@ const createMessage = () => ({
     expireIn: '1 hours',
     singletonKey: JOB_NAME
   }
-});
+})
 
 const handler = async job => {
-  logger.logHandlingJob(job);
+  logger.logHandlingJob(job)
 
   try {
-    return importService.deleteRemovedDocuments();
+    return importService.deleteRemovedDocuments()
   } catch (err) {
-    logger.logJobError(job, err);
-    throw err;
+    logger.logJobError(job, err)
+    throw err
   }
-};
+}
 
 module.exports = {
   createMessage,
   handler,
   jobName: JOB_NAME
-};
+}

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const licenceLoader = require('../load');
-const logger = require('./lib/logger');
-const assertImportTablesExist = require('../lib/assert-import-tables-exist');
+const licenceLoader = require('../load')
+const logger = require('./lib/logger')
+const assertImportTablesExist = require('../lib/assert-import-tables-exist')
 
-const JOB_NAME = 'nald-import.import-licence';
+const JOB_NAME = 'nald-import.import-licence'
 
 const options = {
   teamSize: 75,
   teamConcurrency: 1
-};
+}
 
 const createMessage = licenceNumber => ({
   name: JOB_NAME,
@@ -17,7 +17,7 @@ const createMessage = licenceNumber => ({
   options: {
     singletonKey: licenceNumber
   }
-});
+})
 
 /**
  * Imports a single licence
@@ -25,22 +25,22 @@ const createMessage = licenceNumber => ({
  * @param {String} job.data.licenceNumber
  */
 const handler = async job => {
-  logger.logHandlingJob(job);
+  logger.logHandlingJob(job)
 
   try {
-    await assertImportTablesExist.assertImportTablesExist();
+    await assertImportTablesExist.assertImportTablesExist()
 
     // Import the licence
-    await licenceLoader.load(job.data.licenceNumber);
+    await licenceLoader.load(job.data.licenceNumber)
   } catch (err) {
-    logger.logJobError(job, err);
-    throw err;
+    logger.logJobError(job, err)
+    throw err
   }
-};
+}
 
 module.exports = {
   createMessage,
   handler,
   jobName: JOB_NAME,
   options
-};
+}

--- a/src/modules/nald-import/jobs/index.js
+++ b/src/modules/nald-import/jobs/index.js
@@ -1,27 +1,27 @@
-'use strict';
+'use strict'
 
 const s3Download = {
   job: require('./s3-download'),
   onCompleteHandler: require('./s3-download-complete')
-};
+}
 
 const populatePendingImport = {
   job: require('./populate-pending-import'),
   onCompleteHandler: require('./populate-pending-import-complete')
-};
+}
 
 const deleteRemovedDocuments = {
   job: require('./delete-removed-documents'),
   onCompleteHandler: require('./delete-removed-documents-complete')
-};
+}
 
 const importLicence = {
   job: require('./import-licence')
-};
+}
 
 module.exports = {
   s3Download,
   populatePendingImport,
   deleteRemovedDocuments,
   importLicence
-};
+}

--- a/src/modules/nald-import/jobs/lib/logger.js
+++ b/src/modules/nald-import/jobs/lib/logger.js
@@ -1,22 +1,22 @@
-const { logger } = require('../../../../logger');
+const { logger } = require('../../../../logger')
 
 const logHandlingJob = job =>
-  logger.info(`Handling job: ${job.name}`, job.data);
+  logger.info(`Handling job: ${job.name}`, job.data)
 
 const logJobError = (job, err) =>
-  logger.error(`Error handling job ${job.name}`, err, job.data);
+  logger.error(`Error handling job ${job.name}`, err, job.data)
 
 const logFailedJob = job =>
-  logger.error(`Job: ${job.data.request.name} failed, aborting`, job.data.request.data);
+  logger.error(`Job: ${job.data.request.name} failed, aborting`, job.data.request.data)
 
 const logHandlingOnCompleteJob = job =>
-  logger.info(`Handling onComplete job: ${job.data.request.name}`, job.data.request.data);
+  logger.info(`Handling onComplete job: ${job.data.request.name}`, job.data.request.data)
 
 const logHandlingOnCompleteError = (job, err) =>
-  logger.error(`Error handling onComplete job: ${job.data.request.name}`, err, job.data.request.data);
+  logger.error(`Error handling onComplete job: ${job.data.request.name}`, err, job.data.request.data)
 
 const logAbortingOnComplete = job =>
-  logger.info(`Aborting onComplete job: ${job.data.request.name}`, job.data);
+  logger.info(`Aborting onComplete job: ${job.data.request.name}`, job.data)
 
 module.exports = {
   logHandlingJob,
@@ -25,4 +25,4 @@ module.exports = {
   logHandlingOnCompleteJob,
   logHandlingOnCompleteError,
   logAbortingOnComplete
-};
+}

--- a/src/modules/nald-import/jobs/populate-pending-import-complete.js
+++ b/src/modules/nald-import/jobs/populate-pending-import-complete.js
@@ -1,24 +1,24 @@
-'use strict';
+'use strict'
 
-const logger = require('./lib/logger');
-const importLicenceJob = require('./import-licence');
+const logger = require('./lib/logger')
+const importLicenceJob = require('./import-licence')
 
 const importLicenceComplete = async (job, messageQueue) => {
   if (job.failed) {
-    return logger.logFailedJob(job);
+    return logger.logFailedJob(job)
   }
 
-  logger.logHandlingOnCompleteJob(job);
+  logger.logHandlingOnCompleteJob(job)
 
   try {
-    const { licenceNumbers } = job.data.response;
+    const { licenceNumbers } = job.data.response
     for (const licenceNumber of licenceNumbers) {
-      await messageQueue.publish(importLicenceJob.createMessage(licenceNumber));
+      await messageQueue.publish(importLicenceJob.createMessage(licenceNumber))
     }
   } catch (err) {
-    logger.logHandlingOnCompleteError(job, err);
-    throw err;
+    logger.logHandlingOnCompleteError(job, err)
+    throw err
   }
-};
+}
 
-module.exports = importLicenceComplete;
+module.exports = importLicenceComplete

--- a/src/modules/nald-import/jobs/populate-pending-import.js
+++ b/src/modules/nald-import/jobs/populate-pending-import.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
-const logger = require('./lib/logger');
-const assertImportTablesExist = require('../lib/assert-import-tables-exist');
+const logger = require('./lib/logger')
+const assertImportTablesExist = require('../lib/assert-import-tables-exist')
 
-const JOB_NAME = 'nald-import.populate-pending-import';
-const importService = require('../../../lib/services/import');
+const JOB_NAME = 'nald-import.populate-pending-import'
+const importService = require('../../../lib/services/import')
 
 const createMessage = () => ({
   name: JOB_NAME,
@@ -12,24 +12,24 @@ const createMessage = () => ({
     expireIn: '1 hours',
     singletonKey: JOB_NAME
   }
-});
+})
 
 const handler = async job => {
-  logger.logHandlingJob(job);
+  logger.logHandlingJob(job)
 
   try {
-    await assertImportTablesExist.assertImportTablesExist();
-    const licenceNumbers = await importService.getLicenceNumbers();
+    await assertImportTablesExist.assertImportTablesExist()
+    const licenceNumbers = await importService.getLicenceNumbers()
 
-    return { licenceNumbers };
+    return { licenceNumbers }
   } catch (err) {
-    logger.logJobError(job, err);
-    throw err;
+    logger.logJobError(job, err)
+    throw err
   }
-};
+}
 
 module.exports = {
   createMessage,
   handler,
   jobName: JOB_NAME
-};
+}

--- a/src/modules/nald-import/jobs/s3-download-complete.js
+++ b/src/modules/nald-import/jobs/s3-download-complete.js
@@ -1,23 +1,23 @@
-'use strict';
+'use strict'
 
-const logger = require('./lib/logger');
+const logger = require('./lib/logger')
 
-const populatePendingImportJob = require('./populate-pending-import');
-const deleteRemovedDocumentsJob = require('./delete-removed-documents');
-const importLicenceJob = require('./import-licence');
+const populatePendingImportJob = require('./populate-pending-import')
+const deleteRemovedDocumentsJob = require('./delete-removed-documents')
+const importLicenceJob = require('./import-licence')
 
 const s3DownloadComplete = async (job, messageQueue) => {
   if (job.failed) {
-    return logger.logFailedJob(job);
+    return logger.logFailedJob(job)
   }
 
-  logger.logHandlingOnCompleteJob(job);
+  logger.logHandlingOnCompleteJob(job)
 
   try {
-    const { isRequired } = job.data.response;
+    const { isRequired } = job.data.response
 
     if (!isRequired) {
-      return logger.logAbortingOnComplete(job);
+      return logger.logAbortingOnComplete(job)
     }
 
     // Delete existing PG boss import queues
@@ -25,14 +25,14 @@ const s3DownloadComplete = async (job, messageQueue) => {
       messageQueue.deleteQueue(importLicenceJob.jobName),
       messageQueue.deleteQueue(deleteRemovedDocumentsJob.jobName),
       messageQueue.deleteQueue(populatePendingImportJob.jobName)
-    ]);
+    ])
 
     // Publish a new job to delete any removed documents
-    await messageQueue.publish(deleteRemovedDocumentsJob.createMessage());
+    await messageQueue.publish(deleteRemovedDocumentsJob.createMessage())
   } catch (err) {
-    logger.logHandlingOnCompleteError(job, err);
-    throw err;
+    logger.logHandlingOnCompleteError(job, err)
+    throw err
   }
-};
+}
 
-module.exports = s3DownloadComplete;
+module.exports = s3DownloadComplete

--- a/src/modules/nald-import/lib/assert-import-tables-exist.js
+++ b/src/modules/nald-import/lib/assert-import-tables-exist.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const { NALDImportTablesError } = require('./errors');
-const coreQueries = require('./nald-queries/core');
+const { NALDImportTablesError } = require('./errors')
+const coreQueries = require('./nald-queries/core')
 
 const assertImportTablesExist = async () => {
-  const exists = await coreQueries.importTableExists();
+  const exists = await coreQueries.importTableExists()
   if (!exists) {
-    throw new NALDImportTablesError();
+    throw new NALDImportTablesError()
   }
-};
+}
 
 module.exports = {
   assertImportTablesExist
-};
+}

--- a/src/modules/nald-import/lib/constants.js
+++ b/src/modules/nald-import/lib/constants.js
@@ -1,4 +1,4 @@
-const config = require('../../../../config');
+const config = require('../../../../config')
 
 module.exports = {
   S3_IMPORT_PATH: config.import.nald.path,
@@ -8,4 +8,4 @@ module.exports = {
   SCHEMA_IMPORT: 'import',
   SCHEMA_TEMP: 'import_temp',
   APPLICATION_STATE_KEY: 'nald-import'
-};
+}

--- a/src/modules/nald-import/lib/db.js
+++ b/src/modules/nald-import/lib/db.js
@@ -1,5 +1,5 @@
-const { pool } = require('../../../lib/connectors/db');
-const { logger } = require('../../../logger');
+const { pool } = require('../../../lib/connectors/db')
+const { logger } = require('../../../logger')
 
 /**
  * Perform a database query by getting a client from the connection pool and releasing
@@ -10,17 +10,17 @@ const { logger } = require('../../../logger');
  */
 const dbQuery = async (query, params = []) => {
   try {
-    const { error, rows } = await pool.query(query, params);
+    const { error, rows } = await pool.query(query, params)
     if (error) {
-      throw error;
+      throw error
     }
-    return rows;
+    return rows
   } catch (error) {
-    logger.error('dbQuery error', error);
-    throw error;
+    logger.error('dbQuery error', error)
+    throw error
   }
-};
+}
 
 module.exports = {
   dbQuery
-};
+}

--- a/src/modules/nald-import/lib/end-date.js
+++ b/src/modules/nald-import/lib/end-date.js
@@ -1,9 +1,9 @@
-const moment = require('moment');
-const { first } = require('lodash');
+const moment = require('moment')
+const { first } = require('lodash')
 
-const isValidDate = value => moment(value, 'DD/MM/YYYY').isValid();
+const isValidDate = value => moment(value, 'DD/MM/YYYY').isValid()
 
-const mapDate = value => moment(value, 'DD/MM/YYYY').format('YYYY-MM-DD');
+const mapDate = value => moment(value, 'DD/MM/YYYY').format('YYYY-MM-DD')
 
 /**
  * End date is the minimum of expiry date, revoked date and lapsed date
@@ -15,15 +15,15 @@ const getEndDate = (data = {}) => {
     data.EXPIRY_DATE,
     data.REV_DATE,
     data.LAPSED_DATE
-  ];
+  ]
   const sortedAndFiltered = dates
     .filter(isValidDate)
     .map(mapDate)
-    .sort();
+    .sort()
 
-  return first(sortedAndFiltered);
-};
+  return first(sortedAndFiltered)
+}
 
 module.exports = {
   getEndDate
-};
+}

--- a/src/modules/nald-import/lib/errors.js
+++ b/src/modules/nald-import/lib/errors.js
@@ -1,23 +1,23 @@
-const { DBError } = require('../../../lib/errors');
+const { DBError } = require('../../../lib/errors')
 
 class LicenceNotFoundError extends Error {
   constructor (message) {
-    super(message);
-    this.name = 'LicenceNotFoundError';
+    super(message)
+    this.name = 'LicenceNotFoundError'
   }
 }
 
 class MetaDataError extends Error {
   constructor (message) {
-    super(message);
-    this.name = 'MetaDataError';
+    super(message)
+    this.name = 'MetaDataError'
   }
 }
 
 class NALDImportTablesError extends DBError {
   constructor (message) {
-    super(message);
-    this.name = 'NALDImportTablesError';
+    super(message)
+    this.name = 'NALDImportTablesError'
   }
 }
 
@@ -25,4 +25,4 @@ module.exports = {
   LicenceNotFoundError,
   MetaDataError,
   NALDImportTablesError
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/addresses.js
+++ b/src/modules/nald-import/lib/nald-queries/addresses.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const db = require('../db');
-const sql = require('./sql/addresses');
+const db = require('../db')
+const sql = require('./sql/addresses')
 
 const getAddress = async (addressId, regionCode) => {
-  return db.dbQuery(sql.getAddress, [addressId, regionCode]);
-};
+  return db.dbQuery(sql.getAddress, [addressId, regionCode])
+}
 
 module.exports = {
   getAddress
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/cache.js
+++ b/src/modules/nald-import/lib/nald-queries/cache.js
@@ -1,28 +1,28 @@
-'use strict';
+'use strict'
 
-const { logger } = require('../../../../logger');
-const { flatMap } = require('lodash');
+const { logger } = require('../../../../logger')
+const { flatMap } = require('lodash')
 
 const createCachedQuery = (server, methodName, generate) => {
   return server.cache({
     segment: methodName,
     expiresIn: 5 * 60 * 1000, // cache for 5 mins
     generateFunc: id => {
-      logger.info(`Accessing database for ${methodName}`, id);
-      return generate(id);
+      logger.info(`Accessing database for ${methodName}`, id)
+      return generate(id)
     },
     generateTimeout: 5000
-  });
-};
+  })
+}
 
 const createId = (key, params) => {
   return {
     id: `${key}:${flatMap(Object.entries(params)).join(':')}`,
     ...params
-  };
-};
+  }
+}
 
 module.exports = {
   createCachedQuery,
   createId
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/cams.js
+++ b/src/modules/nald-import/lib/nald-queries/cams.js
@@ -1,26 +1,26 @@
-'use strict';
+'use strict'
 
-const server = require('../../../../../server');
-const db = require('../db');
-const sql = require('./sql/cams');
-const cache = require('./cache');
+const server = require('../../../../../server')
+const db = require('../db')
+const sql = require('./sql/cams')
+const cache = require('./cache')
 
 const _createCamsCache = () => {
   return cache.createCachedQuery(server, 'getCams', id => {
-    const params = [id.code, id.regionCode];
-    return db.dbQuery(sql.getCams, params);
-  });
-};
+    const params = [id.code, id.regionCode]
+    return db.dbQuery(sql.getCams, params)
+  })
+}
 
-const _getCamsCache = _createCamsCache();
+const _getCamsCache = _createCamsCache()
 
 const getCams = (code, regionCode) => {
-  const id = cache.createId('cams', { code, regionCode });
-  return _getCamsCache.get(id);
-};
+  const id = cache.createId('cams', { code, regionCode })
+  return _getCamsCache.get(id)
+}
 
 module.exports = {
   getCams,
   _getCamsCache,
   _createCamsCache
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/charge-versions-metadata.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions-metadata.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const insertChargeVersionMetadata = `
 insert into water_import.charge_versions_metadata
@@ -11,8 +11,8 @@ on conflict (external_id) do update set
   status=EXCLUDED.status,
   is_nald_gap=EXCLUDED.is_nald_gap,
   date_updated=NOW();
-`;
+`
 
 module.exports = {
   insertChargeVersionMetadata
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/charge-versions.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const getNonDraftChargeVersionsForLicence = `SELECT
   l."LIC_NO" AS licence_ref,
@@ -30,8 +30,8 @@ WHERE v."FGAC_REGION_CODE"=$1 and v."AABL_ID"=$2 and v."STATUS"<>'DRAFT'
 ORDER BY 
   to_date(v."EFF_ST_DATE", 'DD/MM/YYYY'),
   v."VERS_NO"::integer;
-`;
+`
 
 module.exports = {
   getNonDraftChargeVersionsForLicence
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/core.js
+++ b/src/modules/nald-import/lib/nald-queries/core.js
@@ -1,21 +1,21 @@
-'use strict';
+'use strict'
 
-const db = require('../db');
-const sql = require('./sql/core');
+const db = require('../db')
+const sql = require('./sql/core')
 
 /**
  * Checks whether import table exists
  * @return {Promise} resolves with boolean
  */
 const importTableExists = async () => {
-  const rows = await db.dbQuery(sql.importTableExists);
+  const rows = await db.dbQuery(sql.importTableExists)
 
   if (rows.length) {
-    return rows[0].count >= 125;
+    return rows[0].count >= 125
   }
-  return false;
-};
+  return false
+}
 
 module.exports = {
   importTableExists
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/licences.js
+++ b/src/modules/nald-import/lib/nald-queries/licences.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
-const db = require('../db');
-const sql = require('./sql/licences');
+const db = require('../db')
+const sql = require('./sql/licences')
 
 const getLicence = async (licenceNo) => {
-  return db.dbQuery(sql.getLicence, [licenceNo]);
-};
+  return db.dbQuery(sql.getLicence, [licenceNo])
+}
 
 const getCurrentVersion = async (licenceId, regionCode) => {
-  const rows = await db.dbQuery(sql.getCurrentVersion, [licenceId, regionCode]);
-  return rows.length ? rows[0] : null;
-};
+  const rows = await db.dbQuery(sql.getCurrentVersion, [licenceId, regionCode])
+  return rows.length ? rows[0] : null
+}
 
 const getVersions = async (licenceId, regionCode) => {
-  return db.dbQuery(sql.getVersions, [licenceId, regionCode]);
-};
+  return db.dbQuery(sql.getVersions, [licenceId, regionCode])
+}
 
 /**
  * Get current formats for the specified licence
@@ -23,12 +23,12 @@ const getVersions = async (licenceId, regionCode) => {
  * @return {Promise} resolves with list of formats
  */
 const getCurrentFormats = async (licenceId, regionCode) => {
-  return db.dbQuery(sql.getCurrentFormats, [licenceId, regionCode]);
-};
+  return db.dbQuery(sql.getCurrentFormats, [licenceId, regionCode])
+}
 
 module.exports = {
   getLicence,
   getCurrentVersion,
   getVersions,
   getCurrentFormats
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/parties.js
+++ b/src/modules/nald-import/lib/nald-queries/parties.js
@@ -1,38 +1,38 @@
-'use strict';
+'use strict'
 
-const server = require('../../../../../server');
-const db = require('../db');
-const cache = require('./cache');
-const sql = require('./sql/parties');
+const server = require('../../../../../server')
+const db = require('../db')
+const cache = require('./cache')
+const sql = require('./sql/parties')
 
 const _createPartiesCache = () => {
   return cache.createCachedQuery(server, 'getParties', id => {
-    return db.dbQuery(sql.getParties, [id.partyId, id.regionCode]);
-  });
-};
+    return db.dbQuery(sql.getParties, [id.partyId, id.regionCode])
+  })
+}
 
 const _createPartyContactsCache = () => {
   return cache.createCachedQuery(server, 'getPartyContacts', id => {
-    return db.dbQuery(sql.getPartyContacts, [id.partyId, id.regionCode]);
-  });
-};
+    return db.dbQuery(sql.getPartyContacts, [id.partyId, id.regionCode])
+  })
+}
 
-const _getPartiesCache = _createPartiesCache();
-const _getPartyContactsCache = _createPartyContactsCache();
+const _getPartiesCache = _createPartiesCache()
+const _getPartyContactsCache = _createPartyContactsCache()
 
 const getParties = async (partyId, regionCode) => {
-  const id = cache.createId('parties', { partyId, regionCode });
-  return _getPartiesCache.get(id);
-};
+  const id = cache.createId('parties', { partyId, regionCode })
+  return _getPartiesCache.get(id)
+}
 
 const getPartyContacts = async (partyId, regionCode) => {
-  const id = cache.createId('partyContacts', { partyId, regionCode });
-  return _getPartyContactsCache.get(id);
-};
+  const id = cache.createId('partyContacts', { partyId, regionCode })
+  return _getPartyContactsCache.get(id)
+}
 
 const getParty = async (partyId, regionCode) => {
-  return db.dbQuery(sql.getParty, [partyId, regionCode]);
-};
+  return db.dbQuery(sql.getParty, [partyId, regionCode])
+}
 
 module.exports = {
   _createPartiesCache,
@@ -42,4 +42,4 @@ module.exports = {
   getParties,
   getParty,
   getPartyContacts
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/purposes.js
+++ b/src/modules/nald-import/lib/nald-queries/purposes.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const server = require('../../../../../server');
-const db = require('../db');
-const sql = require('./sql/purposes');
-const cache = require('./cache');
+const server = require('../../../../../server')
+const db = require('../db')
+const sql = require('./sql/purposes')
+const cache = require('./cache')
 
 const getPurposes = async (licenceId, FGAC_REGION_CODE, ISSUE_NO, INCR_NO) => {
-  let query, params;
+  let query, params
   if (ISSUE_NO && INCR_NO) {
     query = `
       select *
@@ -15,48 +15,48 @@ const getPurposes = async (licenceId, FGAC_REGION_CODE, ISSUE_NO, INCR_NO) => {
       and "FGAC_REGION_CODE" = $2
       and "AABV_ISSUE_NO" = $3
       and "AABV_INCR_NO" = $4;
-    `;
-    params = [licenceId, FGAC_REGION_CODE, ISSUE_NO, INCR_NO];
+    `
+    params = [licenceId, FGAC_REGION_CODE, ISSUE_NO, INCR_NO]
   } else {
     query = `
       select *
       from import."NALD_ABS_LIC_PURPOSES" p
       where p."AABV_AABL_ID" = $1 and "FGAC_REGION_CODE" = $2;
-    `;
-    params = [licenceId, FGAC_REGION_CODE];
+    `
+    params = [licenceId, FGAC_REGION_CODE]
   }
-  return db.dbQuery(query, params);
-};
+  return db.dbQuery(query, params)
+}
 
 const getPurposePoints = async (purposeId, regionCode) => {
-  const params = [purposeId, regionCode];
-  return db.dbQuery(sql.getPurposePoints, params);
-};
+  const params = [purposeId, regionCode]
+  return db.dbQuery(sql.getPurposePoints, params)
+}
 
 const _createPurposeCache = () => {
   return cache.createCachedQuery(server, 'getPurpose', id => {
-    const params = [id.primary, id.secondary, id.tertiary];
-    return db.dbQuery(sql.getPurpose, params);
-  });
-};
+    const params = [id.primary, id.secondary, id.tertiary]
+    return db.dbQuery(sql.getPurpose, params)
+  })
+}
 
-const _getPurposeCache = _createPurposeCache();
+const _getPurposeCache = _createPurposeCache()
 
 const getPurpose = async (purpose) => {
-  const { primary, secondary, tertiary } = purpose;
-  const id = cache.createId('purpose', { primary, secondary, tertiary });
-  return _getPurposeCache.get(id);
-};
+  const { primary, secondary, tertiary } = purpose
+  const id = cache.createId('purpose', { primary, secondary, tertiary })
+  return _getPurposeCache.get(id)
+}
 
 const getPurposePointLicenceAgreements = async (AABP_ID, FGAC_REGION_CODE) => {
-  const params = [AABP_ID, FGAC_REGION_CODE];
-  return db.dbQuery(sql.getPurposePointLicenceAgreements, params);
-};
+  const params = [AABP_ID, FGAC_REGION_CODE]
+  return db.dbQuery(sql.getPurposePointLicenceAgreements, params)
+}
 
 const getPurposePointLicenceConditions = async (AABP_ID, FGAC_REGION_CODE) => {
-  const params = [AABP_ID, FGAC_REGION_CODE];
-  return db.dbQuery(sql.getPurposePointLicenceConditions, params);
-};
+  const params = [AABP_ID, FGAC_REGION_CODE]
+  return db.dbQuery(sql.getPurposePointLicenceConditions, params)
+}
 
 module.exports = {
   _getPurposeCache,
@@ -66,4 +66,4 @@ module.exports = {
   getPurpose,
   getPurposePointLicenceAgreements,
   getPurposePointLicenceConditions
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/returns.js
+++ b/src/modules/nald-import/lib/nald-queries/returns.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
-const server = require('../../../../../server');
-const moment = require('moment');
-const db = require('../db');
-const cache = require('./cache');
-const sql = require('./sql/returns');
+const server = require('../../../../../server')
+const moment = require('moment')
+const db = require('../db')
+const cache = require('./cache')
+const sql = require('./sql/returns')
 
 /**
  * Gets form logs for specified licence number
@@ -12,8 +12,8 @@ const sql = require('./sql/returns');
  * @return {Promise} resolves with array of DB records
  */
 const getFormats = (licenceNumber) => {
-  return db.dbQuery(sql.getFormats, [licenceNumber]);
-};
+  return db.dbQuery(sql.getFormats, [licenceNumber])
+}
 
 /**
  * Get purposes attached to a returns format
@@ -22,8 +22,8 @@ const getFormats = (licenceNumber) => {
  * @return {Promise} resolves with array of DB records
  */
 const getFormatPurposes = (formatId, regionCode) => {
-  return db.dbQuery(sql.getFormatPurposes, [formatId, regionCode]);
-};
+  return db.dbQuery(sql.getFormatPurposes, [formatId, regionCode])
+}
 
 /**
  * Get points attached to a returns format
@@ -32,8 +32,8 @@ const getFormatPurposes = (formatId, regionCode) => {
  * @return {Promise} resolves with array of DB records
  */
 const getFormatPoints = (formatId, regionCode) => {
-  return db.dbQuery(sql.getFormatPoints, [formatId, regionCode]);
-};
+  return db.dbQuery(sql.getFormatPoints, [formatId, regionCode])
+}
 
 /**
  * Get form logs for specified return format
@@ -41,8 +41,8 @@ const getFormatPoints = (formatId, regionCode) => {
  * @return {Promise} resolves with array of DB records
  */
 const getLogs = (formatId, regionCode) => {
-  return db.dbQuery(sql.getLogs, [formatId, regionCode]);
-};
+  return db.dbQuery(sql.getLogs, [formatId, regionCode])
+}
 
 /**
  * Get returns lines
@@ -53,9 +53,9 @@ const getLogs = (formatId, regionCode) => {
  * @return {Promise} resolves with array of DB records
  */
 const getLines = (formatId, regionCode, dateFrom, dateTo) => {
-  const params = [formatId, regionCode, dateFrom, dateTo];
-  return db.dbQuery(sql.getLines, params);
-};
+  const params = [formatId, regionCode, dateFrom, dateTo]
+  return db.dbQuery(sql.getLines, params)
+}
 
 /**
  * Get returns lines for log
@@ -65,10 +65,10 @@ const getLines = (formatId, regionCode, dateFrom, dateTo) => {
  * @return {Promise} resolves with array of DB records
  */
 const getLogLines = (formatId, regionCode, logDateFrom) => {
-  const from = moment(logDateFrom, 'DD/MM/YYYY').format('YYYYMMDD') + '000000';
-  const params = [formatId, regionCode, from];
-  return db.dbQuery(sql.getLogLines, params);
-};
+  const from = moment(logDateFrom, 'DD/MM/YYYY').format('YYYYMMDD') + '000000'
+  const params = [formatId, regionCode, from]
+  return db.dbQuery(sql.getLogLines, params)
+}
 
 /**
  * Checks for nil return over the specified time period
@@ -79,10 +79,10 @@ const getLogLines = (formatId, regionCode, logDateFrom) => {
  * @return {Promise} resolves with boolean
  */
 const isNilReturn = async (formatId, regionCode, dateFrom, dateTo) => {
-  const params = [formatId, regionCode, dateFrom, dateTo];
-  const rows = await db.dbQuery(sql.isNilReturn, params);
-  return rows[0].total_qty === 0;
-};
+  const params = [formatId, regionCode, dateFrom, dateTo]
+  const rows = await db.dbQuery(sql.isNilReturn, params)
+  return rows[0].total_qty === 0
+}
 
 /**
  * Gets the split date for considering returns as either current / non current
@@ -93,12 +93,12 @@ const isNilReturn = async (formatId, regionCode, dateFrom, dateTo) => {
  * @return {String|null} split date in format YYYY-MM-DD, or null if none found
  */
 const getSplitDate = async (licenceNumber) => {
-  const rows = await db.dbQuery(sql.getSplitDate, [licenceNumber]);
+  const rows = await db.dbQuery(sql.getSplitDate, [licenceNumber])
 
   return (rows.length === 1)
     ? moment(rows[0].EFF_ST_DATE, 'DD/MM/YYYY').format('YYYY-MM-DD')
-    : null;
-};
+    : null
+}
 
 /**
  * Gets the reason code from the mod log relating to a new return version
@@ -112,18 +112,18 @@ const getReturnVersionReason = async (licenceId, regionCode, versionNumber) => {
     licenceId,
     regionCode,
     versionNumber
-  });
-  return _getReturnVersionReasonCache.get(id);
-};
+  })
+  return _getReturnVersionReasonCache.get(id)
+}
 
 const _createReturnVersionReasonCache = () => {
   return cache.createCachedQuery(server, 'getReturnVersionReason', id => {
-    const params = [id.licenceId, id.versionNumber, id.regionCode];
-    return db.dbQuery(sql.getReturnVersionReason, params);
-  });
-};
+    const params = [id.licenceId, id.versionNumber, id.regionCode]
+    return db.dbQuery(sql.getReturnVersionReason, params)
+  })
+}
 
-const _getReturnVersionReasonCache = _createReturnVersionReasonCache();
+const _getReturnVersionReasonCache = _createReturnVersionReasonCache()
 
 module.exports = {
   _createReturnVersionReasonCache,
@@ -137,4 +137,4 @@ module.exports = {
   isNilReturn,
   getSplitDate,
   getReturnVersionReason
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/roles.js
+++ b/src/modules/nald-import/lib/nald-queries/roles.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const db = require('../db');
-const sql = require('./sql/roles');
+const db = require('../db')
+const sql = require('./sql/roles')
 
 const getRoles = async (AABL_ID, FGAC_REGION_CODE) => {
-  return db.dbQuery(sql.getRoles, [AABL_ID, FGAC_REGION_CODE]);
-};
+  return db.dbQuery(sql.getRoles, [AABL_ID, FGAC_REGION_CODE])
+}
 
 module.exports = {
   getRoles
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/addresses.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/addresses.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
 const getAddress = `
   select a.*
   from import."NALD_ADDRESSES" a
   where "ID"=$1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 module.exports = {
   getAddress
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/cams.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/cams.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
 const getCams = `
   select *
   from import."NALD_REP_UNITS"
   where "CODE" = $1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 module.exports = {
   getCams
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/core.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/core.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
 const importTableExists = `
   select count(*)
   from information_schema.tables
   where table_schema = 'import';
-`;
+`
 
 module.exports = {
   importTableExists
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/licences.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/licences.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const getLicence = `
   select l.*,
@@ -10,7 +10,7 @@ const getLicence = `
   ) as end_date
   from import."NALD_ABS_LICENCES" l
   where l."LIC_NO" = $1;
-`;
+`
 
 const getCurrentVersion = `
   SELECT v.*, t.*
@@ -46,13 +46,13 @@ const getCurrentVersion = `
   )
   ORDER BY "ISSUE_NO" DESC, "INCR_NO" DESC
   LIMIT 1;
-`;
+`
 
 const getVersions = `
   select *
   from import."NALD_ABS_LIC_VERSIONS"
   where "AABL_ID" = $1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getCurrentFormats = `
   SELECT f.*
@@ -64,11 +64,11 @@ const getCurrentFormats = `
   WHERE rv."AABL_ID" = $1
   AND rv."FGAC_REGION_CODE" = $2
   AND rv."STATUS" = 'CURR';
-`;
+`
 
 module.exports = {
   getLicence,
   getCurrentVersion,
   getVersions,
   getCurrentFormats
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/parties.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/parties.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
 const getParties = `
   select p.*
   from import."NALD_PARTIES" p
   where p."ID" = $1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getPartyContacts = `
   select c.*, row_to_json(a.*) AS party_address
@@ -14,16 +14,16 @@ const getPartyContacts = `
   where c."APAR_ID" = $1
   and c."FGAC_REGION_CODE" = $2
   and a."FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getParty = `
   select p.*
   from import."NALD_PARTIES" p
   where "ID" = $1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 module.exports = {
   getParties,
   getPartyContacts,
   getParty
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/purposes.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/purposes.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const getPurposePoints = `
   select
@@ -14,7 +14,7 @@ const getPurposePoints = `
   where pp."AABP_ID" = $1
   and pp."FGAC_REGION_CODE" = $2
   and p."FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getPurpose = `
   select
@@ -26,12 +26,12 @@ const getPurpose = `
     left join import."NALD_PURP_SECS" p2 on p2."CODE" = $2
     left join import."NALD_PURP_USES" p3 on p3."CODE" = $3
   where p1."CODE" = $1;
-`;
+`
 const getPurposePointLicenceAgreements = `
   select *
   from import."NALD_LIC_AGRMNTS"
   where "AABP_ID" = $1 and "FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getPurposePointLicenceConditions = `
   select c.*, row_to_json(ct.*) as condition_type
@@ -41,11 +41,11 @@ const getPurposePointLicenceConditions = `
       and ct."SUBCODE" = c."ACIN_SUBCODE"
   where c."AABP_ID" = $1 and c."FGAC_REGION_CODE" = $2
   order by "DISP_ORD" asc;
-`;
+`
 
 module.exports = {
   getPurpose,
   getPurposePoints,
   getPurposePointLicenceAgreements,
   getPurposePointLicenceConditions
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/returns.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/returns.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const getFormats = `
   SELECT f.*,
@@ -17,7 +17,7 @@ const getFormats = `
       AND f."FGAC_REGION_CODE"=v."FGAC_REGION_CODE"
   WHERE l."LIC_NO"=$1
   ORDER BY to_date(v."EFF_ST_DATE", 'DD/MM/YYYY');
-`;
+`
 
 const getFormatPurposes = `
   SELECT p.*,
@@ -32,7 +32,7 @@ const getFormatPurposes = `
     LEFT JOIN "import"."NALD_PURP_USES" p3
       ON p."APUR_APUS_CODE" = p3."CODE"
   WHERE p."ARTY_ID" = $1 AND p."FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getFormatPoints = `
   SELECT p.*
@@ -41,14 +41,14 @@ const getFormatPoints = `
       ON fp."AAIP_ID" = p."ID" AND fp."FGAC_REGION_CODE" = p."FGAC_REGION_CODE"
   WHERE fp."ARTY_ID" = $1
   AND fp."FGAC_REGION_CODE" = $2;
-`;
+`
 
 const getLogs = `
   SELECT l.*
   FROM "import"."NALD_RET_FORM_LOGS" l
   WHERE l."ARTY_ID" = $1 AND l."FGAC_REGION_CODE" = $2
   ORDER BY to_date(l."DATE_FROM", 'DD/MM/YYYY');
-`;
+`
 
 const getLines = `
   SELECT l.*
@@ -58,7 +58,7 @@ const getLines = `
   AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')>=to_date($3, 'YYYY-MM-DD')
   AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')<=to_date($4, 'YYYY-MM-DD')
   ORDER BY "RET_DATE";
-`;
+`
 
 const getLogLines = `
   SELECT l.*
@@ -67,7 +67,7 @@ const getLogLines = `
   AND l."FGAC_REGION_CODE" = $2
   AND "ARFL_DATE_FROM" = $3
   ORDER BY "RET_DATE";
-`;
+`
 
 const isNilReturn = `
   SELECT SUM(
@@ -81,7 +81,7 @@ const isNilReturn = `
   AND l."FGAC_REGION_CODE"=$2
   AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')>=to_date($3, 'YYYY-MM-DD')
   AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')<=to_date($4, 'YYYY-MM-DD');
-`;
+`
 
 const getSplitDate = `
   SELECT l."ID", v."ISSUE_NO", v."INCR_NO", v."EFF_ST_DATE", m.*
@@ -97,7 +97,7 @@ const getSplitDate = `
   AND m."AMRE_CODE" = 'SUCC'
   ORDER BY to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') DESC
   LIMIT 1;
-`;
+`
 
 const getReturnVersionReason = `
   SELECT l."AMRE_CODE"
@@ -110,7 +110,7 @@ const getReturnVersionReason = `
   WHERE rv."AABL_ID" = $1
   AND rv."VERS_NO" = $2
   AND rv."FGAC_REGION_CODE" = $3;
-`;
+`
 
 module.exports = {
   getFormats,
@@ -122,4 +122,4 @@ module.exports = {
   isNilReturn,
   getSplitDate,
   getReturnVersionReason
-};
+}

--- a/src/modules/nald-import/lib/nald-queries/sql/roles.js
+++ b/src/modules/nald-import/lib/nald-queries/sql/roles.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 const getRoles = `
   select
@@ -26,8 +26,8 @@ const getRoles = `
     and p."FGAC_REGION_CODE" = $2
     and a."FGAC_REGION_CODE" = $2
     and (r."EFF_END_DATE" = 'null' or to_date(r."EFF_END_DATE", 'DD/MM/YYYY') > now());
-`;
+`
 
 module.exports = {
   getRoles
-};
+}

--- a/src/modules/nald-import/lib/persist-returns.js
+++ b/src/modules/nald-import/lib/persist-returns.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
 /**
  * Creates or updates return cycle via returns API based on the return end date
  */
-const { pick } = require('lodash');
-const moment = require('moment');
+const { pick } = require('lodash')
+const moment = require('moment')
 
-const { replicateReturnsDataFromNaldForNonProductionEnvironments } = require('./returns-helper');
-const returnsApi = require('../../../lib/connectors/returns');
-const config = require('../../../../config');
-const { returns } = returnsApi;
+const { replicateReturnsDataFromNaldForNonProductionEnvironments } = require('./returns-helper')
+const returnsApi = require('../../../lib/connectors/returns')
+const config = require('../../../../config')
+const { returns } = returnsApi
 
 /**
  * Checks whether return exists
@@ -17,12 +17,12 @@ const { returns } = returnsApi;
  * @return {Promise} resolves with boolean
  */
 const returnExists = async (returnId) => {
-  const { data } = await returns.findOne(returnId);
+  const { data } = await returns.findOne(returnId)
   if (data) {
-    return true;
+    return true
   }
-  return false;
-};
+  return false
+}
 
 /**
  * Gets update data from row
@@ -30,14 +30,14 @@ const returnExists = async (returnId) => {
  * @return {Object} row - with only fields that we wish to update set
  */
 const getUpdateRow = (row) => {
-  const { end_date: endDate } = row;
+  const { end_date: endDate } = row
 
   if (moment(endDate).isBefore('2018-10-31')) {
-    return pick(row, ['status', 'metadata', 'received_date', 'due_date']);
+    return pick(row, ['status', 'metadata', 'received_date', 'due_date'])
   } else {
-    return pick(row, ['metadata', 'due_date']);
+    return pick(row, ['metadata', 'due_date'])
   }
-};
+}
 
 /**
  * Creates or updates return depending on whether start_date
@@ -45,24 +45,24 @@ const getUpdateRow = (row) => {
  * @return {Promise} resolves when row is created/updated
  */
 const createOrUpdateReturn = async row => {
-  const { return_id: returnId } = row;
+  const { return_id: returnId } = row
 
-  const exists = await returnExists(returnId);
+  const exists = await returnExists(returnId)
 
   // Conditional update
   if (exists) {
-    return returns.updateOne(returnId, getUpdateRow(row));
+    return returns.updateOne(returnId, getUpdateRow(row))
   } else {
     // Insert
-    const thisReturn = await returns.create(row);
+    const thisReturn = await returns.create(row)
 
     /* For non-production environments, we allow the system to import the returns data so we can test billing */
     if (config.isAcceptanceTestTarget && config.import.nald.overwriteReturns) {
-      await replicateReturnsDataFromNaldForNonProductionEnvironments(row);
+      await replicateReturnsDataFromNaldForNonProductionEnvironments(row)
     }
-    return thisReturn;
+    return thisReturn
   }
-};
+}
 
 /**
  * Persists list of returns to API
@@ -72,15 +72,15 @@ const createOrUpdateReturn = async row => {
 const persistReturns = async (returns) => {
   for (const ret of returns) {
     if (config.isAcceptanceTestTarget && config.import.nald.overwriteReturns) {
-      await returnsApi.deleteAllReturnsData(ret.return_id);
+      await returnsApi.deleteAllReturnsData(ret.return_id)
     }
-    await createOrUpdateReturn(ret);
+    await createOrUpdateReturn(ret)
   }
-};
+}
 
 module.exports = {
   createOrUpdateReturn,
   getUpdateRow,
   returnExists,
   persistReturns
-};
+}

--- a/src/modules/nald-import/load.js
+++ b/src/modules/nald-import/load.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
 /**
  * Code for loading imported data to the target database(s)
  */
-const uuidV4 = require('uuid/v4');
-const { buildCRMPacket } = require('./transform-crm');
-const { buildReturnsPacket } = require('./transform-returns');
-const { getLicenceJson, buildPermitRepoPacket } = require('./transform-permit');
-const returnsConnector = require('../../lib/connectors/returns');
-const { persistReturns } = require('./lib/persist-returns');
+const uuidV4 = require('uuid/v4')
+const { buildCRMPacket } = require('./transform-crm')
+const { buildReturnsPacket } = require('./transform-returns')
+const { getLicenceJson, buildPermitRepoPacket } = require('./transform-permit')
+const returnsConnector = require('../../lib/connectors/returns')
+const { persistReturns } = require('./lib/persist-returns')
 
-const repository = require('./repositories');
-const { logger } = require('../../logger');
+const repository = require('./repositories')
+const { logger } = require('../../logger')
 
-const chargeVersionMetadataImportService = require('./services/charge-version-metadata-import');
+const chargeVersionMetadataImportService = require('./services/charge-version-metadata-import')
 
 /**
  * Loads data into the permit repository and CRM doc header
@@ -22,15 +22,15 @@ const chargeVersionMetadataImportService = require('./services/charge-version-me
  * @return {Promise} resolves when completed
  */
 const loadPermitAndDocumentHeader = async (licenceNumber, licenceData) => {
-  logger.info(`Import: permit for ${licenceNumber}`);
-  const permit = buildPermitRepoPacket(licenceNumber, 1, 8, licenceData);
-  const { rows: [{ licence_id: permitRepoId }] } = await repository.licence.persist(permit, ['licence_id']);
+  logger.info(`Import: permit for ${licenceNumber}`)
+  const permit = buildPermitRepoPacket(licenceNumber, 1, 8, licenceData)
+  const { rows: [{ licence_id: permitRepoId }] } = await repository.licence.persist(permit, ['licence_id'])
 
   // Create CRM data and persist
-  logger.info(`Import: document header for ${licenceNumber}`);
-  const crmData = buildCRMPacket(licenceData, licenceNumber, permitRepoId);
-  await repository.document.persist({ document_id: uuidV4(), ...crmData });
-};
+  logger.info(`Import: document header for ${licenceNumber}`)
+  const crmData = buildCRMPacket(licenceData, licenceNumber, permitRepoId)
+  await repository.document.persist({ document_id: uuidV4(), ...crmData })
+}
 
 /**
  * Calculates and imports a list of return cycles for the given licence
@@ -40,15 +40,15 @@ const loadPermitAndDocumentHeader = async (licenceNumber, licenceData) => {
  * @return {Promise} resolves when returns imported
  */
 const loadReturns = async (licenceNumber) => {
-  logger.info(`Import: returns for ${licenceNumber}`);
+  logger.info(`Import: returns for ${licenceNumber}`)
 
-  const { returns } = await buildReturnsPacket(licenceNumber);
-  await persistReturns(returns);
+  const { returns } = await buildReturnsPacket(licenceNumber)
+  await persistReturns(returns)
 
   // Clean up invalid cycles
-  const returnIds = returns.map(row => row.return_id);
-  await returnsConnector.voidReturns(licenceNumber, returnIds);
-};
+  const returnIds = returns.map(row => row.return_id)
+  await returnsConnector.voidReturns(licenceNumber, returnIds)
+}
 
 /**
  * Imports the whole licence
@@ -56,18 +56,18 @@ const loadReturns = async (licenceNumber) => {
  * @return {Promise} resolves when complete
  */
 const load = async (licenceNumber) => {
-  const licenceData = await getLicenceJson(licenceNumber);
+  const licenceData = await getLicenceJson(licenceNumber)
 
   if (licenceData.data.versions.length > 0) {
-    await loadPermitAndDocumentHeader(licenceNumber, licenceData);
-    await loadReturns(licenceNumber);
+    await loadPermitAndDocumentHeader(licenceNumber, licenceData)
+    await loadReturns(licenceNumber)
   } else {
-    logger.info(`No versions found for ${licenceNumber}`);
+    logger.info(`No versions found for ${licenceNumber}`)
   }
 
-  await chargeVersionMetadataImportService.importChargeVersionMetadataForLicence(licenceData);
-};
+  await chargeVersionMetadataImportService.importChargeVersionMetadataForLicence(licenceData)
+}
 
 module.exports = {
   load
-};
+}

--- a/src/modules/nald-import/mappers/charge-versions.js
+++ b/src/modules/nald-import/mappers/charge-versions.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const { isNull, sortBy } = require('lodash');
-const moment = require('moment');
-const dateHelpers = require('../../../lib/date-helpers');
+const { isNull, sortBy } = require('lodash')
+const moment = require('moment')
+const dateHelpers = require('../../../lib/date-helpers')
 
-const DATE_FORMAT = 'YYYY-MM-DD';
+const DATE_FORMAT = 'YYYY-MM-DD'
 
-const STATUS_SUPERSEDED = 'superseded';
-const STATUS_CURRENT = 'current';
+const STATUS_SUPERSEDED = 'superseded'
+const STATUS_CURRENT = 'current'
 
-const PERIOD_DAY = 'day';
+const PERIOD_DAY = 'day'
 
 /**
  * Whether this charge version is considered an "error"
@@ -21,10 +21,10 @@ const PERIOD_DAY = 'day';
  * @return {Boolean}
  */
 const isErrorChargeVersion = (chargeVersion, nextChargeVersion) => {
-  const isErrorStatus = chargeVersion.error;
-  const isSameStartDate = nextChargeVersion && (chargeVersion.start_date === nextChargeVersion.start_date);
-  return isErrorStatus || isSameStartDate;
-};
+  const isErrorStatus = chargeVersion.error
+  const isSameStartDate = nextChargeVersion && (chargeVersion.start_date === nextChargeVersion.start_date)
+  return isErrorStatus || isSameStartDate
+}
 
 /**
  * Maps status to equivalent in WRLS
@@ -34,13 +34,13 @@ const isErrorChargeVersion = (chargeVersion, nextChargeVersion) => {
  * @return {Object} charge version updated with mapped status
  */
 const mapChargeVersionStatus = (chargeVersion, index, arr) => {
-  const nextRow = arr[index + 1];
+  const nextRow = arr[index + 1]
 
   return {
     ...chargeVersion,
     status: isErrorChargeVersion(chargeVersion, nextRow) ? STATUS_SUPERSEDED : STATUS_CURRENT
-  };
-};
+  }
+}
 
 /**
  * Maps a charge version to a new version where the end date is
@@ -52,17 +52,17 @@ const mapChargeVersionStatus = (chargeVersion, index, arr) => {
  */
 const mapChargeVersionEndDate = (chargeVersion, index, arr) => {
   // If there is no following row, or this row is an error, don't modify date
-  const nextRow = arr[index + 1];
+  const nextRow = arr[index + 1]
   if (!nextRow || isErrorChargeVersion(chargeVersion, nextRow)) {
-    return chargeVersion;
+    return chargeVersion
   }
-  const maxEndDate = moment(nextRow.start_date, DATE_FORMAT).subtract(1, PERIOD_DAY).format(DATE_FORMAT);
-  const endDate = dateHelpers.getMinDate([chargeVersion.end_date, maxEndDate]).format(DATE_FORMAT);
+  const maxEndDate = moment(nextRow.start_date, DATE_FORMAT).subtract(1, PERIOD_DAY).format(DATE_FORMAT)
+  const endDate = dateHelpers.getMinDate([chargeVersion.end_date, maxEndDate]).format(DATE_FORMAT)
   return {
     ...chargeVersion,
     end_date: endDate
-  };
-};
+  }
+}
 
 /**
  * Gets the maximum version number from an array of charge versions.
@@ -71,18 +71,18 @@ const mapChargeVersionEndDate = (chargeVersion, index, arr) => {
  * @return {Number}
  */
 const getMaxVersionNumber = chargeVersions =>
-  Math.max(...chargeVersions.map(cv => cv.version_number), 0);
+  Math.max(...chargeVersions.map(cv => cv.version_number), 0)
 
-const getPreviousDay = str => moment(str).subtract(1, PERIOD_DAY).format(DATE_FORMAT);
-const getNextDay = str => moment(str).add(1, PERIOD_DAY).format(DATE_FORMAT);
+const getPreviousDay = str => moment(str).subtract(1, PERIOD_DAY).format(DATE_FORMAT)
+const getNextDay = str => moment(str).add(1, PERIOD_DAY).format(DATE_FORMAT)
 
-const isCurrentChargeVersion = chargeVersion => chargeVersion.status === STATUS_CURRENT;
+const isCurrentChargeVersion = chargeVersion => chargeVersion.status === STATUS_CURRENT
 
 const createGap = (startDate, endDate, externalId) => ({
   startDate,
   endDate,
   externalId
-});
+})
 
 /**
  * Gets history gaps as an array [[startDate, endDate], ...]
@@ -91,15 +91,15 @@ const createGap = (startDate, endDate, externalId) => ({
  * @return {Array<Array>} date pairs
  */
 const getChargeVersionHistoryGaps = (licence, chargeVersions) => {
-  const currentChargeVersions = chargeVersions.filter(isCurrentChargeVersion);
+  const currentChargeVersions = chargeVersions.filter(isCurrentChargeVersion)
 
   // If there are no charge versions, gap is entire licence timeline
   if (currentChargeVersions.length === 0) {
-    return [createGap(licence.start_date, licence.end_date, `${licence.FGAC_REGION_CODE}:${licence.ID}:licenceStart-licenceEnd`)];
+    return [createGap(licence.start_date, licence.end_date, `${licence.FGAC_REGION_CODE}:${licence.ID}:licenceStart-licenceEnd`)]
   }
 
-  const licenceStart = moment(licence.start_date);
-  const licenceEnd = isNull(licence.end_date) ? null : moment(licence.end_date);
+  const licenceStart = moment(licence.start_date)
+  const licenceEnd = isNull(licence.end_date) ? null : moment(licence.end_date)
 
   return currentChargeVersions
     .reduce((acc, chargeVersion, i, source) => {
@@ -107,29 +107,29 @@ const getChargeVersionHistoryGaps = (licence, chargeVersions) => {
       if (i === 0 && licenceStart.isBefore(chargeVersion.start_date, PERIOD_DAY)) {
         acc.push(
           createGap(licence.start_date, getPreviousDay(chargeVersion.start_date), `${licence.FGAC_REGION_CODE}:${licence.ID}:licenceStart`)
-        );
+        )
       }
 
       // Gaps between charge versions
-      const next = source[i + 1];
-      const nextPreviousDay = next && getPreviousDay(next.start_date);
+      const next = source[i + 1]
+      const nextPreviousDay = next && getPreviousDay(next.start_date)
 
       if (next && chargeVersion.end_date !== nextPreviousDay) {
         acc.push(
           createGap(getNextDay(chargeVersion.end_date), nextPreviousDay, `${licence.FGAC_REGION_CODE}:${licence.ID}:${chargeVersion.version_number}-${next.version_number}`)
-        );
+        )
       }
 
       // Gap between last charge version and licence end date
       if (!next && !isNull(chargeVersion.end_date) && (isNull(licenceEnd) || licenceEnd.isAfter(chargeVersion.end_date, PERIOD_DAY))) {
         acc.push(
           createGap(getNextDay(chargeVersion.end_date), licence.end_date, `${licence.FGAC_REGION_CODE}:${licence.ID}:licenceEnd`)
-        );
+        )
       }
 
-      return acc;
-    }, []);
-};
+      return acc
+    }, [])
+}
 
 const mapHistoryGapToChargeVersion = (gap, licence, versionNumber) => ({
   start_date: gap.startDate,
@@ -138,7 +138,7 @@ const mapHistoryGapToChargeVersion = (gap, licence, versionNumber) => ({
   version_number: versionNumber,
   external_id: gap.externalId,
   is_nald_gap: true
-});
+})
 
 /**
  * Maps licence and NALD charge version data to an array of
@@ -151,21 +151,21 @@ const mapNALDChargeVersionsToWRLS = (licence, chargeVersions) => {
   // Map NALD charge versions to WRLS (end dates and status can change)
   const wrlsChargeVersions = chargeVersions
     .map(mapChargeVersionEndDate)
-    .map(mapChargeVersionStatus);
+    .map(mapChargeVersionStatus)
 
   // Calculate non-chargeable date ranges
-  const maxVersionNumber = getMaxVersionNumber(wrlsChargeVersions);
+  const maxVersionNumber = getMaxVersionNumber(wrlsChargeVersions)
   const nonChargeableChargeVersions = getChargeVersionHistoryGaps(licence, wrlsChargeVersions)
-    .map((gap, i) => mapHistoryGapToChargeVersion(gap, licence, i + maxVersionNumber + 1));
+    .map((gap, i) => mapHistoryGapToChargeVersion(gap, licence, i + maxVersionNumber + 1))
 
   // Combine and sort
   const arr = [
     ...wrlsChargeVersions,
     ...nonChargeableChargeVersions
-  ];
-  return sortBy(arr, ['start_date', 'version_number']);
-};
+  ]
+  return sortBy(arr, ['start_date', 'version_number'])
+}
 
 module.exports = {
   mapNALDChargeVersionsToWRLS
-};
+}

--- a/src/modules/nald-import/plugin.js
+++ b/src/modules/nald-import/plugin.js
@@ -1,45 +1,45 @@
-'use strict';
+'use strict'
 
-const cron = require('node-cron');
-const config = require('../../../config');
-const jobs = require('./jobs');
+const cron = require('node-cron')
+const config = require('../../../config')
+const jobs = require('./jobs')
 
-const getSchedule = () => config.isProduction ? '0 1 * * *' : '0 */1 * * *';
+const getSchedule = () => config.isProduction ? '0 1 * * *' : '0 */1 * * *'
 
 const publishJob = messageQueue => {
-  messageQueue.publish(jobs.s3Download.job.createMessage());
-};
+  messageQueue.publish(jobs.s3Download.job.createMessage())
+}
 
 const subscribe = async (server, job) => {
-  const { jobName, handler, options = {} } = job.job;
+  const { jobName, handler, options = {} } = job.job
 
-  await server.messageQueue.subscribe(jobName, options, handler);
+  await server.messageQueue.subscribe(jobName, options, handler)
 
   if (job.onCompleteHandler) {
     await server.messageQueue.onComplete(jobName, executedJob => {
-      return job.onCompleteHandler(executedJob, server.messageQueue);
-    });
+      return job.onCompleteHandler(executedJob, server.messageQueue)
+    })
   }
-};
+}
 
 const registerSubscribers = async server => {
-  await subscribe(server, jobs.s3Download);
-  await subscribe(server, jobs.deleteRemovedDocuments);
-  await subscribe(server, jobs.populatePendingImport);
-  await subscribe(server, jobs.importLicence);
+  await subscribe(server, jobs.s3Download)
+  await subscribe(server, jobs.deleteRemovedDocuments)
+  await subscribe(server, jobs.populatePendingImport)
+  await subscribe(server, jobs.importLicence)
 
   // Schedule the import process every day at 1am / 1pm depending on environment
   if (process.env.NODE_ENV !== 'test') {
-    cron.schedule(getSchedule(), () => publishJob(server.messageQueue));
+    cron.schedule(getSchedule(), () => publishJob(server.messageQueue))
   }
-};
+}
 
 const plugin = {
   name: 'importNaldData',
   dependencies: ['pgBoss'],
   register: registerSubscribers
-};
+}
 
 module.exports = {
   plugin
-};
+}

--- a/src/modules/nald-import/repositories.js
+++ b/src/modules/nald-import/repositories.js
@@ -1,5 +1,5 @@
-const Repository = require('./lib/repository');
-const { pool } = require('../../lib/connectors/db');
+const Repository = require('./lib/repository')
+const { pool } = require('../../lib/connectors/db')
 
 const repoConfig = {
 
@@ -44,7 +44,7 @@ const repoConfig = {
     }
   }
 
-};
+}
 
 module.exports = {
   licence: new Repository(pool, repoConfig.licence),
@@ -52,4 +52,4 @@ module.exports = {
   return: new Repository(pool, repoConfig.return),
   version: new Repository(pool, repoConfig.version),
   line: new Repository(pool, repoConfig.line)
-};
+}

--- a/src/modules/nald-import/routes.js
+++ b/src/modules/nald-import/routes.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joi')
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 module.exports = [
   {
@@ -47,4 +47,4 @@ module.exports = [
       }
     }
   }
-];
+]

--- a/src/modules/nald-import/services/charge-version-metadata-import.js
+++ b/src/modules/nald-import/services/charge-version-metadata-import.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const mapper = require('../mappers/charge-versions');
+const mapper = require('../mappers/charge-versions')
 
 const queries = {
   charging: require('../lib/nald-queries/charge-versions'),
   chargeVersionMetatdata: require('../lib/nald-queries/charge-versions-metadata')
-};
+}
 
-const { logger } = require('../../../logger');
-const { pool } = require('../../../lib/connectors/db');
+const { logger } = require('../../../logger')
+const { pool } = require('../../../lib/connectors/db')
 
 /**
  * Gets charge versions for licence from DB
@@ -17,7 +17,7 @@ const { pool } = require('../../../lib/connectors/db');
  * @return {Promise<Object>}
  */
 const getNonDraftChargeVersions = (regionCode, licenceId) =>
-  pool.query(queries.charging.getNonDraftChargeVersionsForLicence, [regionCode, licenceId]);
+  pool.query(queries.charging.getNonDraftChargeVersionsForLicence, [regionCode, licenceId])
 
 /**
  * Inserts a single charge version record into the water.charge_versions DB table
@@ -32,11 +32,11 @@ const insertChargeVersionMetadata = chargeVersion => {
     chargeVersion.end_date,
     chargeVersion.status,
     chargeVersion.is_nald_gap || false
-  ];
-  return pool.query(queries.chargeVersionMetatdata.insertChargeVersionMetadata, params);
-};
+  ]
+  return pool.query(queries.chargeVersionMetatdata.insertChargeVersionMetadata, params)
+}
 
-const createParam = i => `$${i + 1}`;
+const createParam = i => `$${i + 1}`
 
 /**
  * Cleans up nald charge versions no longer needed
@@ -45,41 +45,41 @@ const createParam = i => `$${i + 1}`;
  * @return {Promise}
  */
 const cleanup = (licence, chargeVersions) => {
-  const params = [`${licence.FGAC_REGION_CODE}:${licence.ID}:%`];
-  const externalIds = chargeVersions.map(chargeVersion => chargeVersion.external_id);
-  let query = 'delete from water_import.charge_versions_metadata where external_id like $1';
+  const params = [`${licence.FGAC_REGION_CODE}:${licence.ID}:%`]
+  const externalIds = chargeVersions.map(chargeVersion => chargeVersion.external_id)
+  let query = 'delete from water_import.charge_versions_metadata where external_id like $1'
 
   if (externalIds.length) {
-    params.push(...externalIds);
-    query += ` and external_id not in (${externalIds.map((row, i) => createParam(i + 1))})`;
+    params.push(...externalIds)
+    query += ` and external_id not in (${externalIds.map((row, i) => createParam(i + 1))})`
   }
-  return pool.query(query, params);
-};
+  return pool.query(query, params)
+}
 
 const persistChargeVersionMetadata = async wrlsChargeVersions => {
   // Insert to water.charge_versions DB table
   for (const wrlsChargeVersion of wrlsChargeVersions) {
-    await insertChargeVersionMetadata(wrlsChargeVersion);
+    await insertChargeVersionMetadata(wrlsChargeVersion)
   }
-};
+}
 
 const importChargeVersionMetadataForLicence = async licence => {
   try {
-    logger.info(`Import: charge versions metadata for licence ${licence.LIC_NO}`);
+    logger.info(`Import: charge versions metadata for licence ${licence.LIC_NO}`)
 
     // Note: charge versions are already sorted by start date, version number from the DB query
-    const { rows: chargeVersions } = await getNonDraftChargeVersions(licence.FGAC_REGION_CODE, licence.ID);
+    const { rows: chargeVersions } = await getNonDraftChargeVersions(licence.FGAC_REGION_CODE, licence.ID)
 
     // Map to WRLS charge versions
-    const wrlsChargeVersions = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions);
+    const wrlsChargeVersions = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions)
 
-    await persistChargeVersionMetadata(wrlsChargeVersions);
-    await cleanup(licence, wrlsChargeVersions);
+    await persistChargeVersionMetadata(wrlsChargeVersions)
+    await cleanup(licence, wrlsChargeVersions)
   } catch (err) {
-    logger.error(`Error importing charge versions for licence ${licence.LIC_NO}`, err);
+    logger.error(`Error importing charge versions for licence ${licence.LIC_NO}`, err)
   }
-};
+}
 
 module.exports = {
   importChargeVersionMetadataForLicence
-};
+}

--- a/src/modules/nald-import/services/extract-service.js
+++ b/src/modules/nald-import/services/extract-service.js
@@ -1,31 +1,31 @@
-const path = require('path');
-const processHelper = require('@envage/water-abstraction-helpers').process;
-const slack = require('../../../lib/slack');
-const { logger } = require('../../../logger');
+const path = require('path')
+const processHelper = require('@envage/water-abstraction-helpers').process
+const slack = require('../../../lib/slack')
+const { logger } = require('../../../logger')
 
-const constants = require('../lib/constants');
+const constants = require('../lib/constants')
 
-const s3Service = require('./s3-service');
-const zipService = require('./zip-service');
-const schemaService = require('./schema-service');
-const loadCsvService = require('./load-csv-service');
+const s3Service = require('./s3-service')
+const zipService = require('./zip-service')
+const schemaService = require('./schema-service')
+const loadCsvService = require('./load-csv-service')
 
 // Download / unzip paths
-const FINAL_PATH = path.join(constants.LOCAL_TEMP_PATH, constants.CSV_DIRECTORY);
+const FINAL_PATH = path.join(constants.LOCAL_TEMP_PATH, constants.CSV_DIRECTORY)
 
 /**
  * Prepares for import by removing files from tempory folder and creating directory
  */
 const prepare = async () => {
-  await processHelper.execCommand(`rm -rf ${constants.LOCAL_TEMP_PATH}`);
-  await processHelper.execCommand(`mkdir -p ${constants.LOCAL_TEMP_PATH}`);
-  await processHelper.execCommand(`mkdir -p ${FINAL_PATH}`);
-};
+  await processHelper.execCommand(`rm -rf ${constants.LOCAL_TEMP_PATH}`)
+  await processHelper.execCommand(`mkdir -p ${constants.LOCAL_TEMP_PATH}`)
+  await processHelper.execCommand(`mkdir -p ${FINAL_PATH}`)
+}
 
 const logToConsoleAndSlack = message => {
-  slack.post(message);
-  logger.info(message);
-};
+  slack.post(message)
+  logger.info(message)
+}
 
 const steps = [
   {
@@ -56,7 +56,7 @@ const steps = [
     message: 'cleaning up local files',
     action: prepare
   }
-];
+]
 
 /**
  * The download/extract tasks have been combined into a single task
@@ -66,10 +66,10 @@ const steps = [
  */
 const downloadAndExtract = async () => {
   for (const step of steps) {
-    logToConsoleAndSlack(`Import: ${step.message}`);
-    await step.action();
+    logToConsoleAndSlack(`Import: ${step.message}`)
+    await step.action()
   }
-};
+}
 
 /**
  * Move test files
@@ -78,17 +78,17 @@ const downloadAndExtract = async () => {
  * @return {Promise} resolves when command completes
  */
 const copyTestFiles = async () => {
-  await prepare();
-  await schemaService.dropAndCreateSchema(constants.SCHEMA_IMPORT);
+  await prepare()
+  await schemaService.dropAndCreateSchema(constants.SCHEMA_IMPORT)
 
   // move dummy data files
-  await processHelper.execCommand(`cp ./test/dummy-csv/* ${FINAL_PATH}`);
+  await processHelper.execCommand(`cp ./test/dummy-csv/* ${FINAL_PATH}`)
 
   // Import CSV
-  return loadCsvService.importFiles(constants.SCHEMA_IMPORT);
-};
+  return loadCsvService.importFiles(constants.SCHEMA_IMPORT)
+}
 
 module.exports = {
   copyTestFiles,
   downloadAndExtract
-};
+}

--- a/src/modules/nald-import/services/load-csv-service.js
+++ b/src/modules/nald-import/services/load-csv-service.js
@@ -1,32 +1,32 @@
-const path = require('path');
-const fs = require('fs');
-const { promisify } = require('util');
-const readFirstLine = require('firstline');
-const { intersection } = require('lodash');
+const path = require('path')
+const fs = require('fs')
+const { promisify } = require('util')
+const readFirstLine = require('firstline')
+const { intersection } = require('lodash')
 
-const readDir = promisify(fs.readdir);
-const writeFile = promisify(fs.writeFile);
+const readDir = promisify(fs.readdir)
+const writeFile = promisify(fs.writeFile)
 
-const config = require('../../../../config.js');
-const { execCommand } = require('@envage/water-abstraction-helpers').process;
-const { logger } = require('../../../logger');
+const config = require('../../../../config.js')
+const { execCommand } = require('@envage/water-abstraction-helpers').process
+const { logger } = require('../../../logger')
 
-const constants = require('../lib/constants');
+const constants = require('../lib/constants')
 
-const finalPath = path.join(constants.LOCAL_TEMP_PATH, constants.CSV_DIRECTORY);
+const finalPath = path.join(constants.LOCAL_TEMP_PATH, constants.CSV_DIRECTORY)
 
 /**
  * Get a list of files to import
  * @return {Promise} resolves with array of files
  */
 async function getImportFiles () {
-  const files = await readDir(finalPath);
-  const excludeList = ['NALD_RET_LINES_AUDIT', 'NALD_RET_FORM_LOGS_AUDIT'];
+  const files = await readDir(finalPath)
+  const excludeList = ['NALD_RET_LINES_AUDIT', 'NALD_RET_FORM_LOGS_AUDIT']
   return files.filter((file) => {
-    const table = file.split('.')[0];
-    const extn = file.split('.')[1];
-    return !(table.length === 0 || excludeList.includes(table)) && extn === 'txt';
-  });
+    const table = file.split('.')[0]
+    const extn = file.split('.')[1]
+    return !(table.length === 0 || excludeList.includes(table)) && extn === 'txt'
+  })
 }
 
 const indexableFieldsList = [
@@ -64,7 +64,7 @@ const indexableFieldsList = [
   'ARTY_ID',
   'ARFL_ARTY_ID',
   'ARFL_DATE_FROM'
-];
+]
 
 /**
  * Gets SQL for indexes to add to the supplied table
@@ -74,19 +74,19 @@ const indexableFieldsList = [
  * @return {String}
  */
 const getIndexes = (schemaName, table, cols) => {
-  const indexableFields = intersection(indexableFieldsList, cols);
+  const indexableFields = intersection(indexableFieldsList, cols)
   if (table === 'NALD_RET_LINES') {
     // NALD_RET_LINES is large so more care is required when creating indexes which can take a long time to create
-    return `\nCREATE INDEX idx_nald_ret_lines_id_and_region ON ${schemaName}."NALD_RET_LINES" ("ARFL_ARTY_ID", "FGAC_REGION_CODE");`;
+    return `\nCREATE INDEX idx_nald_ret_lines_id_and_region ON ${schemaName}."NALD_RET_LINES" ("ARFL_ARTY_ID", "FGAC_REGION_CODE");`
   } else {
-    let str = '';
+    let str = ''
     for (const field of indexableFields) {
-      const indexName = `${table}_${field}_index`;
-      str += `\nCREATE INDEX "${indexName}" ON ${schemaName}."${table}" ("${field}");`;
+      const indexName = `${table}_${field}_index`
+      str += `\nCREATE INDEX "${indexName}" ON ${schemaName}."${table}" ("${field}");`
     }
-    return str;
+    return str
   }
-};
+}
 
 /**
  * Gets import SQL for single file in import
@@ -94,26 +94,26 @@ const getIndexes = (schemaName, table, cols) => {
  * @return {String} the SQL statements to import the CSV file
  */
 async function getSqlForFile (file, schemaName) {
-  const table = file.split('.')[0];
-  const tablePath = path.join(finalPath, `${table}.txt`);
-  const line = await readFirstLine(tablePath);
-  const cols = line.split(',');
+  const table = file.split('.')[0]
+  const tablePath = path.join(finalPath, `${table}.txt`)
+  const line = await readFirstLine(tablePath)
+  const cols = line.split(',')
 
-  let tableCreate = `\n CREATE TABLE if not exists ${schemaName}."${table}" (`;
+  let tableCreate = `\n CREATE TABLE if not exists ${schemaName}."${table}" (`
 
   for (let col = 0; col < cols.length; col++) {
-    tableCreate += `"${cols[col]}" varchar`;
+    tableCreate += `"${cols[col]}" varchar`
     if (cols.length === (col + 1)) {
-      tableCreate += ');';
+      tableCreate += ');'
     } else {
-      tableCreate += ', ';
+      tableCreate += ', '
     }
   }
 
-  tableCreate += `\n \\copy ${schemaName}."${table}" FROM '${finalPath}/${file}' HEADER DELIMITER ',' CSV;`;
-  tableCreate += getIndexes(schemaName, table, cols);
+  tableCreate += `\n \\copy ${schemaName}."${table}" FROM '${finalPath}/${file}' HEADER DELIMITER ',' CSV;`
+  tableCreate += getIndexes(schemaName, table, cols)
 
-  return tableCreate;
+  return tableCreate
 };
 
 /**
@@ -122,18 +122,18 @@ async function getSqlForFile (file, schemaName) {
  * @return {Promise}
  */
 async function importFiles (schemaName) {
-  const files = await getImportFiles();
-  const sqlPath = path.join(finalPath, 'sql.sql');
+  const files = await getImportFiles()
+  const sqlPath = path.join(finalPath, 'sql.sql')
 
   for (const file of files) {
-    logger.info(`Importing ${file} to PostGres`);
-    const sql = await getSqlForFile(file, schemaName);
+    logger.info(`Importing ${file} to PostGres`)
+    const sql = await getSqlForFile(file, schemaName)
 
-    await writeFile(sqlPath, sql);
-    await execCommand(`psql ${config.pg.connectionString} < ${sqlPath}`);
+    await writeFile(sqlPath, sql)
+    await execCommand(`psql ${config.pg.connectionString} < ${sqlPath}`)
   }
 }
 
 module.exports = {
   importFiles
-};
+}

--- a/src/modules/nald-import/services/s3-service.js
+++ b/src/modules/nald-import/services/s3-service.js
@@ -1,9 +1,9 @@
-const path = require('path');
-const s3 = require('../../../lib/services/s3');
-const constants = require('../lib/constants');
+const path = require('path')
+const s3 = require('../../../lib/services/s3')
+const constants = require('../lib/constants')
 
-const s3Path = path.join(constants.S3_IMPORT_PATH, constants.S3_IMPORT_FILE);
-const localPath = path.join(constants.LOCAL_TEMP_PATH, constants.S3_IMPORT_FILE);
+const s3Path = path.join(constants.S3_IMPORT_PATH, constants.S3_IMPORT_FILE)
+const localPath = path.join(constants.LOCAL_TEMP_PATH, constants.S3_IMPORT_FILE)
 
 /**
  * Gets the ETag of the current NALD zip in the S3 bucket
@@ -12,19 +12,19 @@ const localPath = path.join(constants.LOCAL_TEMP_PATH, constants.S3_IMPORT_FILE)
  * @return {Promise<String>}
  */
 const getEtag = async () => {
-  const result = await s3.getHead(s3Path);
-  return result.ETag.replace(/"/g, '');
-};
+  const result = await s3.getHead(s3Path)
+  return result.ETag.replace(/"/g, '')
+}
 
 /**
  * Downloads latest ZIP file from S3 bucket
  * @return {Promise} resolves when download complete
  */
 const download = async () => {
-  return s3.download(s3Path, localPath);
-};
+  return s3.download(s3Path, localPath)
+}
 
 module.exports = {
   getEtag,
   download
-};
+}

--- a/src/modules/nald-import/services/schema-service.js
+++ b/src/modules/nald-import/services/schema-service.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const db = require('../lib/db');
-const constants = require('../lib/constants');
+const db = require('../lib/db')
+const constants = require('../lib/constants')
 
-const dropSchema = name => db.dbQuery(`drop schema if exists ${name} cascade`);
-const createSchema = name => db.dbQuery(`create schema if not exists ${name}`);
-const renameSchema = (from, to) => db.dbQuery(`alter schema ${from} rename to ${to};`);
+const dropSchema = name => db.dbQuery(`drop schema if exists ${name} cascade`)
+const createSchema = name => db.dbQuery(`create schema if not exists ${name}`)
+const renameSchema = (from, to) => db.dbQuery(`alter schema ${from} rename to ${to};`)
 
 /**
  * Drops and creates the import schema ready to import the CSVs as tables
@@ -13,17 +13,17 @@ const renameSchema = (from, to) => db.dbQuery(`alter schema ${from} rename to ${
  * @return {Promise}
  */
 async function dropAndCreateSchema (schemaName = constants.SCHEMA_IMPORT) {
-  await dropSchema(schemaName);
-  await createSchema(schemaName);
+  await dropSchema(schemaName)
+  await createSchema(schemaName)
 }
 
 const swapTemporarySchema = async () => {
-  await dropSchema(constants.SCHEMA_IMPORT);
-  await renameSchema(constants.SCHEMA_TEMP, constants.SCHEMA_IMPORT);
-};
+  await dropSchema(constants.SCHEMA_IMPORT)
+  await renameSchema(constants.SCHEMA_TEMP, constants.SCHEMA_IMPORT)
+}
 
 module.exports = {
   dropAndCreateSchema,
   swapTemporarySchema,
   renameSchema
-};
+}

--- a/src/modules/nald-import/services/zip-service.js
+++ b/src/modules/nald-import/services/zip-service.js
@@ -1,15 +1,15 @@
-'use strict';
+'use strict'
 
-const { get } = require('lodash');
-const path = require('path');
+const { get } = require('lodash')
+const path = require('path')
 
-const processHelper = require('@envage/water-abstraction-helpers').process;
-const { logger } = require('../../../logger');
-const constants = require('../lib/constants');
-const config = require('../../../../config');
+const processHelper = require('@envage/water-abstraction-helpers').process
+const { logger } = require('../../../logger')
+const constants = require('../lib/constants')
+const config = require('../../../../config')
 
-const primaryPath = path.join(constants.LOCAL_TEMP_PATH, constants.S3_IMPORT_FILE);
-const secondaryPath = path.join(constants.LOCAL_TEMP_PATH, `${constants.CSV_DIRECTORY}.zip`);
+const primaryPath = path.join(constants.LOCAL_TEMP_PATH, constants.S3_IMPORT_FILE)
+const secondaryPath = path.join(constants.LOCAL_TEMP_PATH, `${constants.CSV_DIRECTORY}.zip`)
 
 /**
  *
@@ -18,29 +18,29 @@ const secondaryPath = path.join(constants.LOCAL_TEMP_PATH, `${constants.CSV_DIRE
  * @param {String} [password] - password if encrypted
  */
 const extractArchive = async (source, destination, password) => {
-  let command = `7z x ${source} -o${destination}`;
+  let command = `7z x ${source} -o${destination}`
   if (password) {
-    command += ` -p${password}`;
+    command += ` -p${password}`
   }
-  await processHelper.execCommand(command);
-};
+  await processHelper.execCommand(command)
+}
 
 /**
  * Extracts files from zip downloaded from S3 bucket
  */
 const extract = async () => {
-  logger.info('Extracting data from NALD zip file');
+  logger.info('Extracting data from NALD zip file')
 
   try {
-    const zipPassword = get(config, 'import.nald.zipPassword');
-    await extractArchive(primaryPath, constants.LOCAL_TEMP_PATH, zipPassword);
-    await extractArchive(secondaryPath, constants.LOCAL_TEMP_PATH);
+    const zipPassword = get(config, 'import.nald.zipPassword')
+    await extractArchive(primaryPath, constants.LOCAL_TEMP_PATH, zipPassword)
+    await extractArchive(secondaryPath, constants.LOCAL_TEMP_PATH)
   } catch (err) {
-    logger.error('Could not extract NALD zip', err);
-    throw err;
+    logger.error('Could not extract NALD zip', err)
+    throw err
   }
-};
+}
 
 module.exports = {
   extract
-};
+}

--- a/src/modules/nald-import/transform-crm.js
+++ b/src/modules/nald-import/transform-crm.js
@@ -1,11 +1,11 @@
 /**
  * Transform data for loading into CRM
  */
-const { mapValues, find } = require('lodash');
-const { findCurrent, transformNull } = require('@envage/water-abstraction-helpers').nald;
-const { addressFormatter, crmNameFormatter } = require('@envage/water-abstraction-helpers').nald.formatting;
-const { sentenceCase } = require('sentence-case');
-const { logger } = require('../../logger');
+const { mapValues, find } = require('lodash')
+const { findCurrent, transformNull } = require('@envage/water-abstraction-helpers').nald
+const { addressFormatter, crmNameFormatter } = require('@envage/water-abstraction-helpers').nald.formatting
+const { sentenceCase } = require('sentence-case')
+const { logger } = require('../../logger')
 
 /**
  * Contacts formatter
@@ -16,40 +16,40 @@ const { logger } = require('../../logger');
  */
 const contactsFormatter = (currentVersion, roles) => {
   if (!currentVersion) {
-    return [];
+    return []
   }
 
   const licenceHolderParty = find(currentVersion.parties, (party) => {
-    return party.ID === currentVersion.ACON_APAR_ID;
-  });
+    return party.ID === currentVersion.ACON_APAR_ID
+  })
 
   const licenceHolderAddress = find(licenceHolderParty.contacts, (contact) => {
-    return contact.AADD_ID === currentVersion.ACON_AADD_ID;
-  });
+    return contact.AADD_ID === currentVersion.ACON_AADD_ID
+  })
 
   const contacts = [{
     role: 'Licence holder',
     ...crmNameFormatter(licenceHolderParty),
     ...addressFormatter(licenceHolderAddress.party_address)
-  }];
+  }]
 
   roles.forEach((role) => {
     contacts.push({
       role: sentenceCase(role.role_type.DESCR),
       ...crmNameFormatter(role.role_party),
       ...addressFormatter(role.role_address)
-    });
-  });
+    })
+  })
 
-  return transformNull(contacts);
-};
+  return transformNull(contacts)
+}
 
 /**
  * Data from NALD import has null as "null" string
  * prune this to empty value
  */
 function pruneNullString (data) {
-  return mapValues(data, value => value === 'null' ? '' : value);
+  return mapValues(data, value => value === 'null' ? '' : value)
 }
 
 /**
@@ -58,8 +58,8 @@ function pruneNullString (data) {
  * @return {Object} contact metadata
  */
 function buildCRMContactMetadata (currentVersion) {
-  const party = currentVersion.party;
-  const address = currentVersion.address;
+  const party = currentVersion.party
+  const address = currentVersion.address
   return {
     Name: party.NAME,
     Salutation: party.SALUTATION,
@@ -73,7 +73,7 @@ function buildCRMContactMetadata (currentVersion) {
     County: address.COUNTY,
     Postcode: address.POSTCODE,
     Country: address.COUNTRY
-  };
+  }
 }
 
 /**
@@ -85,19 +85,19 @@ function buildCRMMetadata (currentVersion) {
   if (!currentVersion) {
     return {
       IsCurrent: false
-    };
+    }
   }
-  const expires = currentVersion.expiry_date;
-  const modified = currentVersion.version_effective_date;
-  const contact = buildCRMContactMetadata(currentVersion);
+  const expires = currentVersion.expiry_date
+  const modified = currentVersion.version_effective_date
+  const contact = buildCRMContactMetadata(currentVersion)
 
   const data = {
     ...contact,
     Expires: expires,
     Modified: modified,
     IsCurrent: true
-  };
-  return pruneNullString(data);
+  }
+  return pruneNullString(data)
 }
 
 /**
@@ -113,21 +113,21 @@ function buildCRMPacket (licenceData, licenceRef, licenceId) {
     system_id: 'permit-repo',
     system_internal_id: licenceId,
     system_external_id: licenceRef
-  };
+  }
 
   try {
-    const currentVersion = licenceData.data.current_version;
-    const metadata = buildCRMMetadata(currentVersion);
-    metadata.contacts = contactsFormatter(findCurrent(licenceData.data.versions), licenceData.data.roles);
-    crmData.metadata = JSON.stringify(metadata);
+    const currentVersion = licenceData.data.current_version
+    const metadata = buildCRMMetadata(currentVersion)
+    metadata.contacts = contactsFormatter(findCurrent(licenceData.data.versions), licenceData.data.roles)
+    crmData.metadata = JSON.stringify(metadata)
   } catch (error) {
-    logger.error('Cannot build CRM packet', error, crmData);
+    logger.error('Cannot build CRM packet', error, crmData)
   }
-  return crmData;
+  return crmData
 }
 
 module.exports = {
   buildCRMPacket,
   buildCRMMetadata,
   contactsFormatter
-};
+}

--- a/src/modules/nald-import/transform-permit.js
+++ b/src/modules/nald-import/transform-permit.js
@@ -120,18 +120,17 @@ const getVersionsJson = async (licenceRow) => {
 const getLicenceJson = async (licenceNumber) => {
   try {
     const data = await licenceQueries.getLicence(licenceNumber)
+    const licenceRow = data[0]
 
-    for (const licenceRow in data) {
-      const thisLicenceRow = data[licenceRow]
-      thisLicenceRow.vmlVersion = 2
-      thisLicenceRow.data = {}
-      thisLicenceRow.data.versions = await getVersionsJson(thisLicenceRow)
-      thisLicenceRow.data.current_version = await getCurrentVersionJson(thisLicenceRow)
-      thisLicenceRow.data.cams = await cams.getCams(thisLicenceRow.AREP_CAMS_CODE, thisLicenceRow.FGAC_REGION_CODE)
-      thisLicenceRow.data.roles = await rolesQueries.getRoles(thisLicenceRow.ID, thisLicenceRow.FGAC_REGION_CODE)
-      thisLicenceRow.data.purposes = await getPurposesJson(thisLicenceRow)
-      return thisLicenceRow
-    }
+    licenceRow.vmlVersion = 2
+    licenceRow.data = {}
+    licenceRow.data.versions = await getVersionsJson(licenceRow)
+    licenceRow.data.current_version = await getCurrentVersionJson(licenceRow)
+    licenceRow.data.cams = await cams.getCams(licenceRow.AREP_CAMS_CODE, licenceRow.FGAC_REGION_CODE)
+    licenceRow.data.roles = await rolesQueries.getRoles(licenceRow.ID, licenceRow.FGAC_REGION_CODE)
+    licenceRow.data.purposes = await getPurposesJson(licenceRow)
+
+    return licenceRow
   } catch (error) {
     logger.error('Error getting licence JSON', error, { licenceNumber })
   }

--- a/src/modules/nald-import/transform-permit.js
+++ b/src/modules/nald-import/transform-permit.js
@@ -1,19 +1,19 @@
-const { orderBy } = require('lodash');
-const dates = require('@envage/water-abstraction-helpers').nald.dates;
+const { orderBy } = require('lodash')
+const dates = require('@envage/water-abstraction-helpers').nald.dates
 
-const licenceQueries = require('./lib/nald-queries/licences');
-const partyQueries = require('./lib/nald-queries/parties');
-const addressQueries = require('./lib/nald-queries/addresses');
-const rolesQueries = require('./lib/nald-queries/roles');
-const purposesQueries = require('./lib/nald-queries/purposes');
+const licenceQueries = require('./lib/nald-queries/licences')
+const partyQueries = require('./lib/nald-queries/parties')
+const addressQueries = require('./lib/nald-queries/addresses')
+const rolesQueries = require('./lib/nald-queries/roles')
+const purposesQueries = require('./lib/nald-queries/purposes')
 
-const cams = require('./lib/nald-queries/cams');
+const cams = require('./lib/nald-queries/cams')
 
-const { getEndDate } = require('./lib/end-date');
+const { getEndDate } = require('./lib/end-date')
 
-const { getFormatPoints, getFormatPurposes } = require('./lib/nald-queries/returns');
+const { getFormatPoints, getFormatPurposes } = require('./lib/nald-queries/returns')
 
-const { logger } = require('../../logger');
+const { logger } = require('../../logger')
 
 /**
  * Gets the purposes together with their points, agreements and conditions
@@ -23,12 +23,12 @@ const { logger } = require('../../logger');
  * @return {Promise}
  */
 const getPurposesJson = async (licenceRow, currentVersion = null) => {
-  const regionCode = licenceRow.FGAC_REGION_CODE;
-  let purposes;
+  const regionCode = licenceRow.FGAC_REGION_CODE
+  let purposes
   if (currentVersion) {
-    purposes = await purposesQueries.getPurposes(licenceRow.ID, regionCode, currentVersion.ISSUE_NO, currentVersion.INCR_NO);
+    purposes = await purposesQueries.getPurposes(licenceRow.ID, regionCode, currentVersion.ISSUE_NO, currentVersion.INCR_NO)
   } else {
-    purposes = await purposesQueries.getPurposes(licenceRow.ID, regionCode);
+    purposes = await purposesQueries.getPurposes(licenceRow.ID, regionCode)
   }
 
   for (const purpose of purposes) {
@@ -36,13 +36,13 @@ const getPurposesJson = async (licenceRow, currentVersion = null) => {
       primary: purpose.APUR_APPR_CODE,
       secondary: purpose.APUR_APSE_CODE,
       tertiary: purpose.APUR_APUS_CODE
-    });
-    purpose.purposePoints = await purposesQueries.getPurposePoints(purpose.ID, regionCode);
-    purpose.licenceAgreements = await purposesQueries.getPurposePointLicenceAgreements(purpose.ID, regionCode);
-    purpose.licenceConditions = await purposesQueries.getPurposePointLicenceConditions(purpose.ID, regionCode);
+    })
+    purpose.purposePoints = await purposesQueries.getPurposePoints(purpose.ID, regionCode)
+    purpose.licenceAgreements = await purposesQueries.getPurposePointLicenceAgreements(purpose.ID, regionCode)
+    purpose.licenceConditions = await purposesQueries.getPurposePointLicenceConditions(purpose.ID, regionCode)
   }
-  return purposes;
-};
+  return purposes
+}
 
 /**
  * Gets current return formats for specified licence ID and region code
@@ -51,15 +51,15 @@ const getPurposesJson = async (licenceRow, currentVersion = null) => {
  * @return {Promise} resolves with formats and purposes/points
  */
 const getReturnFormats = async (licenceId, regionCode) => {
-  const formats = await licenceQueries.getCurrentFormats(licenceId, regionCode);
+  const formats = await licenceQueries.getCurrentFormats(licenceId, regionCode)
 
   for (const format of formats) {
-    format.points = await getFormatPoints(format.ID, regionCode);
-    format.purposes = await getFormatPurposes(format.ID, regionCode);
+    format.points = await getFormatPoints(format.ID, regionCode)
+    format.purposes = await getFormatPurposes(format.ID, regionCode)
   }
 
-  return formats;
-};
+  return formats
+}
 
 /**
  * Gets the JSON for the current version of the licence (if available)
@@ -67,33 +67,33 @@ const getReturnFormats = async (licenceId, regionCode) => {
  * return {Promise} resolves with object of current version, or null
  */
 const getCurrentVersionJson = async (licenceRow) => {
-  const regionCode = licenceRow.FGAC_REGION_CODE;
-  const currentVersion = await licenceQueries.getCurrentVersion(licenceRow.ID, regionCode);
+  const regionCode = licenceRow.FGAC_REGION_CODE
+  const currentVersion = await licenceQueries.getCurrentVersion(licenceRow.ID, regionCode)
 
   if (currentVersion) {
     const data = {
       licence: currentVersion
-    };
+    }
 
-    data.licence.party = await partyQueries.getParties(currentVersion.ACON_APAR_ID, regionCode);
+    data.licence.party = await partyQueries.getParties(currentVersion.ACON_APAR_ID, regionCode)
 
     for (const p in data.licence.parties) {
-      data.licence.parties[p].contacts = await partyQueries.getPartyContacts(currentVersion.parties[p].ID, regionCode);
+      data.licence.parties[p].contacts = await partyQueries.getPartyContacts(currentVersion.parties[p].ID, regionCode)
     }
-    data.party = (await partyQueries.getParty(currentVersion.ACON_APAR_ID, regionCode))[0];
-    data.address = (await addressQueries.getAddress(currentVersion.ACON_AADD_ID, regionCode))[0];
-    data.original_effective_date = dates.calendarToSortable(licenceRow.ORIG_EFF_DATE);
-    data.version_effective_date = dates.calendarToSortable(currentVersion.EFF_ST_DATE);
-    data.expiry_date = dates.calendarToSortable(licenceRow.EXPIRY_DATE);
+    data.party = (await partyQueries.getParty(currentVersion.ACON_APAR_ID, regionCode))[0]
+    data.address = (await addressQueries.getAddress(currentVersion.ACON_AADD_ID, regionCode))[0]
+    data.original_effective_date = dates.calendarToSortable(licenceRow.ORIG_EFF_DATE)
+    data.version_effective_date = dates.calendarToSortable(currentVersion.EFF_ST_DATE)
+    data.expiry_date = dates.calendarToSortable(licenceRow.EXPIRY_DATE)
 
-    data.purposes = await getPurposesJson(licenceRow, currentVersion);
-    data.formats = await getReturnFormats(licenceRow.ID, regionCode);
+    data.purposes = await getPurposesJson(licenceRow, currentVersion)
+    data.formats = await getReturnFormats(licenceRow.ID, regionCode)
 
-    return data;
+    return data
   }
 
-  return null;
-};
+  return null
+}
 
 /**
  * Gets all licence versions (including current)
@@ -101,16 +101,16 @@ const getCurrentVersionJson = async (licenceRow) => {
  * @return {Promise} resolves with versions array
  */
 const getVersionsJson = async (licenceRow) => {
-  const versions = await licenceQueries.getVersions(licenceRow.ID, licenceRow.FGAC_REGION_CODE);
+  const versions = await licenceQueries.getVersions(licenceRow.ID, licenceRow.FGAC_REGION_CODE)
 
   for (const version of versions) {
-    version.parties = await partyQueries.getParties(version.ACON_APAR_ID, licenceRow.FGAC_REGION_CODE);
+    version.parties = await partyQueries.getParties(version.ACON_APAR_ID, licenceRow.FGAC_REGION_CODE)
     for (const party of version.parties) {
-      party.contacts = await partyQueries.getPartyContacts(party.ID, licenceRow.FGAC_REGION_CODE);
+      party.contacts = await partyQueries.getPartyContacts(party.ID, licenceRow.FGAC_REGION_CODE)
     }
   }
-  return versions;
-};
+  return versions
+}
 
 /**
  * Build full licence JSON for storing in permit repo from NALD import tables
@@ -119,23 +119,23 @@ const getVersionsJson = async (licenceRow) => {
  */
 const getLicenceJson = async (licenceNumber) => {
   try {
-    const data = await licenceQueries.getLicence(licenceNumber);
+    const data = await licenceQueries.getLicence(licenceNumber)
 
     for (const licenceRow in data) {
-      const thisLicenceRow = data[licenceRow];
-      thisLicenceRow.vmlVersion = 2;
-      thisLicenceRow.data = {};
-      thisLicenceRow.data.versions = await getVersionsJson(thisLicenceRow);
-      thisLicenceRow.data.current_version = await getCurrentVersionJson(thisLicenceRow);
-      thisLicenceRow.data.cams = await cams.getCams(thisLicenceRow.AREP_CAMS_CODE, thisLicenceRow.FGAC_REGION_CODE);
-      thisLicenceRow.data.roles = await rolesQueries.getRoles(thisLicenceRow.ID, thisLicenceRow.FGAC_REGION_CODE);
-      thisLicenceRow.data.purposes = await getPurposesJson(thisLicenceRow);
-      return thisLicenceRow;
+      const thisLicenceRow = data[licenceRow]
+      thisLicenceRow.vmlVersion = 2
+      thisLicenceRow.data = {}
+      thisLicenceRow.data.versions = await getVersionsJson(thisLicenceRow)
+      thisLicenceRow.data.current_version = await getCurrentVersionJson(thisLicenceRow)
+      thisLicenceRow.data.cams = await cams.getCams(thisLicenceRow.AREP_CAMS_CODE, thisLicenceRow.FGAC_REGION_CODE)
+      thisLicenceRow.data.roles = await rolesQueries.getRoles(thisLicenceRow.ID, thisLicenceRow.FGAC_REGION_CODE)
+      thisLicenceRow.data.purposes = await getPurposesJson(thisLicenceRow)
+      return thisLicenceRow
     }
   } catch (error) {
-    logger.error('Error getting licence JSON', error, { licenceNumber });
+    logger.error('Error getting licence JSON', error, { licenceNumber })
   }
-};
+}
 
 /**
  * Gets the latest version of the specified licence data
@@ -146,12 +146,12 @@ const getLicenceJson = async (licenceNumber) => {
  */
 const getLatestVersion = (versions) => {
   const sortedVersions = orderBy(versions, (version) => {
-    const issueNo = 1000 * parseInt(version.ISSUE_NO, 10);
-    const incrNo = parseInt(version.INCR_NO, 10);
-    return issueNo + incrNo;
-  });
-  return sortedVersions[sortedVersions.length - 1];
-};
+    const issueNo = 1000 * parseInt(version.ISSUE_NO, 10)
+    const incrNo = parseInt(version.INCR_NO, 10)
+    return issueNo + incrNo
+  })
+  return sortedVersions[sortedVersions.length - 1]
+}
 
 /**
  * Build packet of data to post to permit repository
@@ -162,7 +162,7 @@ const getLatestVersion = (versions) => {
  * @return {Object} - packet of data for posting to permit repo
  */
 const buildPermitRepoPacket = (licenceRef, regimeId, licenceTypeId, data) => {
-  const latestVersion = getLatestVersion(data.data.versions);
+  const latestVersion = getLatestVersion(data.data.versions)
 
   const permitRepoData = {
     licence_ref: licenceRef,
@@ -172,20 +172,20 @@ const buildPermitRepoPacket = (licenceRef, regimeId, licenceTypeId, data) => {
     licence_type_id: licenceTypeId,
     licence_regime_id: regimeId,
     licence_data_value: JSON.stringify(data)
-  };
+  }
 
   // remove null attributes so as not to anger JOI
   if (permitRepoData.licence_end_dt == null) {
-    delete permitRepoData.licence_end_dt;
+    delete permitRepoData.licence_end_dt
   }
 
   if (permitRepoData.licence_start_dt == null) {
-    delete permitRepoData.licence_start_dt;
+    delete permitRepoData.licence_start_dt
   }
-  return permitRepoData;
-};
+  return permitRepoData
+}
 
 module.exports = {
   getLicenceJson,
   buildPermitRepoPacket
-};
+}

--- a/src/modules/returns/lib/api-helpers.js
+++ b/src/modules/returns/lib/api-helpers.js
@@ -5,18 +5,18 @@
  * @return {Object} filter object for HAPI rest API
  */
 const getVersionFilter = (request) => {
-  const { start, end } = request.query;
+  const { start, end } = request.query
   const filter = {
     current: true,
     created_at: { $gte: start }
-  };
-
-  if (end) {
-    filter.created_at.$lte = end;
   }
 
-  return filter;
-};
+  if (end) {
+    filter.created_at.$lte = end
+  }
+
+  return filter
+}
 
 /**
  * Gets filter for API request to water service events endpoint
@@ -25,18 +25,18 @@ const getVersionFilter = (request) => {
  * @return {Object} filter object for HAPI rest API
  */
 const getEventFilter = (request) => {
-  const { start, end } = request.query;
+  const { start, end } = request.query
   const filter = {
     created: { $gte: start },
     type: 'return.status'
-  };
-
-  if (end) {
-    filter.created.$lte = end;
   }
 
-  return filter;
-};
+  if (end) {
+    filter.created.$lte = end
+  }
+
+  return filter
+}
 
 /**
  * Gets pagination object for HAPI rest API
@@ -45,11 +45,11 @@ const getEventFilter = (request) => {
  * @return {Object} pagination object for HAPI rest API
  */
 const getPagination = (request) => {
-  return Object.assign({ perPage: 2000, page: 1 }, request.query.pagination);
-};
+  return Object.assign({ perPage: 2000, page: 1 }, request.query.pagination)
+}
 
 module.exports = {
   getVersionFilter,
   getEventFilter,
   getPagination
-};
+}

--- a/src/modules/returns/lib/date-helpers.js
+++ b/src/modules/returns/lib/date-helpers.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const moment = require('moment')
 
 /**
  * Checks whether the supplied date is within the return cycle
@@ -7,10 +7,10 @@ const moment = require('moment');
  * @return {Boolean} true if within return cycle
  */
 const isDateWithinReturnCycle = (returnData, date) => {
-  const { start_date: startDate, end_date: endDate } = returnData;
-  return moment(date).isBetween(startDate, endDate, 'day', '[]');
-};
+  const { start_date: startDate, end_date: endDate } = returnData
+  return moment(date).isBetween(startDate, endDate, 'day', '[]')
+}
 
 module.exports = {
   isDateWithinReturnCycle
-};
+}

--- a/src/modules/returns/lib/generate-nil-lines.js
+++ b/src/modules/returns/lib/generate-nil-lines.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
-const moment = require('moment');
-const { pick, mapValues } = require('lodash');
+const moment = require('moment')
+const { pick, mapValues } = require('lodash')
 
-const waterHelpers = require('@envage/water-abstraction-helpers');
-const naldDates = waterHelpers.nald.dates;
+const waterHelpers = require('@envage/water-abstraction-helpers')
+const naldDates = waterHelpers.nald.dates
 
 /**
  * Get required daily return lines
@@ -13,20 +13,20 @@ const naldDates = waterHelpers.nald.dates;
  * @return {Array} list of required return lines
  */
 const getDays = (startDate, endDate) => {
-  const datePtr = moment(startDate);
-  const lines = [];
+  const datePtr = moment(startDate)
+  const lines = []
   do {
     lines.push({
       startDate: datePtr.format('YYYY-MM-DD'),
       endDate: datePtr.format('YYYY-MM-DD'),
       timePeriod: 'day'
-    });
-    datePtr.add(1, 'day');
+    })
+    datePtr.add(1, 'day')
   }
-  while (datePtr.isSameOrBefore(endDate, 'day'));
+  while (datePtr.isSameOrBefore(endDate, 'day'))
 
-  return lines;
-};
+  return lines
+}
 
 /**
  * Get required monthly return lines
@@ -35,19 +35,19 @@ const getDays = (startDate, endDate) => {
  * @return {Array} list of required return lines
  */
 const getMonths = (startDate, endDate) => {
-  const datePtr = moment(startDate);
-  const lines = [];
+  const datePtr = moment(startDate)
+  const lines = []
   do {
     lines.push({
       startDate: datePtr.startOf('month').format('YYYY-MM-DD'),
       endDate: datePtr.endOf('month').format('YYYY-MM-DD'),
       timePeriod: 'month'
-    });
-    datePtr.add(1, 'month');
+    })
+    datePtr.add(1, 'month')
   }
-  while (datePtr.isSameOrBefore(endDate, 'month'));
-  return lines;
-};
+  while (datePtr.isSameOrBefore(endDate, 'month'))
+  return lines
+}
 
 /**
  * Get required annual return lines
@@ -60,8 +60,8 @@ const getYears = (startDate, endDate) => {
     startDate,
     endDate,
     timePeriod: 'year'
-  }];
-};
+  }]
+}
 
 /**
  * Get required weekly return lines
@@ -70,21 +70,21 @@ const getYears = (startDate, endDate) => {
  * @return {Array} list of required return lines
  */
 const getWeeks = (startDate, endDate) => {
-  let datePtr = naldDates.getWeek(startDate);
-  const lines = [];
+  let datePtr = naldDates.getWeek(startDate)
+  const lines = []
 
   do {
     lines.push({
       startDate: datePtr.start.format('YYYY-MM-DD'),
       endDate: datePtr.end.format('YYYY-MM-DD'),
       timePeriod: 'week'
-    });
-    datePtr = naldDates.getWeek(datePtr.start.add(1, 'week'));
+    })
+    datePtr = naldDates.getWeek(datePtr.start.add(1, 'week'))
   }
-  while (datePtr.end.isSameOrBefore(endDate, 'day'));
+  while (datePtr.end.isSameOrBefore(endDate, 'day'))
 
-  return lines;
-};
+  return lines
+}
 
 /**
  * Calculates lines required in return
@@ -96,21 +96,21 @@ const getWeeks = (startDate, endDate) => {
 const getRequiredLines = (startDate, endDate, frequency) => {
   switch (frequency) {
     case 'day':
-      return getDays(startDate, endDate);
+      return getDays(startDate, endDate)
 
     case 'week':
-      return getWeeks(startDate, endDate);
+      return getWeeks(startDate, endDate)
 
     case 'month':
-      return getMonths(startDate, endDate);
+      return getMonths(startDate, endDate)
 
     case 'year':
-      return getYears(startDate, endDate);
+      return getYears(startDate, endDate)
 
     default:
-      throw new Error(`Unknown frequency ${frequency}`);
+      throw new Error(`Unknown frequency ${frequency}`)
   }
-};
+}
 
 /**
  * Checks whether a supplied day/month is the same or after a reference day/month
@@ -122,10 +122,10 @@ const getRequiredLines = (startDate, endDate, frequency) => {
  */
 const isSameOrAfter = (day, month, refDay, refMonth) => {
   if (month > refMonth) {
-    return true;
+    return true
   }
-  return ((month === refMonth) && (day >= refDay));
-};
+  return ((month === refMonth) && (day >= refDay))
+}
 
 /**
  * Checks whether a supplied day/month is the same or before a reference day/month
@@ -137,10 +137,10 @@ const isSameOrAfter = (day, month, refDay, refMonth) => {
  */
 const isSameOrBefore = (day, month, refDay, refMonth) => {
   if (month < refMonth) {
-    return true;
+    return true
   }
-  return (month === refMonth) && (day <= refDay);
-};
+  return (month === refMonth) && (day <= refDay)
+}
 
 /**
  * Checks whether the specified date is within the abstraction period
@@ -158,31 +158,31 @@ const isDateWithinAbstractionPeriod = (date, options) => {
     periodEndMonth,
     periodStartDay,
     periodStartMonth
-  } = options;
+  } = options
 
   // Month and day of test date
-  const month = moment(date).month() + 1;
-  const day = moment(date).date();
+  const month = moment(date).month() + 1
+  const day = moment(date).date()
 
   // Period start date is >= period end date
   if (isSameOrAfter(periodEndDay, periodEndMonth, periodStartDay, periodStartMonth)) {
     return isSameOrAfter(day, month, periodStartDay, periodStartMonth) &&
-      isSameOrBefore(day, month, periodEndDay, periodEndMonth);
+      isSameOrBefore(day, month, periodEndDay, periodEndMonth)
   } else {
     const prevYear = isSameOrAfter(day, month, 1, 1) &&
-     isSameOrBefore(day, month, periodEndDay, periodEndMonth);
+     isSameOrBefore(day, month, periodEndDay, periodEndMonth)
 
     const thisYear = isSameOrAfter(day, month, periodStartDay, periodStartMonth) &&
-     isSameOrBefore(day, month, 31, 12);
+     isSameOrBefore(day, month, 31, 12)
 
-    return prevYear || thisYear;
+    return prevYear || thisYear
   }
-};
+}
 
 const getAbsPeriod = (returnData) => {
-  const data = pick(returnData.metadata.nald, ['periodStartDay', 'periodStartMonth', 'periodEndDay', 'periodEndMonth']);
-  return mapValues(data, parseInt);
-};
+  const data = pick(returnData.metadata.nald, ['periodStartDay', 'periodStartMonth', 'periodEndDay', 'periodEndMonth'])
+  return mapValues(data, parseInt)
+}
 
 /**
  * Accepts a line generated by the getRequiredLines call, and returns a line
@@ -193,9 +193,9 @@ const getAbsPeriod = (returnData) => {
  * @return {Object} mapped line
  */
 const mapLine = (line, absPeriod) => {
-  const { startDate, endDate, timePeriod } = line;
+  const { startDate, endDate, timePeriod } = line
 
-  const isInPeriod = isDateWithinAbstractionPeriod(endDate, absPeriod);
+  const isInPeriod = isDateWithinAbstractionPeriod(endDate, absPeriod)
 
   return {
     start_date: startDate,
@@ -205,8 +205,8 @@ const mapLine = (line, absPeriod) => {
     user_unit: 'm³',
     reading_type: 'measured',
     time_period: timePeriod
-  };
-};
+  }
+}
 
 /**
  * Given return data for a nil return, generates a list of return
@@ -216,14 +216,14 @@ const mapLine = (line, absPeriod) => {
  * @return {Array} return lines
  */
 const generateNilLines = (returnData) => {
-  const { start_date: startDate, end_date: endDate, returns_frequency: frequency } = returnData;
+  const { start_date: startDate, end_date: endDate, returns_frequency: frequency } = returnData
 
-  const absPeriod = getAbsPeriod(returnData);
+  const absPeriod = getAbsPeriod(returnData)
 
-  const lines = getRequiredLines(startDate, endDate, frequency);
+  const lines = getRequiredLines(startDate, endDate, frequency)
 
-  return lines.map(line => mapLine(line, absPeriod));
-};
+  return lines.map(line => mapLine(line, absPeriod))
+}
 
 module.exports = {
   getDays,
@@ -234,4 +234,4 @@ module.exports = {
   isDateWithinAbstractionPeriod,
   getAbsPeriod,
   mapLine
-};
+}

--- a/src/modules/returns/lib/transformers.js
+++ b/src/modules/returns/lib/transformers.js
@@ -1,17 +1,17 @@
-'use strict';
+'use strict'
 
-const moment = require('moment');
-const { returns: { date: { getPeriodStart } } } = require('@envage/water-abstraction-helpers');
-const { flow, toUpper, first, range, get, pick } = require('lodash');
-const { isDateWithinReturnCycle } = require('./date-helpers');
+const moment = require('moment')
+const { returns: { date: { getPeriodStart } } } = require('@envage/water-abstraction-helpers')
+const { flow, toUpper, first, range, get, pick } = require('lodash')
+const { isDateWithinReturnCycle } = require('./date-helpers')
 
-const DATE_FORMAT = 'YYYY-MM-DD';
+const DATE_FORMAT = 'YYYY-MM-DD'
 
 const getFutureDate = (date, daysForward) => {
-  return moment(date, DATE_FORMAT).add(daysForward, 'days').format(DATE_FORMAT);
-};
+  return moment(date, DATE_FORMAT).add(daysForward, 'days').format(DATE_FORMAT)
+}
 
-const getNaldStyleDate = date => moment(date, DATE_FORMAT).format('YYYYMMDD000000');
+const getNaldStyleDate = date => moment(date, DATE_FORMAT).format('YYYYMMDD000000')
 
 /**
  * Given return data from the return service, calculates the return cycle
@@ -21,40 +21,40 @@ const getNaldStyleDate = date => moment(date, DATE_FORMAT).format('YYYYMMDD00000
  * @return {String}            - date in format 'YYYY-MM-DD'
  */
 const getReturnCycleStart = (returnData) => {
-  const isSummer = get(returnData, 'metadata.isSummer', undefined);
+  const isSummer = get(returnData, 'metadata.isSummer', undefined)
   if (typeof isSummer !== 'undefined') {
-    return getPeriodStart(returnData.start_date, isSummer);
+    return getPeriodStart(returnData.start_date, isSummer)
   }
-};
+}
 
 /**
  * Takes a WRLS return object and converts to a smaller object ready
  * for loading into NALD
  */
 const transformReturn = (returnData, addFields = []) => {
-  const pickFields = ['returns_frequency', 'licence_ref', 'start_date', 'end_date', 'status', 'received_date', 'under_query', 'under_query_comment', ...addFields];
-  const transformed = pick(returnData, pickFields);
+  const pickFields = ['returns_frequency', 'licence_ref', 'start_date', 'end_date', 'status', 'received_date', 'under_query', 'under_query_comment', ...addFields]
+  const transformed = pick(returnData, pickFields)
 
-  transformed.under_query_comment = returnData.under_query_comment || '';
-  transformed.regionCode = get(returnData, 'metadata.nald.regionCode');
-  transformed.formatId = get(returnData, 'metadata.nald.formatId');
-  transformed.nald_date_from = getNaldStyleDate(moment(transformed.start_date).startOf('month').format('YYYY-MM-DD'));
-  transformed.nald_ret_date = getNaldStyleDate(transformed.received_date);
-  transformed.return_cycle_start = getReturnCycleStart(returnData);
+  transformed.under_query_comment = returnData.under_query_comment || ''
+  transformed.regionCode = get(returnData, 'metadata.nald.regionCode')
+  transformed.formatId = get(returnData, 'metadata.nald.formatId')
+  transformed.nald_date_from = getNaldStyleDate(moment(transformed.start_date).startOf('month').format('YYYY-MM-DD'))
+  transformed.nald_ret_date = getNaldStyleDate(transformed.received_date)
+  transformed.return_cycle_start = getReturnCycleStart(returnData)
 
-  return transformed;
-};
+  return transformed
+}
 
 const transformQuantity = (quantity = 0) => {
   if (quantity === null || toUpper(quantity) === 'NULL') {
-    return null;
+    return null
   }
 
-  const val = quantity.toString();
-  return val.includes('.') ? parseFloat(val).toFixed(3) : val;
-};
+  const val = quantity.toString()
+  return val.includes('.') ? parseFloat(val).toFixed(3) : val
+}
 
-const getUpperCasedFirstCharacter = flow(first, toUpper);
+const getUpperCasedFirstCharacter = flow(first, toUpper)
 
 /**
  * Transforms user units to NALD unit flag
@@ -65,10 +65,10 @@ const getUpperCasedFirstCharacter = flow(first, toUpper);
  */
 const transformUnits = (unit) => {
   if (unit.toLowerCase() === 'gal') {
-    return 'I';
+    return 'I'
   }
-  return 'M';
-};
+  return 'M'
+}
 
 /**
  * Takes a WRLS line object and converts to a smaller object ready
@@ -76,16 +76,16 @@ const transformUnits = (unit) => {
  */
 const transformLine = lineData => {
   if (lineData.time_period === 'week') {
-    throw new Error('Please use transformWeeklyLine for weekly lines');
+    throw new Error('Please use transformWeeklyLine for weekly lines')
   }
-  const paths = ['start_date', 'end_date', 'time_period', 'reading_type', 'unit', 'user_unit'];
-  const line = pick(lineData, paths);
-  line.quantity = transformQuantity(lineData.quantity);
-  line.nald_reading_type = getUpperCasedFirstCharacter(line.reading_type);
-  line.nald_time_period = getUpperCasedFirstCharacter(line.time_period);
-  line.nald_units = transformUnits(line.user_unit);
-  return line;
-};
+  const paths = ['start_date', 'end_date', 'time_period', 'reading_type', 'unit', 'user_unit']
+  const line = pick(lineData, paths)
+  line.quantity = transformQuantity(lineData.quantity)
+  line.nald_reading_type = getUpperCasedFirstCharacter(line.reading_type)
+  line.nald_time_period = getUpperCasedFirstCharacter(line.time_period)
+  line.nald_units = transformUnits(line.user_unit)
+  return line
+}
 
 /**
  * Takes a weekly WRLS line object and converts to 7 daily lines
@@ -94,24 +94,24 @@ const transformLine = lineData => {
  */
 const transformWeeklyLine = lineData => {
   if (lineData.time_period !== 'week') {
-    throw new Error('Please use transformLine when not weekly');
+    throw new Error('Please use transformLine when not weekly')
   }
 
   const dailies = range(7).reduce((lines, daysForward) => {
-    const date = getFutureDate(lineData.start_date, daysForward);
-    const quantity = daysForward === 6 ? lineData.quantity : null;
+    const date = getFutureDate(lineData.start_date, daysForward)
+    const quantity = daysForward === 6 ? lineData.quantity : null
 
     const dailyLine = transformLine(Object.assign({}, lineData, {
       start_date: date,
       end_date: date,
       quantity,
       time_period: 'day'
-    }));
-    return [...lines, dailyLine];
-  }, []);
+    }))
+    return [...lines, dailyLine]
+  }, [])
 
-  return dailies;
-};
+  return dailies
+}
 
 /**
  * Filters lines to ensure that they are all within the return cycle
@@ -120,12 +120,12 @@ const transformWeeklyLine = lineData => {
  * @return {Array} array of filtered return lines
  */
 const filterLines = (returnData, lines) => {
-  const { returns_frequency: frequency } = returnData;
+  const { returns_frequency: frequency } = returnData
   if (frequency !== 'week') {
-    return lines;
+    return lines
   }
-  return lines.filter(line => isDateWithinReturnCycle(returnData, line.end_date));
-};
+  return lines.filter(line => isDateWithinReturnCycle(returnData, line.end_date))
+}
 
 module.exports = {
   transformReturn,
@@ -135,4 +135,4 @@ module.exports = {
   transformUnits,
   filterLines,
   getReturnCycleStart
-};
+}

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const Joi = require('@hapi/joi');
-const controller = require('./controller');
+const Joi = require('@hapi/joi')
+const controller = require('./controller')
 
 const getVersions = {
   method: 'GET',
@@ -20,7 +20,7 @@ const getVersions = {
     }
   },
   path: '/etl/versions'
-};
+}
 
 const getLinesForVersion = {
   method: 'GET',
@@ -34,7 +34,7 @@ const getLinesForVersion = {
     }
   },
   path: '/etl/versions/{versionID}/lines'
-};
+}
 
 const getReturns = {
   method: 'GET',
@@ -53,10 +53,10 @@ const getReturns = {
     }
   },
   path: '/etl/returns'
-};
+}
 
 module.exports = [
   getVersions,
   getLinesForVersion,
   getReturns
-];
+]

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,9 +1,9 @@
-const coreRoutes = require('./modules/core/routes');
-const returnsRoutes = require('./modules/returns/routes');
-const chargingImportRoutes = require('./modules/charging-import/routes');
-const licenceImportRoutes = require('./modules/licence-import/routes');
-const naldImportRoutes = require('./modules/nald-import/routes');
-const jobSummaryRoutes = require('./modules/jobs/routes');
+const coreRoutes = require('./modules/core/routes')
+const returnsRoutes = require('./modules/returns/routes')
+const chargingImportRoutes = require('./modules/charging-import/routes')
+const licenceImportRoutes = require('./modules/licence-import/routes')
+const naldImportRoutes = require('./modules/nald-import/routes')
+const jobSummaryRoutes = require('./modules/jobs/routes')
 
 module.exports = [
   ...coreRoutes,
@@ -12,4 +12,4 @@ module.exports = [
   ...licenceImportRoutes,
   ...jobSummaryRoutes,
   ...naldImportRoutes
-];
+]

--- a/test/lib/connectors/import.js
+++ b/test/lib/connectors/import.js
@@ -1,43 +1,43 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { pool } = require('../../../src/lib/connectors/db');
-const importConnector = require('../../../src/lib/connectors/import');
+const { pool } = require('../../../src/lib/connectors/db')
+const importConnector = require('../../../src/lib/connectors/import')
 
 experiment('lib/connectors/import', () => {
   beforeEach(async () => {
-    sandbox.stub(pool, 'query').resolves({});
-  });
+    sandbox.stub(pool, 'query').resolves({})
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getLicenceNumbers', () => {
     experiment('when no data is returned', () => {
       test('an empty array is returned', async () => {
-        const licenceNumbers = await importConnector.getLicenceNumbers();
-        expect(licenceNumbers).to.equal([]);
-      });
-    });
+        const licenceNumbers = await importConnector.getLicenceNumbers()
+        expect(licenceNumbers).to.equal([])
+      })
+    })
 
     experiment('when data is returned', () => {
       test('the rows are returned', async () => {
         pool.query.resolves({
           rows: ['01/01', '01/02']
-        });
-        const licenceNumbers = await importConnector.getLicenceNumbers();
-        expect(licenceNumbers).to.equal(['01/01', '01/02']);
-      });
-    });
-  });
-});
+        })
+        const licenceNumbers = await importConnector.getLicenceNumbers()
+        expect(licenceNumbers).to.equal(['01/01', '01/02'])
+      })
+    })
+  })
+})

--- a/test/lib/connectors/s3.js
+++ b/test/lib/connectors/s3.js
@@ -1,91 +1,91 @@
-'use strict';
+'use strict'
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 const {
   beforeEach,
   afterEach,
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const aws = require('aws-sdk');
+const aws = require('aws-sdk')
 
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const s3 = require('../../../src/lib/connectors/s3');
-const config = require('../../../config');
+const s3 = require('../../../src/lib/connectors/s3')
+const config = require('../../../config')
 
-const PROXY = 'http://some-proxy.example.com';
+const PROXY = 'http://some-proxy.example.com'
 
 const S3_CREDENTIALS = {
   accessKeyId: 'key-id',
   secretAccessKey: 'a-secret-key',
   region: 'some-region',
   bucket: 'bucket-name'
-};
+}
 
 experiment('lib/services/s3', () => {
   beforeEach(async () => {
-    sandbox.stub(config, 'proxy').value(PROXY);
-    sandbox.stub(config, 's3').value(S3_CREDENTIALS);
-    sandbox.stub(aws.config, 'update');
-  });
+    sandbox.stub(config, 'proxy').value(PROXY)
+    sandbox.stub(config, 's3').value(S3_CREDENTIALS)
+    sandbox.stub(aws.config, 'update')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('._getS3Options', () => {
     experiment('when a proxy is defined', () => {
-      let result;
+      let result
 
       beforeEach(async () => {
-        result = s3._getS3Options();
-      });
+        result = s3._getS3Options()
+      })
 
       test('result is an object', async () => {
-        expect(result).to.be.an.object();
-      });
+        expect(result).to.be.an.object()
+      })
 
       test('proxy agent is defined', async () => {
-        expect(result.httpOptions.agent).to.be.an.object();
-      });
+        expect(result.httpOptions.agent).to.be.an.object()
+      })
 
       test('bucket region is defined', async () => {
-        expect(result.region).to.equal(S3_CREDENTIALS.region);
-      });
+        expect(result.region).to.equal(S3_CREDENTIALS.region)
+      })
 
       test('aws credentials are defined', async () => {
-        expect(result.accessKeyId).to.equal(S3_CREDENTIALS.accessKeyId);
-        expect(result.secretAccessKey).to.equal(S3_CREDENTIALS.secretAccessKey);
-      });
-    });
+        expect(result.accessKeyId).to.equal(S3_CREDENTIALS.accessKeyId)
+        expect(result.secretAccessKey).to.equal(S3_CREDENTIALS.secretAccessKey)
+      })
+    })
 
     experiment('when a proxy is not defined', () => {
-      let result;
+      let result
 
       beforeEach(async () => {
-        sandbox.stub(config, 'proxy').value(undefined);
-        result = s3._getS3Options();
-      });
+        sandbox.stub(config, 'proxy').value(undefined)
+        result = s3._getS3Options()
+      })
 
       test('result is an object', async () => {
-        expect(result).to.be.an.object();
-      });
+        expect(result).to.be.an.object()
+      })
 
       test('proxy agent is not defined', async () => {
-        expect(result.httpOptions).to.be.undefined();
-      });
+        expect(result.httpOptions).to.be.undefined()
+      })
 
       test('bucket region is defined', async () => {
-        expect(result.region).to.equal(S3_CREDENTIALS.region);
-      });
+        expect(result.region).to.equal(S3_CREDENTIALS.region)
+      })
 
       test('aws credentials are defined', async () => {
-        expect(result.accessKeyId).to.equal(S3_CREDENTIALS.accessKeyId);
-        expect(result.secretAccessKey).to.equal(S3_CREDENTIALS.secretAccessKey);
-      });
-    });
-  });
-});
+        expect(result.accessKeyId).to.equal(S3_CREDENTIALS.accessKeyId)
+        expect(result.secretAccessKey).to.equal(S3_CREDENTIALS.secretAccessKey)
+      })
+    })
+  })
+})

--- a/test/lib/connectors/water/application-state.js
+++ b/test/lib/connectors/water/application-state.js
@@ -1,72 +1,72 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const config = require('../../../../config');
-const { serviceRequest } = require('@envage/water-abstraction-helpers');
-const connector = require('../../../../src/lib/connectors/water/application-state');
+const config = require('../../../../config')
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const connector = require('../../../../src/lib/connectors/water/application-state')
 
 experiment('lib/connectors/water/application-state', () => {
   beforeEach(async () => {
-    sandbox.stub(serviceRequest, 'get');
-    sandbox.stub(serviceRequest, 'post');
-    sandbox.stub(config.services, 'water').value('http://example.com');
-  });
+    sandbox.stub(serviceRequest, 'get')
+    sandbox.stub(serviceRequest, 'post')
+    sandbox.stub(config.services, 'water').value('http://example.com')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getState', () => {
     test('makes a request to the expected url', async () => {
-      await connector.getState('test-key');
-      const [url] = serviceRequest.get.lastCall.args;
+      await connector.getState('test-key')
+      const [url] = serviceRequest.get.lastCall.args
 
-      expect(url).to.equal('http://example.com/application-state/test-key');
-    });
+      expect(url).to.equal('http://example.com/application-state/test-key')
+    })
 
     test('returns the data', async () => {
       serviceRequest.get.resolves({
         applicationStateId: 'test-key'
-      });
+      })
 
-      const state = await connector.getState('test-key');
+      const state = await connector.getState('test-key')
 
-      expect(state.applicationStateId).to.equal('test-key');
-    });
-  });
+      expect(state.applicationStateId).to.equal('test-key')
+    })
+  })
 
   experiment('.postState', () => {
     test('makes a request to the expected url', async () => {
-      await connector.postState('test-key', { data: true });
-      const [url] = serviceRequest.post.lastCall.args;
+      await connector.postState('test-key', { data: true })
+      const [url] = serviceRequest.post.lastCall.args
 
-      expect(url).to.equal('http://example.com/application-state/test-key');
-    });
+      expect(url).to.equal('http://example.com/application-state/test-key')
+    })
 
     test('includes the data in the request', async () => {
-      await connector.postState('test-key', { data: true });
-      const [, options] = serviceRequest.post.lastCall.args;
+      await connector.postState('test-key', { data: true })
+      const [, options] = serviceRequest.post.lastCall.args
 
-      expect(options.body.data).to.equal(true);
-    });
+      expect(options.body.data).to.equal(true)
+    })
 
     test('returns the data', async () => {
       serviceRequest.post.resolves({
         applicationStateId: 'test-key'
-      });
+      })
 
-      const state = await connector.postState('test-key', { data: true });
+      const state = await connector.postState('test-key', { data: true })
 
-      expect(state.applicationStateId).to.equal('test-key');
-    });
-  });
-});
+      expect(state.applicationStateId).to.equal('test-key')
+    })
+  })
+})

--- a/test/lib/connectors/water/notify.js
+++ b/test/lib/connectors/water/notify.js
@@ -1,52 +1,52 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const config = require('../../../../config');
-const { serviceRequest } = require('@envage/water-abstraction-helpers');
-const connector = require('../../../../src/lib/connectors/water/notify');
+const config = require('../../../../config')
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const connector = require('../../../../src/lib/connectors/water/notify')
 
 experiment('lib/connectors/water/application-state', () => {
   beforeEach(async () => {
-    sandbox.stub(serviceRequest, 'post');
-    sandbox.stub(config.services, 'water').value('http://example.com');
-  });
+    sandbox.stub(serviceRequest, 'post')
+    sandbox.stub(config.services, 'water').value('http://example.com')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.postSendNotify', () => {
     test('makes a request to the expected url', async () => {
-      await connector.postSendNotify('test-key', { data: true });
-      const [url] = serviceRequest.post.lastCall.args;
+      await connector.postSendNotify('test-key', { data: true })
+      const [url] = serviceRequest.post.lastCall.args
 
-      expect(url).to.equal('http://example.com/notify/test-key');
-    });
+      expect(url).to.equal('http://example.com/notify/test-key')
+    })
 
     test('includes the data in the request', async () => {
-      await connector.postSendNotify('test-key', { data: true });
-      const [, options] = serviceRequest.post.lastCall.args;
+      await connector.postSendNotify('test-key', { data: true })
+      const [, options] = serviceRequest.post.lastCall.args
 
-      expect(options.body.data).to.equal(true);
-    });
+      expect(options.body.data).to.equal(true)
+    })
 
     test('returns the data', async () => {
       serviceRequest.post.resolves({
         applicationStateId: 'test-key'
-      });
+      })
 
-      const response = await connector.postSendNotify('test-key', { data: true });
+      const response = await connector.postSendNotify('test-key', { data: true })
 
-      expect(response.applicationStateId).to.equal('test-key');
-    });
-  });
-});
+      expect(response.applicationStateId).to.equal('test-key')
+    })
+  })
+})

--- a/test/lib/plugin.js
+++ b/test/lib/plugin.js
@@ -1,52 +1,52 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const plugin = require('../../src/lib/plugin');
+const plugin = require('../../src/lib/plugin')
 
 experiment('lib/plugin', () => {
   experiment('createRegister', () => {
-    let registerSubscribers;
-    let server;
+    let registerSubscribers
+    let server
 
     beforeEach(async () => {
-      registerSubscribers = sandbox.spy();
-      server = Symbol('test server');
-    });
+      registerSubscribers = sandbox.spy()
+      server = Symbol('test server')
+    })
 
     afterEach(async () => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     experiment('when in the travis environment', () => {
       test('registerSubscribers is not called', async () => {
         sandbox.stub(process, 'env').value({
           TRAVIS: 1
-        });
-        plugin.createRegister(server, registerSubscribers);
-        expect(registerSubscribers.called).to.equal(false);
-      });
-    });
+        })
+        plugin.createRegister(server, registerSubscribers)
+        expect(registerSubscribers.called).to.equal(false)
+      })
+    })
 
     experiment('when not in the travis environment', () => {
-      const registerEnvironments = ['local', 'dev', 'test', 'preprod', 'production'];
+      const registerEnvironments = ['local', 'dev', 'test', 'preprod', 'production']
 
       registerEnvironments.forEach(env => {
         test(`registerSubscribers is called for ${env}`, async () => {
-          sandbox.stub(process, 'env').value({ NODE_ENV: env });
-          plugin.createRegister(server, registerSubscribers);
+          sandbox.stub(process, 'env').value({ NODE_ENV: env })
+          plugin.createRegister(server, registerSubscribers)
 
-          expect(registerSubscribers.called).to.equal(true);
-        });
-      });
-    });
-  });
-});
+          expect(registerSubscribers.called).to.equal(true)
+        })
+      })
+    })
+  })
+})

--- a/test/lib/services/import.js
+++ b/test/lib/services/import.js
@@ -1,37 +1,37 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const importConnector = require('../../../src/lib/connectors/import');
-const importService = require('../../../src/lib/services/import');
+const importConnector = require('../../../src/lib/connectors/import')
+const importService = require('../../../src/lib/services/import')
 
 experiment('lib/services/import', () => {
   beforeEach(async () => {
-    sandbox.stub(importConnector, 'getLicenceNumbers');
-    sandbox.stub(importConnector, 'deleteRemovedDocuments');
-  });
+    sandbox.stub(importConnector, 'getLicenceNumbers')
+    sandbox.stub(importConnector, 'deleteRemovedDocuments')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getLicenceNumbers', () => {
     experiment('when there is no data', () => {
       test('returns an empty array', async () => {
-        importConnector.getLicenceNumbers.resolves([]);
-        const licences = await importService.getLicenceNumbers();
+        importConnector.getLicenceNumbers.resolves([])
+        const licences = await importService.getLicenceNumbers()
 
-        expect(licences).to.equal([]);
-      });
-    });
+        expect(licences).to.equal([])
+      })
+    })
 
     experiment('when there is data', () => {
       test('returns an array of licence numbers', async () => {
@@ -39,22 +39,22 @@ experiment('lib/services/import', () => {
           { LIC_NO: '111' },
           { LIC_NO: '222' },
           { LIC_NO: '333' }
-        ]);
-        const licences = await importService.getLicenceNumbers();
+        ])
+        const licences = await importService.getLicenceNumbers()
 
-        expect(licences).to.equal(['111', '222', '333']);
-      });
-    });
-  });
+        expect(licences).to.equal(['111', '222', '333'])
+      })
+    })
+  })
 
   experiment('.deleteRemovedDocuments', () => {
     beforeEach(async () => {
-      importConnector.deleteRemovedDocuments.resolves();
-      await importService.deleteRemovedDocuments();
-    });
+      importConnector.deleteRemovedDocuments.resolves()
+      await importService.deleteRemovedDocuments()
+    })
 
     test('calls through to the connector', async () => {
-      expect(importConnector.deleteRemovedDocuments.called).to.equal(true);
-    });
-  });
-});
+      expect(importConnector.deleteRemovedDocuments.called).to.equal(true)
+    })
+  })
+})

--- a/test/lib/services/notify.js
+++ b/test/lib/services/notify.js
@@ -1,35 +1,35 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const notifyConnector = require('../../../src/lib/connectors/water/notify');
-const notifyService = require('../../../src/lib/services/notify');
+const notifyConnector = require('../../../src/lib/connectors/water/notify')
+const notifyService = require('../../../src/lib/services/notify')
 
 experiment('lib/services/notify', () => {
   beforeEach(async () => {
-    sandbox.stub(notifyConnector, 'postSendNotify').resolves();
-    await notifyService.sendEmail('test@email.com', 'service_status_alert', { test: 'data' });
-  });
+    sandbox.stub(notifyConnector, 'postSendNotify').resolves()
+    await notifyService.sendEmail('test@email.com', 'service_status_alert', { test: 'data' })
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.sendNotifyMessage', () => {
     test('calls the notify connector with the right params', async () => {
-      const [key, data] = notifyConnector.postSendNotify.lastCall.args;
-      expect(key).to.equal('email');
-      expect(data.templateId).to.equal('c34d1b16-694b-4364-8e7e-83e9dbd34a62');
-      expect(data.recipient).to.equal('test@email.com');
-      expect(data.personalisation).to.equal({ test: 'data' });
-    });
-  });
-});
+      const [key, data] = notifyConnector.postSendNotify.lastCall.args
+      expect(key).to.equal('email')
+      expect(data.templateId).to.equal('c34d1b16-694b-4364-8e7e-83e9dbd34a62')
+      expect(data.recipient).to.equal('test@email.com')
+      expect(data.personalisation).to.equal({ test: 'data' })
+    })
+  })
+})

--- a/test/lib/services/s3.js
+++ b/test/lib/services/s3.js
@@ -1,35 +1,35 @@
-'use strict';
+'use strict'
 
-const sandbox = require('sinon').createSandbox();
-const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox()
+const { expect } = require('@hapi/code')
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const fs = require('fs');
-const EventEmitter = require('events');
+const fs = require('fs')
+const EventEmitter = require('events')
 
-const config = require('../../../config');
-const s3Connector = require('../../../src/lib/connectors/s3');
-const s3Service = require('../../../src/lib/services/s3');
+const config = require('../../../config')
+const s3Connector = require('../../../src/lib/connectors/s3')
+const s3Service = require('../../../src/lib/services/s3')
 
-const BUCKET = 'test-bucket';
+const BUCKET = 'test-bucket'
 
 experiment('lib/services/s3', () => {
-  let stub, read, write;
+  let stub, read, write
 
   beforeEach(async () => {
-    sandbox.stub(config.s3, 'bucket').value(BUCKET);
+    sandbox.stub(config.s3, 'bucket').value(BUCKET)
 
-    write = new EventEmitter();
-    sandbox.spy(write, 'on');
+    write = new EventEmitter()
+    sandbox.spy(write, 'on')
 
-    read = new EventEmitter();
-    sandbox.spy(read, 'on');
-    read.pipe = sandbox.spy();
+    read = new EventEmitter()
+    sandbox.spy(read, 'on')
+    read.pipe = sandbox.spy()
 
     stub = {
       headObject: sandbox.stub().returnsThis(),
@@ -37,66 +37,66 @@ experiment('lib/services/s3', () => {
       getObject: sandbox.stub().returnsThis(),
       createReadStream: sandbox.stub().returns(read),
       promise: sandbox.stub().resolves()
-    };
-    sandbox.stub(s3Connector, 'getS3').returns(stub);
-    sandbox.stub(fs, 'createWriteStream').returns(write);
-  });
+    }
+    sandbox.stub(s3Connector, 'getS3').returns(stub)
+    sandbox.stub(fs, 'createWriteStream').returns(write)
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.upload', () => {
-    let buffer;
+    let buffer
 
     beforeEach(async () => {
-      buffer = Buffer.from('test-contents');
-      await s3Service.upload('test/key.txt', buffer);
-    });
+      buffer = Buffer.from('test-contents')
+      await s3Service.upload('test/key.txt', buffer)
+    })
 
     test('calls upload on connector with correct options', async () => {
       expect(stub.upload.calledWith({
         Key: 'test/key.txt',
         Bucket: BUCKET,
         Body: buffer
-      })).to.be.true();
-    });
+      })).to.be.true()
+    })
 
     test('calls promise() method', async () => {
-      expect(stub.promise.called).to.be.true();
-    });
+      expect(stub.promise.called).to.be.true()
+    })
 
     test('chains methods in correct order', async () => {
       sandbox.assert.callOrder(
         stub.upload,
         stub.promise
-      );
-    });
-  });
+      )
+    })
+  })
 
   experiment('.getObject', () => {
     beforeEach(async () => {
-      await s3Service.getObject('test/key.txt');
-    });
+      await s3Service.getObject('test/key.txt')
+    })
 
     test('calls upload on connector with correct options', async () => {
       expect(stub.getObject.calledWith({
         Key: 'test/key.txt',
         Bucket: BUCKET
-      })).to.be.true();
-    });
+      })).to.be.true()
+    })
 
     test('calls promise() method', async () => {
-      expect(stub.promise.called).to.be.true();
-    });
+      expect(stub.promise.called).to.be.true()
+    })
 
     test('chains methods in correct order', async () => {
       sandbox.assert.callOrder(
         stub.getObject,
         stub.promise
-      );
-    });
-  });
+      )
+    })
+  })
 
   experiment('.download', () => {
     experiment('when there is no read error', () => {
@@ -104,59 +104,59 @@ experiment('lib/services/s3', () => {
         await Promise.all([
           s3Service.download('test/key.txt', 'test-destination/'),
           write.emit('close')
-        ]);
-      });
+        ])
+      })
 
       test('calls fs.createWriteStream with correct path', async () => {
-        expect(fs.createWriteStream.calledWith('test-destination/'));
-      });
+        expect(fs.createWriteStream.calledWith('test-destination/'))
+      })
 
       test('calls getObject on connector with correct options', async () => {
         expect(stub.getObject.calledWith({
           Key: 'test/key.txt',
           Bucket: BUCKET
-        })).to.be.true();
-      });
+        })).to.be.true()
+      })
 
       test('calls createReadStream', async () => {
-        expect(stub.createReadStream.called).to.be.true();
-      });
+        expect(stub.createReadStream.called).to.be.true()
+      })
 
       test('calls .pipe() on read stream', async () => {
-        expect(read.pipe.called).to.be.true();
-      });
-    });
+        expect(read.pipe.called).to.be.true()
+      })
+    })
 
     test('when there is a read error, rejects', async () => {
       const func = () => Promise.all([
         s3Service.download('test/key.txt', 'test-destination/'),
         read.emit('error', new Error())
-      ]);
-      expect(func()).to.reject();
-    });
-  });
+      ])
+      expect(func()).to.reject()
+    })
+  })
 
   experiment('.getHead', () => {
     beforeEach(async () => {
-      await s3Service.getHead('test/key.txt');
-    });
+      await s3Service.getHead('test/key.txt')
+    })
 
     test('calls headObject on connector with correct options', async () => {
       expect(stub.headObject.calledWith({
         Key: 'test/key.txt',
         Bucket: BUCKET
-      })).to.be.true();
-    });
+      })).to.be.true()
+    })
 
     test('calls promise() method', async () => {
-      expect(stub.promise.called).to.be.true();
-    });
+      expect(stub.promise.called).to.be.true()
+    })
 
     test('chains methods in correct order', async () => {
       sandbox.assert.callOrder(
         stub.headObject,
         stub.promise
-      );
-    });
-  });
-});
+      )
+    })
+  })
+})

--- a/test/modules/charging-import/controller.js
+++ b/test/modules/charging-import/controller.js
@@ -1,33 +1,33 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const controller = require('../../../src/modules/charging-import/controller');
-const chargeVersionsJob = require('../../../src/modules/charging-import/jobs/charge-versions');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const controller = require('../../../src/modules/charging-import/controller')
+const chargeVersionsJob = require('../../../src/modules/charging-import/jobs/charge-versions')
+const sandbox = require('sinon').createSandbox()
 
 experiment('modules/charging-import/controller.js', () => {
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('postImportChargingData', () => {
-    let response, request;
+    let response, request
 
     beforeEach(async () => {
       request = {
         messageQueue: {
           publish: sandbox.stub()
         }
-      };
-      response = await controller.postImportChargingData(request);
-    });
+      }
+      response = await controller.postImportChargingData(request)
+    })
 
     test('publishes a message to the message queue to begin the import', async () => {
-      const [message] = request.messageQueue.publish.lastCall.args;
-      expect(message.name).to.equal(chargeVersionsJob.jobName);
-    });
+      const [message] = request.messageQueue.publish.lastCall.args
+      expect(message.name).to.equal(chargeVersionsJob.jobName)
+    })
 
     test('resolves with { error : null } HTTP response', async () => {
-      expect(response).to.equal({ error: null });
-    });
-  });
-});
+      expect(response).to.equal({ error: null })
+    })
+  })
+})

--- a/test/modules/charging-import/jobs/charge-versions.js
+++ b/test/modules/charging-import/jobs/charge-versions.js
@@ -1,25 +1,25 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader');
-const chargeVersionsJob = require('../../../../src/modules/charging-import/jobs/charge-versions');
-const chargeVersionQueries = require('../../../../src/modules/charging-import/lib/queries/charging');
+const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader')
+const chargeVersionsJob = require('../../../../src/modules/charging-import/jobs/charge-versions')
+const chargeVersionQueries = require('../../../../src/modules/charging-import/lib/queries/charging')
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
 experiment('modules/charging-import/jobs/charge-versions.js', () => {
   beforeEach(async () => {
-    sandbox.stub(queryLoader, 'loadQueries');
-  });
+    sandbox.stub(queryLoader, 'loadQueries')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.handler', () => {
     beforeEach(async () => {
-      chargeVersionsJob.handler();
-    });
+      chargeVersionsJob.handler()
+    })
 
     test('runs the correct queries', async () => {
       expect(queryLoader.loadQueries.calledWith(
@@ -30,7 +30,7 @@ experiment('modules/charging-import/jobs/charge-versions.js', () => {
           chargeVersionQueries.cleanupChargeElements,
           chargeVersionQueries.cleanupChargeVersions
         ]
-      )).to.be.true();
-    });
-  });
-});
+      )).to.be.true()
+    })
+  })
+})

--- a/test/modules/charging-import/jobs/charging-data.js
+++ b/test/modules/charging-import/jobs/charging-data.js
@@ -1,27 +1,27 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader');
-const chargingDataJob = require('../../../../src/modules/charging-import/jobs/charging-data');
-const purposesQueries = require('../../../../src/modules/charging-import/lib/queries/purposes');
-const returnVersionQueries = require('../../../../src/modules/charging-import/lib/queries/return-versions');
-const financialAgreementTypeQueries = require('../../../../src/modules/charging-import/lib/queries/financial-agreement-types');
+const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader')
+const chargingDataJob = require('../../../../src/modules/charging-import/jobs/charging-data')
+const purposesQueries = require('../../../../src/modules/charging-import/lib/queries/purposes')
+const returnVersionQueries = require('../../../../src/modules/charging-import/lib/queries/return-versions')
+const financialAgreementTypeQueries = require('../../../../src/modules/charging-import/lib/queries/financial-agreement-types')
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
 experiment('modules/charging-import/jobs/charging-data.js', () => {
   beforeEach(async () => {
-    sandbox.stub(queryLoader, 'loadQueries');
-  });
+    sandbox.stub(queryLoader, 'loadQueries')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.handler', () => {
     beforeEach(async () => {
-      chargingDataJob.handler();
-    });
+      chargingDataJob.handler()
+    })
 
     test('runs the correct queries', async () => {
       expect(queryLoader.loadQueries.calledWith(
@@ -36,7 +36,7 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
           returnVersionQueries.importReturnRequirements,
           returnVersionQueries.importReturnRequirementPurposes
         ]
-      )).to.be.true();
-    });
-  });
-});
+      )).to.be.true()
+    })
+  })
+})

--- a/test/modules/charging-import/lib/query-loader.js
+++ b/test/modules/charging-import/lib/query-loader.js
@@ -1,100 +1,100 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader');
-const { logger } = require('../../../../src/logger');
-const slack = require('../../../../src/lib/slack');
-const { pool } = require('../../../../src/lib/connectors/db');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const queryLoader = require('../../../../src/modules/charging-import/lib/query-loader')
+const { logger } = require('../../../../src/logger')
+const slack = require('../../../../src/lib/slack')
+const { pool } = require('../../../../src/lib/connectors/db')
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
 experiment('modules/charging-import/lib/query-loader', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(slack, 'post');
-    sandbox.stub(pool, 'query');
-  });
+    sandbox.stub(logger, 'info')
+    sandbox.stub(slack, 'post')
+    sandbox.stub(pool, 'query')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createQueryLoader', () => {
-    const name = 'Test job';
+    const name = 'Test job'
     const queries = [
       'select * from test_1',
       'select * from test_2'
-    ];
+    ]
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        await queryLoader.loadQueries(name, queries);
-      });
+        await queryLoader.loadQueries(name, queries)
+      })
 
       test('logs a start message', async () => {
-        expect(logger.info.firstCall.args[0]).to.equal(`Starting ${name}`);
-      });
+        expect(logger.info.firstCall.args[0]).to.equal(`Starting ${name}`)
+      })
 
       test('slacks a start message', async () => {
-        expect(slack.post.firstCall.args[0]).to.equal(`Starting ${name}`);
-      });
+        expect(slack.post.firstCall.args[0]).to.equal(`Starting ${name}`)
+      })
 
       test('runs queries in order', async () => {
-        expect(pool.query.firstCall.args[0]).to.equal(queries[0]);
-        expect(pool.query.secondCall.args[0]).to.equal(queries[1]);
-      });
+        expect(pool.query.firstCall.args[0]).to.equal(queries[0])
+        expect(pool.query.secondCall.args[0]).to.equal(queries[1])
+      })
 
       test('logs a finished message', async () => {
-        expect(logger.info.lastCall.args[0]).to.equal(`Finished ${name}`);
-      });
+        expect(logger.info.lastCall.args[0]).to.equal(`Finished ${name}`)
+      })
 
       test('slacks a finished message', async () => {
-        expect(slack.post.lastCall.args[0]).to.equal(`Finished ${name}`);
-      });
-    });
+        expect(slack.post.lastCall.args[0]).to.equal(`Finished ${name}`)
+      })
+    })
 
     experiment('when there is an errors', () => {
-      const err = new Error('oops!');
-      let result;
+      const err = new Error('oops!')
+      let result
 
       beforeEach(async () => {
-        pool.query.rejects(err);
-        const func = () => queryLoader.loadQueries(name, queries);
-        result = await expect(func()).to.reject();
-      });
+        pool.query.rejects(err)
+        const func = () => queryLoader.loadQueries(name, queries)
+        result = await expect(func()).to.reject()
+      })
 
       test('logs a start message', async () => {
-        expect(logger.info.firstCall.args[0]).to.equal(`Starting ${name}`);
-      });
+        expect(logger.info.firstCall.args[0]).to.equal(`Starting ${name}`)
+      })
 
       test('slacks a start message', async () => {
-        expect(slack.post.firstCall.args[0]).to.equal(`Starting ${name}`);
-      });
+        expect(slack.post.firstCall.args[0]).to.equal(`Starting ${name}`)
+      })
 
       test('runs the first query order', async () => {
-        expect(pool.query.firstCall.args[0]).to.equal(queries[0]);
-      });
+        expect(pool.query.firstCall.args[0]).to.equal(queries[0])
+      })
 
       test('errors before the second query', async () => {
-        expect(pool.query.calledWith(queries[1])).to.be.false();
-      });
+        expect(pool.query.calledWith(queries[1])).to.be.false()
+      })
 
       test('rejects with the thrown error', async () => {
-        expect(result).to.equal(err);
-      });
+        expect(result).to.equal(err)
+      })
 
       test('does not log a finished message', async () => {
         expect(logger.info.calledWith(
           `Finished ${name}`
-        )).to.be.false();
-      });
+        )).to.be.false()
+      })
 
       test('does not slack a finished message', async () => {
         expect(slack.post.calledWith(
           `Finished ${name}`
-        )).to.be.false();
-      });
-    });
-  });
-});
+        )).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/charging-import/plugin.js
+++ b/test/modules/charging-import/plugin.js
@@ -1,17 +1,17 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sandbox = require('sinon').createSandbox();
-const cron = require('node-cron');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sandbox = require('sinon').createSandbox()
+const cron = require('node-cron')
 
-const { plugin } = require('../../../src/modules/charging-import/plugin');
+const { plugin } = require('../../../src/modules/charging-import/plugin')
 
-const chargingDataJob = require('../../../src/modules/charging-import/jobs/charging-data');
+const chargingDataJob = require('../../../src/modules/charging-import/jobs/charging-data')
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
 experiment('modules/charging-import/plugin.js', () => {
-  let server;
+  let server
 
   beforeEach(async () => {
     server = {
@@ -20,65 +20,65 @@ experiment('modules/charging-import/plugin.js', () => {
         publish: sandbox.stub().resolves(),
         onComplete: sandbox.stub().resolves()
       }
-    };
-    sandbox.stub(cron, 'schedule');
-  });
+    }
+    sandbox.stub(cron, 'schedule')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   test('has a plugin name', async () => {
-    expect(plugin.name).to.equal('importChargingData');
-  });
+    expect(plugin.name).to.equal('importChargingData')
+  })
 
   test('requires pgBoss plugin', async () => {
-    expect(plugin.dependencies).to.equal(['pgBoss']);
-  });
+    expect(plugin.dependencies).to.equal(['pgBoss'])
+  })
 
   experiment('register', () => {
     experiment('on target environments', () => {
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'test'
-        });
-        await plugin.register(server);
-      });
+        })
+        await plugin.register(server)
+      })
 
       test('adds subscriber for import charging data job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           chargingDataJob.jobName, chargingDataJob.handler
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('adds subscriber for import charge versions job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           chargingDataJob.jobName, chargingDataJob.handler
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('schedules a cron job at 2pm on weekdays on non-prod environments to run the charging import', async () => {
-        const [schedule, func] = cron.schedule.firstCall.args;
-        expect(schedule).to.equal('0 14 * * 1,2,3,4,5');
-        func();
-        const [{ name }] = server.messageQueue.publish.lastCall.args;
-        expect(name).to.equal('import.charging-data');
-      });
-    });
+        const [schedule, func] = cron.schedule.firstCall.args
+        expect(schedule).to.equal('0 14 * * 1,2,3,4,5')
+        func()
+        const [{ name }] = server.messageQueue.publish.lastCall.args
+        expect(name).to.equal('import.charging-data')
+      })
+    })
 
     experiment('on production', () => {
       beforeEach(async () => {
-        sandbox.stub(process.env, 'NODE_ENV').value('production');
-        await plugin.register(server);
-      });
+        sandbox.stub(process.env, 'NODE_ENV').value('production')
+        await plugin.register(server)
+      })
 
       test('2 subscribers are bound', async () => {
-        expect(server.messageQueue.subscribe.callCount).to.equal(2);
-      });
+        expect(server.messageQueue.subscribe.callCount).to.equal(2)
+      })
 
       test('1 cron job is scheduled', async () => {
-        expect(cron.schedule.callCount).to.equal(1);
-      });
-    });
-  });
-});
+        expect(cron.schedule.callCount).to.equal(1)
+      })
+    })
+  })
+})

--- a/test/modules/core/controller.js
+++ b/test/modules/core/controller.js
@@ -1,12 +1,12 @@
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const controller = require('../../../src/modules/core/controller');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const controller = require('../../../src/modules/core/controller')
 
 experiment('modules/core/controller', () => {
   experiment('getStatus', () => {
     test('returns an object with the application version', () => {
-      const response = controller.getStatus();
-      expect(response.version).to.match(/^\d*\.\d*\.\d*$/);
-    });
-  });
-});
+      const response = controller.getStatus()
+      expect(response.version).to.match(/^\d*\.\d*\.\d*$/)
+    })
+  })
+})

--- a/test/modules/core/jobs/import-tracker.js
+++ b/test/modules/core/jobs/import-tracker.js
@@ -1,77 +1,77 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const jobsConnector = require('../../../../src/lib/connectors/water-import/jobs');
-const notifyService = require('../../../../src/lib/services/notify');
-const importTrackerJob = require('../../../../src/modules/core/jobs/import-tracker');
-const slack = require('../../../../src/lib/slack');
+const { logger } = require('../../../../src/logger')
+const jobsConnector = require('../../../../src/lib/connectors/water-import/jobs')
+const notifyService = require('../../../../src/lib/services/notify')
+const importTrackerJob = require('../../../../src/modules/core/jobs/import-tracker')
+const slack = require('../../../../src/lib/slack')
 
 experiment('modules/core/jobs/import-tracker', () => {
-  const jobName = 'import.tracker';
+  const jobName = 'import.tracker'
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
-    sandbox.stub(slack, 'post');
-    sandbox.stub(jobsConnector, 'getFailedJobs');
-    sandbox.stub(notifyService, 'sendEmail');
-  });
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
+    sandbox.stub(slack, 'post')
+    sandbox.stub(jobsConnector, 'getFailedJobs')
+    sandbox.stub(notifyService, 'sendEmail')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const job = importTrackerJob.createMessage();
+      const job = importTrackerJob.createMessage()
       expect(job).to.equal({
         name: jobName,
         options: {
           singletonKey: jobName
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.handler', () => {
     const job = {
       name: jobName
-    };
+    }
 
     experiment('when there are jobs that have failed', () => {
       experiment('on the production environment', () => {
-        let testMessage = 'There is 1 failed import job in the production environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n';
+        let testMessage = 'There is 1 failed import job in the production environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n'
         beforeEach(async () => {
           sandbox.stub(process, 'env').value({
             NODE_ENV: 'production',
             WATER_SERVICE_MAILBOX: 'test-mailbox@test.com'
-          });
+          })
           jobsConnector.getFailedJobs.resolves([{
             jobName: 'Test.Job.Name',
             total: 100,
             dateCreated: '2001-01-01',
             dateCompleted: '2001-01-01'
-          }]);
-          await importTrackerJob.handler(job);
-        });
+          }])
+          await importTrackerJob.handler(job)
+        })
 
         test('the handler post the correct message to slack', async () => {
-          const result = slack.post.lastCall.args[0];
-          expect(result).to.equal(testMessage);
-        });
+          const result = slack.post.lastCall.args[0]
+          expect(result).to.equal(testMessage)
+        })
         test('the handler post the correct message to notify', async () => {
-          const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args;
-          expect(recipient).to.equal('test-mailbox@test.com');
-          expect(templateRef).to.equal('service_status_alert');
-          expect(data).to.equal({ content: testMessage });
-        });
+          const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args
+          expect(recipient).to.equal('test-mailbox@test.com')
+          expect(templateRef).to.equal('service_status_alert')
+          expect(data).to.equal({ content: testMessage })
+        })
         test('when there are 2 failed job the sub title is pluralised', async () => {
           testMessage = 'There are 2 failed import jobs in the production environment.' +
             '\n\nJob Name: Test.Job.Name 1 \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n' +
-            'Job Name: Test.Job.Name 2 \nTotal Errors: 100 \nDate created: 2010-01-01 \nDate completed: 2010-01-01\n\n';
+            'Job Name: Test.Job.Name 2 \nTotal Errors: 100 \nDate created: 2010-01-01 \nDate completed: 2010-01-01\n\n'
           jobsConnector.getFailedJobs.resolves([{
             jobName: 'Test.Job.Name 1',
             total: 100,
@@ -83,80 +83,80 @@ experiment('modules/core/jobs/import-tracker', () => {
             total: 100,
             dateCreated: '2010-01-01',
             dateCompleted: '2010-01-01'
-          }]);
-          await importTrackerJob.handler(job);
-          const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args;
-          expect(recipient).to.equal('test-mailbox@test.com');
-          expect(templateRef).to.equal('service_status_alert');
-          expect(data).to.equal({ content: testMessage });
-        });
-      });
-    });
+          }])
+          await importTrackerJob.handler(job)
+          const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args
+          expect(recipient).to.equal('test-mailbox@test.com')
+          expect(templateRef).to.equal('service_status_alert')
+          expect(data).to.equal({ content: testMessage })
+        })
+      })
+    })
 
     experiment('on the preprod environment', () => {
-      const testMessage = 'There is 1 failed import job in the preprod environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n';
+      const testMessage = 'There is 1 failed import job in the preprod environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n'
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'preprod',
           WATER_SERVICE_MAILBOX: 'test-mailbox@test.com'
-        });
+        })
         jobsConnector.getFailedJobs.resolves([{
           jobName: 'Test.Job.Name',
           total: 100,
           dateCreated: '2001-01-01',
           dateCompleted: '2001-01-01'
-        }]);
-        await importTrackerJob.handler(job);
-      });
+        }])
+        await importTrackerJob.handler(job)
+      })
 
       test('the handler post the correct message to slack', async () => {
-        const result = slack.post.lastCall.args[0];
-        expect(result).to.equal(testMessage);
-      });
+        const result = slack.post.lastCall.args[0]
+        expect(result).to.equal(testMessage)
+      })
       test('the handler post the correct message to notify', async () => {
-        const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args;
-        expect(recipient).to.equal('test-mailbox@test.com');
-        expect(templateRef).to.equal('service_status_alert');
-        expect(data).to.equal({ content: testMessage });
-      });
-    });
+        const [recipient, templateRef, data] = notifyService.sendEmail.lastCall.args
+        expect(recipient).to.equal('test-mailbox@test.com')
+        expect(templateRef).to.equal('service_status_alert')
+        expect(data).to.equal({ content: testMessage })
+      })
+    })
 
     experiment('on the test environment', () => {
-      const testMessage = 'There is 1 failed import job in the test environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n';
+      const testMessage = 'There is 1 failed import job in the test environment.\n\nJob Name: Test.Job.Name \nTotal Errors: 100 \nDate created: 2001-01-01 \nDate completed: 2001-01-01\n\n'
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'test'
-        });
+        })
         jobsConnector.getFailedJobs.resolves([{
           jobName: 'Test.Job.Name',
           total: 100,
           dateCreated: '2001-01-01',
           dateCompleted: '2001-01-01'
-        }]);
-        await importTrackerJob.handler(job);
-      });
+        }])
+        await importTrackerJob.handler(job)
+      })
 
       test('the handler post the correct message to slack', async () => {
-        const result = slack.post.lastCall.args[0];
-        expect(result).to.equal(testMessage);
-      });
+        const result = slack.post.lastCall.args[0]
+        expect(result).to.equal(testMessage)
+      })
       test('the handler does not post a message to notify', async () => {
-        expect(notifyService.sendEmail.calledOnce).to.be.false();
-      });
-    });
+        expect(notifyService.sendEmail.calledOnce).to.be.false()
+      })
+    })
 
     experiment('when there are NO jobs that have failed', () => {
       beforeEach(async () => {
-        jobsConnector.getFailedJobs.resolves([]);
-        await importTrackerJob.handler(job);
-      });
+        jobsConnector.getFailedJobs.resolves([])
+        await importTrackerJob.handler(job)
+      })
 
       test('the handler post the correct message to slack', async () => {
-        expect(slack.post.calledOnce).to.be.false();
-      });
+        expect(slack.post.calledOnce).to.be.false()
+      })
       test('the handler post the correct message to notify', async () => {
-        expect(notifyService.sendEmail.calledOnce).to.be.false();
-      });
-    });
-  });
-});
+        expect(notifyService.sendEmail.calledOnce).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/core/plugin.js
+++ b/test/modules/core/plugin.js
@@ -3,18 +3,18 @@ const {
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const cron = require('node-cron');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const cron = require('node-cron')
 
-const config = require('../../../config');
-const { plugin } = require('../../../src/modules/core/plugin');
-const job = require('../../../src/modules/core/jobs/import-tracker');
+const config = require('../../../config')
+const { plugin } = require('../../../src/modules/core/plugin')
+const job = require('../../../src/modules/core/jobs/import-tracker')
 
 experiment('modules/core/plugin', () => {
-  let server;
+  let server
 
   beforeEach(async () => {
     server = {
@@ -23,60 +23,60 @@ experiment('modules/core/plugin', () => {
         subscribe: sandbox.stub(),
         onComplete: sandbox.stub()
       }
-    };
-    sandbox.stub(cron, 'schedule');
-  });
+    }
+    sandbox.stub(cron, 'schedule')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   test('plugin has a name', async () => {
-    expect(plugin.name).to.equal('importTracker');
-  });
+    expect(plugin.name).to.equal('importTracker')
+  })
 
   experiment('when the plugin is registered', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(false);
-      await plugin.register(server);
-    });
+      sandbox.stub(config, 'isProduction').value(false)
+      await plugin.register(server)
+    })
 
     test('registers the job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(0).args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(0).args
 
-      expect(jobName).to.equal(job.jobName);
-      expect(options).to.equal({});
-      expect(handler).to.equal(job.handler);
-    });
-  });
+      expect(jobName).to.equal(job.jobName)
+      expect(options).to.equal({})
+      expect(handler).to.equal(job.handler)
+    })
+  })
 
   experiment('in production', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(true);
+      sandbox.stub(config, 'isProduction').value(true)
       sandbox.stub(process, 'env').value({
         NODE_ENV: 'production'
-      });
-      await plugin.register(server);
-    });
+      })
+      await plugin.register(server)
+    })
 
     test('schedules cron job to run at 10am every week day', async () => {
-      const [schedule] = cron.schedule.firstCall.args;
-      expect(schedule).to.equal('0 10 * * 1,2,3,4,5');
-    });
-  });
+      const [schedule] = cron.schedule.firstCall.args
+      expect(schedule).to.equal('0 10 * * 1,2,3,4,5')
+    })
+  })
 
   experiment('in non-production', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(false);
+      sandbox.stub(config, 'isProduction').value(false)
       sandbox.stub(process, 'env').value({
         NODE_ENV: 'qa'
-      });
-      await plugin.register(server);
-    });
+      })
+      await plugin.register(server)
+    })
 
     test('schedules cron job to run 3pm every week day', async () => {
-      const [schedule] = cron.schedule.firstCall.args;
-      expect(schedule).to.equal('0 15 * * 1,2,3,4,5');
-    });
-  });
-});
+      const [schedule] = cron.schedule.firstCall.args
+      expect(schedule).to.equal('0 15 * * 1,2,3,4,5')
+    })
+  })
+})

--- a/test/modules/core/routes.js
+++ b/test/modules/core/routes.js
@@ -1,29 +1,29 @@
-'use strict';
+'use strict'
 
-const { experiment, it } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, it } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const { createServerForRoute } = require('../../test-helpers');
-const routes = require('../../../src/modules/core/routes');
+const { createServerForRoute } = require('../../test-helpers')
+const routes = require('../../../src/modules/core/routes')
 
 experiment('modules/core/routes', () => {
   experiment('/status', () => {
     it('exists', async () => {
-      const request = { method: 'GET', url: '/status' };
-      const server = createServerForRoute(routes[0]);
+      const request = { method: 'GET', url: '/status' }
+      const server = createServerForRoute(routes[0])
 
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(200);
-    });
-  });
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(200)
+    })
+  })
 
   experiment('/etl/testing', () => {
     it('exists', async () => {
-      const request = { method: 'GET', url: '/etl/testing' };
-      const server = createServerForRoute(routes[1]);
+      const request = { method: 'GET', url: '/etl/testing' }
+      const server = createServerForRoute(routes[1])
 
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(200);
-    });
-  });
-});
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(200)
+    })
+  })
+})

--- a/test/modules/licence-import/connectors/documents.js
+++ b/test/modules/licence-import/connectors/documents.js
@@ -1,36 +1,36 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { pool } = require('../../../../src/lib/connectors/db');
-const queries = require('../../../../src/modules/licence-import/connectors/queries/documents');
-const connector = require('../../../../src/modules/licence-import/connectors/documents');
+const { pool } = require('../../../../src/lib/connectors/db')
+const queries = require('../../../../src/modules/licence-import/connectors/queries/documents')
+const connector = require('../../../../src/modules/licence-import/connectors/documents')
 
 experiment('modules/licence-import/connectors/documents', () => {
   beforeEach(async () => {
-    sandbox.stub(pool, 'query');
-  });
+    sandbox.stub(pool, 'query')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('deleteRemovedDocuments', () => {
     beforeEach(async () => {
-      await connector.deleteRemovedDocuments();
-    });
+      await connector.deleteRemovedDocuments()
+    })
 
     test('passes the expected query to the pool', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.deleteCrmV2Documents);
-    });
-  });
-});
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.deleteCrmV2Documents)
+    })
+  })
+})

--- a/test/modules/licence-import/connectors/import-companies.js
+++ b/test/modules/licence-import/connectors/import-companies.js
@@ -1,31 +1,31 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const importConnector = require('../../../../src/modules/licence-import/connectors/import-companies');
-const queries = require('../../../../src/modules/licence-import/connectors/queries/import-companies');
-const { pool } = require('../../../../src/lib/connectors/db');
+const importConnector = require('../../../../src/modules/licence-import/connectors/import-companies')
+const queries = require('../../../../src/modules/licence-import/connectors/queries/import-companies')
+const { pool } = require('../../../../src/lib/connectors/db')
 
 experiment('modules/licence-import/connectors/import-companies', () => {
-  let result;
+  let result
 
   beforeEach(async () => {
-    sandbox.stub(pool, 'query');
-  });
+    sandbox.stub(pool, 'query')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.clear', () => {
     beforeEach(async () => {
-      await importConnector.clear();
-    });
+      await importConnector.clear()
+    })
 
     test('the correct query is called', async () => {
-      expect(pool.query.calledWith(queries.clear));
-    });
-  });
+      expect(pool.query.calledWith(queries.clear))
+    })
+  })
 
   experiment('.initialise', () => {
     const data = {
@@ -33,53 +33,53 @@ experiment('modules/licence-import/connectors/import-companies', () => {
         { region_code: 3, party_id: 124 },
         { region_code: 5, party_id: 789 }
       ]
-    };
+    }
 
     beforeEach(async () => {
-      pool.query.resolves(data);
-      result = await importConnector.initialise();
-    });
+      pool.query.resolves(data)
+      result = await importConnector.initialise()
+    })
 
     test('the correct query is called', async () => {
-      expect(pool.query.calledWith(queries.initialise));
-    });
+      expect(pool.query.calledWith(queries.initialise))
+    })
 
     test('the function resolves with the correct data', async () => {
-      expect(result).to.equal(data.rows);
-    });
-  });
+      expect(result).to.equal(data.rows)
+    })
+  })
 
   experiment('.setImportedStatus', () => {
-    const regionCode = 3;
-    const partyId = 123;
+    const regionCode = 3
+    const partyId = 123
 
     beforeEach(async () => {
-      result = await importConnector.setImportedStatus(regionCode, partyId);
-    });
+      result = await importConnector.setImportedStatus(regionCode, partyId)
+    })
 
     test('the correct query is called with the region code and party ID params', async () => {
-      expect(pool.query.calledWith(queries.setImportedStatus, [regionCode, partyId]));
-    });
-  });
+      expect(pool.query.calledWith(queries.setImportedStatus, [regionCode, partyId]))
+    })
+  })
 
   experiment('.getPendingCount', () => {
     const data = {
       rows: [
         { count: '3' }
       ]
-    };
+    }
 
     beforeEach(async () => {
-      pool.query.resolves(data);
-      result = await importConnector.getPendingCount();
-    });
+      pool.query.resolves(data)
+      result = await importConnector.getPendingCount()
+    })
 
     test('the correct query is called', async () => {
-      expect(pool.query.calledWith(queries.getPendingCount));
-    });
+      expect(pool.query.calledWith(queries.getPendingCount))
+    })
 
     test('the function resolves with the count converted to an integer', async () => {
-      expect(result).to.equal(3);
-    });
-  });
-});
+      expect(result).to.equal(3)
+    })
+  })
+})

--- a/test/modules/licence-import/controller.js
+++ b/test/modules/licence-import/controller.js
@@ -1,135 +1,135 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sandbox = require('sinon').createSandbox();
-const jobs = require('../../../src/modules/licence-import/jobs');
-const controller = require('../../../src/modules/licence-import/controller');
-const { logger } = require('../../../src/logger.js');
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sandbox = require('sinon').createSandbox()
+const jobs = require('../../../src/modules/licence-import/jobs')
+const controller = require('../../../src/modules/licence-import/controller')
+const { logger } = require('../../../src/logger.js')
+const { expect } = require('@hapi/code')
 
 const createRequest = () => ({
   query: {},
   messageQueue: {
     publish: sandbox.stub().resolves()
   }
-});
+})
 
 experiment('modules/licence-import/controller.js', () => {
-  let h;
+  let h
 
   experiment('.postImport', () => {
-    let request, response;
+    let request, response
 
     beforeEach(async () => {
-      sandbox.stub(logger, 'error');
+      sandbox.stub(logger, 'error')
       h = {
         response: sandbox.stub().returnsThis(),
         code: sandbox.stub()
-      };
-    });
+      }
+    })
 
     afterEach(async () => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        request = createRequest();
-        response = await controller.postImport(request, h);
-      });
+        request = createRequest()
+        response = await controller.postImport(request, h)
+      })
 
       test('an "import delete documents" job is published', async () => {
-        expect(request.messageQueue.publish.callCount).to.equal(1);
-        const [job] = request.messageQueue.publish.lastCall.args;
-        expect(job.name).to.equal(jobs.DELETE_DOCUMENTS_JOB);
-      });
+        expect(request.messageQueue.publish.callCount).to.equal(1)
+        const [job] = request.messageQueue.publish.lastCall.args
+        expect(job.name).to.equal(jobs.DELETE_DOCUMENTS_JOB)
+      })
 
       test('a success response is returned', async () => {
-        expect(h.response.calledWith({ error: null })).to.be.true();
-      });
+        expect(h.response.calledWith({ error: null })).to.be.true()
+      })
 
       test('a 202 http status code is returned', async () => {
-        expect(h.code.calledWith(202)).to.be.true();
-      });
-    });
+        expect(h.code.calledWith(202)).to.be.true()
+      })
+    })
 
     experiment('when there is an error', () => {
       beforeEach(async () => {
-        request = createRequest();
-        request.messageQueue.publish.rejects();
-        response = await controller.postImport(request, h);
-      });
+        request = createRequest()
+        request.messageQueue.publish.rejects()
+        response = await controller.postImport(request, h)
+      })
 
       test('an error is logged', async () => {
-        expect(logger.error.callCount).to.equal(1);
-        const [message] = logger.error.lastCall.args;
-        expect(message).to.equal('Error importing companies');
-      });
+        expect(logger.error.callCount).to.equal(1)
+        const [message] = logger.error.lastCall.args
+        expect(message).to.equal('Error importing companies')
+      })
 
       test('a Boom 500 error is returned', async () => {
-        expect(response.isBoom).to.equal(true);
-        expect(response.output.statusCode).to.equal(500);
-      });
-    });
-  });
+        expect(response.isBoom).to.equal(true)
+        expect(response.output.statusCode).to.equal(500)
+      })
+    })
+  })
 
   experiment('.postImportLicence', () => {
-    let request;
-    let h;
-    let response;
-    let code;
+    let request
+    let h
+    let response
+    let code
 
     beforeEach(async () => {
-      sandbox.stub(logger, 'error');
-      code = sandbox.spy();
+      sandbox.stub(logger, 'error')
+      code = sandbox.spy()
 
       h = {
         response: sandbox.stub().returns({ code })
-      };
-    });
+      }
+    })
 
     afterEach(async () => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        request = createRequest();
-        request.query.licenceNumber = 'test-lic';
-        await controller.postImportLicence(request, h);
-      });
+        request = createRequest()
+        request.query.licenceNumber = 'test-lic'
+        await controller.postImportLicence(request, h)
+      })
 
       test('an "import licence" job is published', async () => {
-        expect(request.messageQueue.publish.callCount).to.equal(1);
-        const [job] = request.messageQueue.publish.lastCall.args;
-        expect(job.name).to.equal(jobs.IMPORT_LICENCE_JOB);
-      });
+        expect(request.messageQueue.publish.callCount).to.equal(1)
+        const [job] = request.messageQueue.publish.lastCall.args
+        expect(job.name).to.equal(jobs.IMPORT_LICENCE_JOB)
+      })
 
       test('a success response is returned', async () => {
-        const [data] = h.response.lastCall.args;
-        const [statusCode] = code.lastCall.args;
+        const [data] = h.response.lastCall.args
+        const [statusCode] = code.lastCall.args
 
-        expect(data).to.equal({ error: null });
-        expect(statusCode).to.equal(202);
-      });
-    });
+        expect(data).to.equal({ error: null })
+        expect(statusCode).to.equal(202)
+      })
+    })
 
     experiment('when there is an error', () => {
       beforeEach(async () => {
-        request = createRequest();
-        request.query.licenceNumber = 'test-lic';
-        request.messageQueue.publish.rejects();
-        response = await controller.postImportLicence(request, h);
-      });
+        request = createRequest()
+        request.query.licenceNumber = 'test-lic'
+        request.messageQueue.publish.rejects()
+        response = await controller.postImportLicence(request, h)
+      })
 
       test('an error is logged', async () => {
-        expect(logger.error.callCount).to.equal(1);
-        const [message] = logger.error.lastCall.args;
-        expect(message).to.equal('Error importing licence');
-      });
+        expect(logger.error.callCount).to.equal(1)
+        const [message] = logger.error.lastCall.args
+        expect(message).to.equal('Error importing licence')
+      })
 
       test('a Boom 500 error is returned', async () => {
-        expect(response.isBoom).to.equal(true);
-        expect(response.output.statusCode).to.equal(500);
-      });
-    });
-  });
-});
+        expect(response.isBoom).to.equal(true)
+        expect(response.output.statusCode).to.equal(500)
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/extract/connectors/index.js
+++ b/test/modules/licence-import/extract/connectors/index.js
@@ -1,231 +1,231 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const queries = require('../../../../../src/modules/licence-import/extract/connectors/queries');
-const sandbox = require('sinon').createSandbox();
-const { pool } = require('../../../../../src/lib/connectors/db');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const queries = require('../../../../../src/modules/licence-import/extract/connectors/queries')
+const sandbox = require('sinon').createSandbox()
+const { pool } = require('../../../../../src/lib/connectors/db')
 
-const importConnector = require('../../../../../src/modules/licence-import/extract/connectors/index');
+const importConnector = require('../../../../../src/modules/licence-import/extract/connectors/index')
 
-const licenceNumber = 'licence_1';
-const licenceId = 123;
-const regionCode = 2;
-const partyId = 15;
-const partyIds = [19, 265];
-const addressIds = [124, 92];
+const licenceNumber = 'licence_1'
+const licenceId = 123
+const regionCode = 2
+const partyId = 15
+const partyIds = [19, 265]
+const addressIds = [124, 92]
 
 experiment('modules/licence-import/connectors/import', () => {
   const data = [{
     foo: 'bar'
   }, {
     bar: 'baz'
-  }];
+  }]
 
   beforeEach(async () => {
-    sandbox.stub(pool, 'query').resolves({ rows: data });
-  });
+    sandbox.stub(pool, 'query').resolves({ rows: data })
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('getLicence', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getLicence(licenceNumber);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getLicence);
-      expect(params).to.equal([licenceNumber]);
-    });
+      await importConnector.getLicence(licenceNumber)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getLicence)
+      expect(params).to.equal([licenceNumber])
+    })
 
     test('resolves with the first row found', async () => {
-      const result = await importConnector.getLicence(licenceNumber);
-      expect(result).to.equal(data[0]);
-    });
-  });
+      const result = await importConnector.getLicence(licenceNumber)
+      expect(result).to.equal(data[0])
+    })
+  })
 
   experiment('getLicenceVersions', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getLicenceVersions(regionCode, licenceId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getLicenceVersions);
-      expect(params).to.equal([regionCode, licenceId]);
-    });
+      await importConnector.getLicenceVersions(regionCode, licenceId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getLicenceVersions)
+      expect(params).to.equal([regionCode, licenceId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getLicenceVersions(licenceNumber);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getLicenceVersions(licenceNumber)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getAllParties', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getAllParties();
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getAllParties);
-    });
+      await importConnector.getAllParties()
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getAllParties)
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getAllParties();
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getAllParties()
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getAllAddresses', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getAllAddresses();
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getAllAddresses);
-    });
+      await importConnector.getAllAddresses()
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getAllAddresses)
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getAllAddresses();
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getAllAddresses()
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getChargeVersions', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getChargeVersions(regionCode, licenceId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getChargeVersions);
-      expect(params).to.equal([regionCode, licenceId]);
-    });
+      await importConnector.getChargeVersions(regionCode, licenceId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getChargeVersions)
+      expect(params).to.equal([regionCode, licenceId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getChargeVersions(regionCode, licenceId);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getChargeVersions(regionCode, licenceId)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getTwoPartTariffAgreements', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getTwoPartTariffAgreements(regionCode, licenceId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getTwoPartTariffAgreements);
-      expect(params).to.equal([regionCode, licenceId]);
-    });
+      await importConnector.getTwoPartTariffAgreements(regionCode, licenceId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getTwoPartTariffAgreements)
+      expect(params).to.equal([regionCode, licenceId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getTwoPartTariffAgreements(regionCode, licenceId);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getTwoPartTariffAgreements(regionCode, licenceId)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getSection130Agreements', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getSection130Agreements(regionCode, licenceId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getSection130Agreements);
-      expect(params).to.equal([regionCode, licenceId]);
-    });
+      await importConnector.getSection130Agreements(regionCode, licenceId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getSection130Agreements)
+      expect(params).to.equal([regionCode, licenceId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getSection130Agreements(regionCode, licenceId);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getSection130Agreements(regionCode, licenceId)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getInvoiceAccounts', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getInvoiceAccounts(regionCode, partyId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getInvoiceAccounts);
-      expect(params).to.equal([regionCode, partyId]);
-    });
+      await importConnector.getInvoiceAccounts(regionCode, partyId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getInvoiceAccounts)
+      expect(params).to.equal([regionCode, partyId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getInvoiceAccounts(regionCode, partyId);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getInvoiceAccounts(regionCode, partyId)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getPartyLicenceVersions', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getPartyLicenceVersions(regionCode, partyId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getPartyLicenceVersions);
-      expect(params).to.equal([regionCode, partyId]);
-    });
+      await importConnector.getPartyLicenceVersions(regionCode, partyId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getPartyLicenceVersions)
+      expect(params).to.equal([regionCode, partyId])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getPartyLicenceVersions(regionCode, partyId);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getPartyLicenceVersions(regionCode, partyId)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getParties', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getParties(regionCode, partyIds);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getParties);
-      expect(params).to.equal([regionCode, '19,265']);
-    });
+      await importConnector.getParties(regionCode, partyIds)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getParties)
+      expect(params).to.equal([regionCode, '19,265'])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getParties(regionCode, partyIds);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getParties(regionCode, partyIds)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getAddresses', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getAddresses(regionCode, addressIds);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getAddresses);
-      expect(params).to.equal([regionCode, '124,92']);
-    });
+      await importConnector.getAddresses(regionCode, addressIds)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getAddresses)
+      expect(params).to.equal([regionCode, '124,92'])
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getAddresses(regionCode, addressIds);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getAddresses(regionCode, addressIds)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getAllLicenceNumbers', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getAllLicenceNumbers();
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getAllLicenceNumbers);
-    });
+      await importConnector.getAllLicenceNumbers()
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getAllLicenceNumbers)
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getAllLicenceNumbers(regionCode);
-      expect(result).to.equal(data);
-    });
-  });
+      const result = await importConnector.getAllLicenceNumbers(regionCode)
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('getParty', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getParty(regionCode, partyId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getParty);
-      expect(params).to.equal([regionCode, partyId]);
-    });
+      await importConnector.getParty(regionCode, partyId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getParty)
+      expect(params).to.equal([regionCode, partyId])
+    })
 
     test('resolves with the first row found', async () => {
-      const result = await importConnector.getParty(regionCode, partyId);
-      expect(result).to.equal(data[0]);
-    });
-  });
+      const result = await importConnector.getParty(regionCode, partyId)
+      expect(result).to.equal(data[0])
+    })
+  })
 
   experiment('getLicenceRoles', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getLicenceRoles(regionCode, licenceId);
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getLicenceRoles);
-      expect(params).to.equal([regionCode, licenceId]);
-    });
-  });
+      await importConnector.getLicenceRoles(regionCode, licenceId)
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getLicenceRoles)
+      expect(params).to.equal([regionCode, licenceId])
+    })
+  })
 
   experiment('getPurposeConditions', () => {
     test('calls pool.query with the correct arguments', async () => {
-      await importConnector.getPurposeConditions();
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getPurposeConditions);
-    });
+      await importConnector.getPurposeConditions()
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getPurposeConditions)
+    })
 
     test('resolves with all rows found', async () => {
-      const result = await importConnector.getPurposeConditions();
-      expect(result).to.equal(data);
-    });
-  });
-});
+      const result = await importConnector.getPurposeConditions()
+      expect(result).to.equal(data)
+    })
+  })
+})

--- a/test/modules/licence-import/extract/index.js
+++ b/test/modules/licence-import/extract/index.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const extract = require('../../../../src/modules/licence-import/extract/');
-const importConnector = require('../../../../src/modules/licence-import/extract/connectors');
+const extract = require('../../../../src/modules/licence-import/extract/')
+const importConnector = require('../../../../src/modules/licence-import/extract/connectors')
 
 const data = {
   licence: { ID: '7', FGAC_REGION_CODE: '4' },
@@ -34,136 +34,136 @@ const data = {
   roles: [
     { ALRT_CODE: 'RT', EFF_ST_DATE: '09/04/2015', EFF_END_DATE: '12/08/2015', ACON_APAR_ID: 'party_4', ACON_AADD_ID: 'address_4', FGAC_REGION_CODE: '1' }
   ]
-};
+}
 
 experiment('modules/licence-import/extract/index.js', () => {
-  let result;
+  let result
 
   beforeEach(async () => {
-    sandbox.stub(importConnector, 'getParties').resolves(data.parties);
-    sandbox.stub(importConnector, 'getParty').resolves(data.party);
-    sandbox.stub(importConnector, 'getAddresses').resolves(data.addresses);
-    sandbox.stub(importConnector, 'getLicence').resolves(data.licence);
-    sandbox.stub(importConnector, 'getLicenceVersions').resolves(data.licenceVersions);
-    sandbox.stub(importConnector, 'getChargeVersions').resolves(data.chargeVersions);
-    sandbox.stub(importConnector, 'getTwoPartTariffAgreements').resolves(data.twoPartTariffAgreements);
-    sandbox.stub(importConnector, 'getSection130Agreements').resolves(data.section130Agreements);
-    sandbox.stub(importConnector, 'getInvoiceAccounts').resolves(data.invoiceAccounts);
-    sandbox.stub(importConnector, 'getPartyLicenceVersions').resolves(data.licenceVersions);
-    sandbox.stub(importConnector, 'getLicencePurposes').resolves(data.purposes);
-    sandbox.stub(importConnector, 'getPurposeConditions').resolves(data.conditions);
-    sandbox.stub(importConnector, 'getLicenceRoles').resolves(data.roles);
-    sandbox.stub(importConnector, 'getPartyLicenceRoles').resolves(data.roles);
-  });
+    sandbox.stub(importConnector, 'getParties').resolves(data.parties)
+    sandbox.stub(importConnector, 'getParty').resolves(data.party)
+    sandbox.stub(importConnector, 'getAddresses').resolves(data.addresses)
+    sandbox.stub(importConnector, 'getLicence').resolves(data.licence)
+    sandbox.stub(importConnector, 'getLicenceVersions').resolves(data.licenceVersions)
+    sandbox.stub(importConnector, 'getChargeVersions').resolves(data.chargeVersions)
+    sandbox.stub(importConnector, 'getTwoPartTariffAgreements').resolves(data.twoPartTariffAgreements)
+    sandbox.stub(importConnector, 'getSection130Agreements').resolves(data.section130Agreements)
+    sandbox.stub(importConnector, 'getInvoiceAccounts').resolves(data.invoiceAccounts)
+    sandbox.stub(importConnector, 'getPartyLicenceVersions').resolves(data.licenceVersions)
+    sandbox.stub(importConnector, 'getLicencePurposes').resolves(data.purposes)
+    sandbox.stub(importConnector, 'getPurposeConditions').resolves(data.conditions)
+    sandbox.stub(importConnector, 'getLicenceRoles').resolves(data.roles)
+    sandbox.stub(importConnector, 'getPartyLicenceRoles').resolves(data.roles)
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('getLicenceData', () => {
     beforeEach(async () => {
-      result = await extract.getLicenceData('01/123');
-    });
+      result = await extract.getLicenceData('01/123')
+    })
 
     test('importConnector.getLicence is called with the licence number', async () => {
       expect(
         importConnector.getLicence.calledWith('01/123')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getLicenceVersions is called with the region code / licence ID', async () => {
       expect(
         importConnector.getLicenceVersions.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getChargeVersions is called with the region code / licence ID', async () => {
       expect(
         importConnector.getChargeVersions.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getTwoPartTariffAgreements is called with the region code / licence ID', async () => {
       expect(
         importConnector.getTwoPartTariffAgreements.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getSection130Agreements is called with the region code / licence ID', async () => {
       expect(
         importConnector.getSection130Agreements.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getLicencePurposes is called with the region code / licence ID', async () => {
-      const [regionId, licenceId] = importConnector.getLicencePurposes.lastCall.args;
-      expect(regionId).to.equal('4');
-      expect(licenceId).to.equal('7');
-    });
+      const [regionId, licenceId] = importConnector.getLicencePurposes.lastCall.args
+      expect(regionId).to.equal('4')
+      expect(licenceId).to.equal('7')
+    })
 
     test('importConnector.getParties called with region code and array of party IDs', async () => {
       expect(
         importConnector.getParties.calledWith('4', ['party_1', 'party_2', 'party_4'])
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getAddresses called with region code and array of address IDs', async () => {
       expect(
         importConnector.getAddresses.calledWith('4', ['address_1', 'address_2', 'address_4'])
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getLicenceRoles called with region code and licence ID', async () => {
       expect(
         importConnector.getLicenceRoles.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('importConnector.getPurposeConditions called with region code and licence ID', async () => {
       expect(
         importConnector.getPurposeConditions.calledWith('4', '7')
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('resolves with the retrieved data', async () => {
-      expect(result.licence).to.equal(data.licence);
-      expect(result.versions).to.equal(data.licenceVersions);
-      expect(result.chargeVersions).to.equal(data.chargeVersions);
-      expect(result.tptAgreements).to.equal(data.twoPartTariffAgreements);
-      expect(result.section130Agreements).to.equal(data.section130Agreements);
-      expect(result.parties).to.equal(data.parties);
-      expect(result.addresses).to.equal(data.addresses);
-      expect(result.purposes).to.equal(data.purposes);
-      expect(result.conditions).to.equal(data.conditions);
-    });
-  });
+      expect(result.licence).to.equal(data.licence)
+      expect(result.versions).to.equal(data.licenceVersions)
+      expect(result.chargeVersions).to.equal(data.chargeVersions)
+      expect(result.tptAgreements).to.equal(data.twoPartTariffAgreements)
+      expect(result.section130Agreements).to.equal(data.section130Agreements)
+      expect(result.parties).to.equal(data.parties)
+      expect(result.addresses).to.equal(data.addresses)
+      expect(result.purposes).to.equal(data.purposes)
+      expect(result.conditions).to.equal(data.conditions)
+    })
+  })
 
   experiment('getCompanyData', () => {
     beforeEach(async () => {
-      result = await extract.getCompanyData(5, 123);
-    });
+      result = await extract.getCompanyData(5, 123)
+    })
 
     test('importConnector.getParty is called with region code and party ID', async () => {
-      expect(importConnector.getParty.calledWith(5, 123)).to.be.true();
-    });
+      expect(importConnector.getParty.calledWith(5, 123)).to.be.true()
+    })
 
     test('importConnector.getInvoiceAccounts is called with region code and party ID', async () => {
-      expect(importConnector.getInvoiceAccounts.calledWith(5, 123)).to.be.true();
-    });
+      expect(importConnector.getInvoiceAccounts.calledWith(5, 123)).to.be.true()
+    })
 
     test('importConnector.getPartyLicenceVersions is called with region code and party ID', async () => {
-      expect(importConnector.getPartyLicenceVersions.calledWith(5, 123)).to.be.true();
-    });
+      expect(importConnector.getPartyLicenceVersions.calledWith(5, 123)).to.be.true()
+    })
 
     test('importConnector.addresses is called with region code and array of address IDs', async () => {
-      expect(importConnector.getAddresses.calledWith(5, ['address_1', 'address_3', 'address_4'])).to.be.true();
-    });
+      expect(importConnector.getAddresses.calledWith(5, ['address_1', 'address_3', 'address_4'])).to.be.true()
+    })
 
     test('resolves with the data', async () => {
-      expect(result.party).to.equal(data.party);
-      expect(result.addresses).to.equal(data.addresses);
-      expect(result.invoiceAccounts).to.equal(data.invoiceAccounts);
-      expect(result.licenceVersions).to.equal(data.licenceVersions);
-    });
-  });
-});
+      expect(result.party).to.equal(data.party)
+      expect(result.addresses).to.equal(data.addresses)
+      expect(result.invoiceAccounts).to.equal(data.invoiceAccounts)
+      expect(result.licenceVersions).to.equal(data.licenceVersions)
+    })
+  })
+})

--- a/test/modules/licence-import/handlers/index.js
+++ b/test/modules/licence-import/handlers/index.js
@@ -1,84 +1,84 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach, fail } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const handlers = require('../../../../src/modules/licence-import/handlers');
-const extract = require('../../../../src/modules/licence-import/extract');
-const transform = require('../../../../src/modules/licence-import/transform');
-const load = require('../../../../src/modules/licence-import/load');
-const importCompanies = require('../../../../src/modules/licence-import/connectors/import-companies');
-const purposeConditionTypesConnector = require('../../../../src/modules/licence-import/connectors/purpose-conditions-types');
+const { test, experiment, beforeEach, afterEach, fail } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const handlers = require('../../../../src/modules/licence-import/handlers')
+const extract = require('../../../../src/modules/licence-import/extract')
+const transform = require('../../../../src/modules/licence-import/transform')
+const load = require('../../../../src/modules/licence-import/load')
+const importCompanies = require('../../../../src/modules/licence-import/connectors/import-companies')
+const purposeConditionTypesConnector = require('../../../../src/modules/licence-import/connectors/purpose-conditions-types')
 
-const { logger } = require('../../../../src/logger');
+const { logger } = require('../../../../src/logger')
 
 experiment('modules/licence-import/transform/handlers', () => {
-  let server;
+  let server
 
   beforeEach(async () => {
-    sandbox.stub(logger, 'error');
-    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error')
+    sandbox.stub(logger, 'info')
 
     server = {
       messageQueue: {
         publish: sandbox.stub().resolves()
       }
-    };
-  });
+    }
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('importLicences', () => {
     beforeEach(async () => {
       sandbox.stub(extract, 'getAllLicenceNumbers').resolves([
         { LIC_NO: 'A' },
         { LIC_NO: 'B' }
-      ]);
-    });
+      ])
+    })
 
     experiment('importLicences', () => {
-      let result;
+      let result
 
       experiment('when there are no errors', () => {
         beforeEach(async () => {
-          result = await handlers.importLicences();
-        });
+          result = await handlers.importLicences()
+        })
 
         test('an info message is logged', async () => {
-          expect(logger.info.callCount).to.equal(1);
-        });
+          expect(logger.info.callCount).to.equal(1)
+        })
 
         test('list of licences/region codes/parties are loaded', async () => {
-          expect(extract.getAllLicenceNumbers.callCount).to.equal(1);
-        });
+          expect(extract.getAllLicenceNumbers.callCount).to.equal(1)
+        })
 
         test('the job resolves with the list of licences', async () => {
           expect(result).to.equal([
             { LIC_NO: 'A' },
             { LIC_NO: 'B' }
-          ]);
-        });
-      });
+          ])
+        })
+      })
 
       experiment('when there is an error', () => {
         beforeEach(async () => {
-          extract.getAllLicenceNumbers.throws();
-        });
+          extract.getAllLicenceNumbers.throws()
+        })
 
         test('error is logged and rethrown', async () => {
           try {
-            await handlers.importLicences();
-            fail();
+            await handlers.importLicences()
+            fail()
           } catch (err) {
-            expect(logger.error.callCount).to.equal(1);
-            expect(logger.error.lastCall.args[0]).to.equal('Import licences error');
+            expect(logger.error.callCount).to.equal(1)
+            expect(logger.error.lastCall.args[0]).to.equal('Import licences error')
           }
-        });
-      });
-    });
-  });
+        })
+      })
+    })
+  })
 
   experiment('onComplete importLicences', () => {
     const job = {
@@ -93,162 +93,162 @@ experiment('modules/licence-import/transform/handlers', () => {
           ]
         }
       }
-    };
+    }
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        await handlers.onCompleteImportLicences(server.messageQueue, job);
-      });
+        await handlers.onCompleteImportLicences(server.messageQueue, job)
+      })
 
       test('an info message is logged', async () => {
         expect(logger.info.calledWith(
           'Handling onComplete test-name'
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('2 import jobs are published', async () => {
-        expect(server.messageQueue.publish.callCount).to.equal(2);
-      });
+        expect(server.messageQueue.publish.callCount).to.equal(2)
+      })
 
       test('an import licence job is published for the first licence', async () => {
-        const [message] = server.messageQueue.publish.firstCall.args;
-        expect(message.name).to.equal('import.licence');
-        expect(message.data.licenceNumber).to.equal('A');
-      });
+        const [message] = server.messageQueue.publish.firstCall.args
+        expect(message.name).to.equal('import.licence')
+        expect(message.data.licenceNumber).to.equal('A')
+      })
 
       test('an import licence job is published for the second licence', async () => {
-        const [message] = server.messageQueue.publish.secondCall.args;
-        expect(message.name).to.equal('import.licence');
-        expect(message.data.licenceNumber).to.equal('B');
-      });
-    });
+        const [message] = server.messageQueue.publish.secondCall.args
+        expect(message.name).to.equal('import.licence')
+        expect(message.data.licenceNumber).to.equal('B')
+      })
+    })
 
     experiment('when there are errors', () => {
       beforeEach(async () => {
-        server.messageQueue.publish.rejects();
-      });
+        server.messageQueue.publish.rejects()
+      })
 
       test('an error is logged and thrown', async () => {
-        const func = () => handlers.onCompleteImportLicences(server.messageQueue, job);
-        await expect(func()).to.reject();
-        expect(logger.error.called).to.be.true();
-      });
-    });
-  });
+        const func = () => handlers.onCompleteImportLicences(server.messageQueue, job)
+        await expect(func()).to.reject()
+        expect(logger.error.called).to.be.true()
+      })
+    })
+  })
 
   experiment('importLicence', () => {
-    const jobData = { data: { licenceNumber: 'A' } };
+    const jobData = { data: { licenceNumber: 'A' } }
 
     beforeEach(async () => {
       sandbox.stub(extract, 'getLicenceData').resolves({
         foo: 'bar'
-      });
+      })
       sandbox.stub(transform.licence, 'transformLicence').returns({
         bar: 'foo'
-      });
-      sandbox.stub(load.licence, 'loadLicence');
-    });
+      })
+      sandbox.stub(load.licence, 'loadLicence')
+    })
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        await handlers.importLicence(jobData);
-      });
+        await handlers.importLicence(jobData)
+      })
 
       test('an info message is logged', async () => {
-        expect(logger.info.callCount).to.equal(1);
-      });
+        expect(logger.info.callCount).to.equal(1)
+      })
 
       test('extract.getLicenceData is called', async () => {
-        expect(extract.getLicenceData.calledWith(jobData.data.licenceNumber)).to.be.true();
-      });
+        expect(extract.getLicenceData.calledWith(jobData.data.licenceNumber)).to.be.true()
+      })
 
       test('raw licence data is transformed', async () => {
-        expect(transform.licence.transformLicence.calledWith({ foo: 'bar' })).to.be.true();
-      });
+        expect(transform.licence.transformLicence.calledWith({ foo: 'bar' })).to.be.true()
+      })
 
       test('transformed licence data is stored', async () => {
-        expect(load.licence.loadLicence.calledWith({ bar: 'foo' })).to.be.true();
-      });
-    });
+        expect(load.licence.loadLicence.calledWith({ bar: 'foo' })).to.be.true()
+      })
+    })
 
     experiment('when there is an error', () => {
       beforeEach(async () => {
-        extract.getLicenceData.rejects();
-      });
+        extract.getLicenceData.rejects()
+      })
 
       test('error is logged and rethrown', async () => {
         try {
-          await handlers.importLicence();
-          fail();
+          await handlers.importLicence()
+          fail()
         } catch (err) {
-          expect(logger.error.callCount).to.equal(1);
-          expect(logger.error.lastCall.args[0]).to.equal('Import licence error');
+          expect(logger.error.callCount).to.equal(1)
+          expect(logger.error.lastCall.args[0]).to.equal('Import licence error')
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('importCompany', () => {
-    const jobData = { data: { regionCode: '1', partyId: '101' } };
+    const jobData = { data: { regionCode: '1', partyId: '101' } }
 
     beforeEach(async () => {
       sandbox.stub(extract, 'getCompanyData').resolves({
         foo: 'bar'
-      });
+      })
       sandbox.stub(transform.company, 'transformCompany').returns({
         bar: 'foo'
-      });
-      sandbox.stub(load.company, 'loadCompany');
-      sandbox.stub(importCompanies, 'setImportedStatus');
-    });
+      })
+      sandbox.stub(load.company, 'loadCompany')
+      sandbox.stub(importCompanies, 'setImportedStatus')
+    })
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
-        await handlers.importCompany(jobData);
-      });
+        await handlers.importCompany(jobData)
+      })
 
       test('an info message is logged', async () => {
-        expect(logger.info.callCount).to.equal(1);
-      });
+        expect(logger.info.callCount).to.equal(1)
+      })
 
       test('extract.getCompanyData is called', async () => {
         expect(extract.getCompanyData.calledWith(
           jobData.data.regionCode, jobData.data.partyId
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('raw company data is transformed', async () => {
-        expect(transform.company.transformCompany.calledWith({ foo: 'bar' })).to.be.true();
-      });
+        expect(transform.company.transformCompany.calledWith({ foo: 'bar' })).to.be.true()
+      })
 
       test('transformed company data is stored', async () => {
-        expect(load.company.loadCompany.calledWith({ bar: 'foo' })).to.be.true();
-      });
-    });
+        expect(load.company.loadCompany.calledWith({ bar: 'foo' })).to.be.true()
+      })
+    })
 
     experiment('when there is an error', () => {
       beforeEach(async () => {
-        extract.getCompanyData.rejects();
-      });
+        extract.getCompanyData.rejects()
+      })
 
       test('error is logged and rethrown', async () => {
         try {
-          await handlers.importCompany();
-          fail();
+          await handlers.importCompany()
+          fail()
         } catch (err) {
-          expect(logger.error.callCount).to.equal(1);
-          expect(logger.error.lastCall.args[0]).to.equal('Import company error');
+          expect(logger.error.callCount).to.equal(1)
+          expect(logger.error.lastCall.args[0]).to.equal('Import company error')
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('importCompanies', () => {
-    let result;
+    let result
 
     beforeEach(async () => {
-      sandbox.stub(importCompanies, 'clear');
-    });
+      sandbox.stub(importCompanies, 'clear')
+    })
 
     experiment('when there are no errors', () => {
       beforeEach(async () => {
@@ -257,55 +257,55 @@ experiment('modules/licence-import/transform/handlers', () => {
             region_code: 1,
             party_id: 123
           }
-        ]);
-        result = await handlers.importCompanies();
-      });
+        ])
+        result = await handlers.importCompanies()
+      })
 
       test('logs an info message', async () => {
         expect(logger.info.calledWith(
           'Import companies'
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('clears existing import_companies table data', async () => {
-        expect(importCompanies.clear.called).to.be.true();
-      });
+        expect(importCompanies.clear.called).to.be.true()
+      })
 
       test('initialises the import_companies table with new data', async () => {
-        expect(importCompanies.initialise.called).to.be.true();
-      });
+        expect(importCompanies.initialise.called).to.be.true()
+      })
 
       test('resolves with mapped list of region codes/party IDs', async () => {
         expect(result).to.equal([{
           regionCode: 1,
           partyId: 123
-        }]);
-      });
-    });
+        }])
+      })
+    })
 
     experiment('when there are errors', () => {
       beforeEach(async () => {
-        sandbox.stub(importCompanies, 'initialise').rejects();
-      });
+        sandbox.stub(importCompanies, 'initialise').rejects()
+      })
 
       test('an error is logged and rethrown', async () => {
         try {
-          await handlers.importCompanies();
-          fail();
+          await handlers.importCompanies()
+          fail()
         } catch (err) {
-          expect(logger.error.called).to.be.true();
+          expect(logger.error.called).to.be.true()
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('onComplete importCompanies', () => {
-    let messageQueue;
+    let messageQueue
 
     beforeEach(async () => {
       messageQueue = {
         publish: sandbox.stub()
-      };
+      }
       const job = {
         data: {
           response: {
@@ -315,102 +315,102 @@ experiment('modules/licence-import/transform/handlers', () => {
             }]
           }
         }
-      };
-      await handlers.onCompleteImportCompanies(messageQueue, job);
-    });
+      }
+      await handlers.onCompleteImportCompanies(messageQueue, job)
+    })
 
     test('a job is published to import each company', async () => {
-      const [{ name, data }] = messageQueue.publish.lastCall.args;
-      expect(name).to.equal('import.company');
+      const [{ name, data }] = messageQueue.publish.lastCall.args
+      expect(name).to.equal('import.company')
       expect(data).to.equal({
         regionCode: 1, partyId: 123
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('onComplete importCompany', () => {
-    let messageQueue;
+    let messageQueue
 
     beforeEach(async () => {
-      sandbox.stub(importCompanies, 'getPendingCount');
+      sandbox.stub(importCompanies, 'getPendingCount')
       messageQueue = {
         deleteQueue: sandbox.stub(),
         publish: sandbox.stub()
-      };
-    });
+      }
+    })
 
     experiment('when there are still companies to import', () => {
       beforeEach(async () => {
-        importCompanies.getPendingCount.resolves(5);
-        await handlers.onCompleteImportCompany(messageQueue);
-      });
+        importCompanies.getPendingCount.resolves(5)
+        await handlers.onCompleteImportCompany(messageQueue)
+      })
 
       test('the queue is not deleted', async () => {
-        expect(messageQueue.deleteQueue.called).to.be.false();
-      });
+        expect(messageQueue.deleteQueue.called).to.be.false()
+      })
 
       test('the import licences job is not published', async () => {
-        expect(messageQueue.publish.called).to.be.false();
-      });
-    });
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
 
     experiment('when all the companies are imported', () => {
       beforeEach(async () => {
-        importCompanies.getPendingCount.resolves(0);
-        await handlers.onCompleteImportCompany(messageQueue);
-      });
+        importCompanies.getPendingCount.resolves(0)
+        await handlers.onCompleteImportCompany(messageQueue)
+      })
 
       test('the queue is deleted', async () => {
-        expect(messageQueue.deleteQueue.called).to.be.true();
-      });
+        expect(messageQueue.deleteQueue.called).to.be.true()
+      })
 
       test('the import licences job is published', async () => {
-        const [{ name }] = messageQueue.publish.lastCall.args;
-        expect(name).to.equal('import.licences');
-      });
-    });
-  });
+        const [{ name }] = messageQueue.publish.lastCall.args
+        expect(name).to.equal('import.licences')
+      })
+    })
+  })
 
   experiment('importPurposeConditionTypes', () => {
     beforeEach(async () => {
-      sandbox.stub(purposeConditionTypesConnector, 'createPurposeConditionTypes').resolves();
-      await handlers.importPurposeConditionTypes();
-    });
+      sandbox.stub(purposeConditionTypesConnector, 'createPurposeConditionTypes').resolves()
+      await handlers.importPurposeConditionTypes()
+    })
 
     test('logs an info message', async () => {
       expect(logger.info.calledWith(
         'Import purpose condition types'
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('calls the right connector method', async () => {
-      expect(purposeConditionTypesConnector.createPurposeConditionTypes.called).to.be.true();
-    });
+      expect(purposeConditionTypesConnector.createPurposeConditionTypes.called).to.be.true()
+    })
 
     experiment('when there are errors', () => {
       test('an error is logged and rethrown', async () => {
-        const err = new Error('test error');
-        purposeConditionTypesConnector.createPurposeConditionTypes.throws(err);
+        const err = new Error('test error')
+        purposeConditionTypesConnector.createPurposeConditionTypes.throws(err)
         try {
-          await handlers.importPurposeConditionTypes();
+          await handlers.importPurposeConditionTypes()
         } catch (err) {
-          expect(logger.error.called).to.be.true();
+          expect(logger.error.called).to.be.true()
         }
-      });
-    });
-  });
+      })
+    })
+  })
   experiment('onComplete importPurposeConditionTypes', () => {
-    let messageQueue;
+    let messageQueue
 
     beforeEach(async () => {
       messageQueue = {
         publish: sandbox.stub()
-      };
-    });
+      }
+    })
 
     test('the next job is published', async () => {
-      await handlers.onCompleteImportPurposeConditionTypes(messageQueue);
-      expect(messageQueue.publish.called).to.be.true();
-    });
-  });
-});
+      await handlers.onCompleteImportPurposeConditionTypes(messageQueue)
+      expect(messageQueue.publish.called).to.be.true()
+    })
+  })
+})

--- a/test/modules/licence-import/jobs/index.js
+++ b/test/modules/licence-import/jobs/index.js
@@ -1,56 +1,56 @@
-'use strict';
+'use strict'
 
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const jobs = require('../../../../src/modules/licence-import/jobs');
+const jobs = require('../../../../src/modules/licence-import/jobs')
 
 experiment('modules/licence-import/transform/jobs', () => {
   test('importCompany', async () => {
-    const { name, data, options } = jobs.importCompany(1, 100);
-    expect(name).to.equal(jobs.IMPORT_COMPANY_JOB);
+    const { name, data, options } = jobs.importCompany(1, 100)
+    expect(name).to.equal(jobs.IMPORT_COMPANY_JOB)
     expect(data).to.equal({
       regionCode: 1,
       partyId: 100
-    });
+    })
     expect(options).to.equal({
       singletonKey: 'import.company.1.100',
       expireIn: '4 hour'
-    });
-  });
+    })
+  })
 
   test('importCompanies', async () => {
-    const { name, options } = jobs.importCompanies();
-    expect(name).to.equal(jobs.IMPORT_COMPANIES_JOB);
+    const { name, options } = jobs.importCompanies()
+    expect(name).to.equal(jobs.IMPORT_COMPANIES_JOB)
     expect(options).to.equal({
       singletonKey: 'import.companies',
       singletonHours: 1,
       expireIn: '4 hour'
-    });
-  });
+    })
+  })
 
   test('importLicences', async () => {
-    const { name, options } = jobs.importLicences();
-    expect(name).to.equal(jobs.IMPORT_LICENCES_JOB);
+    const { name, options } = jobs.importLicences()
+    expect(name).to.equal(jobs.IMPORT_LICENCES_JOB)
     expect(options).to.equal({
       singletonKey: 'import.licences',
       singletonHours: 1,
       expireIn: '4 hour'
-    });
-  });
+    })
+  })
 
   test('importLicence', async () => {
-    const { name, data, options } = jobs.importLicence('01/123');
-    expect(name).to.equal(jobs.IMPORT_LICENCE_JOB);
+    const { name, data, options } = jobs.importLicence('01/123')
+    expect(name).to.equal(jobs.IMPORT_LICENCE_JOB)
     expect(data).to.equal({
       licenceNumber: '01/123'
-    });
+    })
     expect(options).to.equal({
       singletonKey: 'import.licence.01/123'
-    });
-  });
+    })
+  })
   test('importPurposeConditionTypes', async () => {
-    const { name } = jobs.importPurposeConditionTypes();
-    expect(name).to.equal(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB);
-  });
-});
+    const { name } = jobs.importPurposeConditionTypes()
+    expect(name).to.equal(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB)
+  })
+})

--- a/test/modules/licence-import/load/company.js
+++ b/test/modules/licence-import/load/company.js
@@ -1,11 +1,11 @@
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { loadCompany } = require('../../../../src/modules/licence-import/load/company');
-const connectors = require('../../../../src/modules/licence-import/load/connectors');
+const { loadCompany } = require('../../../../src/modules/licence-import/load/company')
+const connectors = require('../../../../src/modules/licence-import/load/connectors')
 
-const config = require('../../../../config');
+const config = require('../../../../config')
 
 const createCompany = () => ({
   externalId: '1:100',
@@ -47,106 +47,106 @@ const createCompany = () => ({
       }
     }]
   }]
-});
+})
 
 experiment('modules/licence-import/load/company', () => {
-  let company;
+  let company
 
   beforeEach(async () => {
-    sandbox.stub(connectors, 'createCompany');
-    sandbox.stub(connectors, 'createAddress');
-    sandbox.stub(connectors, 'createContact');
-    sandbox.stub(connectors, 'createCompanyAddress');
-    sandbox.stub(connectors, 'createCompanyContact');
-    sandbox.stub(connectors, 'createInvoiceAccount');
-    sandbox.stub(connectors, 'createInvoiceAccountAddress');
+    sandbox.stub(connectors, 'createCompany')
+    sandbox.stub(connectors, 'createAddress')
+    sandbox.stub(connectors, 'createContact')
+    sandbox.stub(connectors, 'createCompanyAddress')
+    sandbox.stub(connectors, 'createCompanyContact')
+    sandbox.stub(connectors, 'createInvoiceAccount')
+    sandbox.stub(connectors, 'createInvoiceAccountAddress')
 
-    company = createCompany();
-  });
+    company = createCompany()
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('when the flags are enabled in the config', () => {
     beforeEach(async () => {
-      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(true);
+      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(true)
 
-      await loadCompany(company);
-    });
+      await loadCompany(company)
+    })
 
     test('creates company', async () => {
       expect(
         connectors.createCompany.calledWith(company)
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates addresses', async () => {
       expect(
         connectors.createAddress.calledWith(company.addresses[0].address)
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates company addresses', async () => {
       expect(
         connectors.createCompanyAddress.calledWith(company, company.addresses[0])
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates invoice account addresses', async () => {
       expect(
         connectors.createAddress.calledWith(company.invoiceAccounts[0].addresses[0].address)
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates contacts', async () => {
       expect(
         connectors.createContact.calledWith(company.contacts[0].contact)
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates company contact', async () => {
       expect(
         connectors.createCompanyContact.calledWith(company, company.contacts[0])
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates invoice account', async () => {
       expect(
         connectors.createInvoiceAccount.calledWith(company, company.invoiceAccounts[0])
-      ).to.be.true();
-    });
+      ).to.be.true()
+    })
 
     test('creates invoice account addresses', async () => {
       expect(
         connectors.createInvoiceAccountAddress.calledWith(company.invoiceAccounts[0], company.invoiceAccounts[0].addresses[0])
-      ).to.be.true();
-    });
-  });
+      ).to.be.true()
+    })
+  })
 
   experiment('when the isInvoiceAccountImportEnabled flag is disabled in the config', () => {
     beforeEach(async () => {
-      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(false);
+      sandbox.stub(config.import.licences, 'isInvoiceAccountImportEnabled').value(false)
 
-      await loadCompany(company);
-    });
+      await loadCompany(company)
+    })
 
     test('creates invoice account addresses', async () => {
       expect(
         connectors.createAddress.calledWith(company.invoiceAccounts[0].addresses[0].address)
-      ).to.be.false();
-    });
+      ).to.be.false()
+    })
 
     test('creates invoice account', async () => {
       expect(
         connectors.createInvoiceAccount.calledWith(company, company.invoiceAccounts[0])
-      ).to.be.false();
-    });
+      ).to.be.false()
+    })
 
     test('creates invoice account addresses', async () => {
       expect(
         connectors.createInvoiceAccountAddress.calledWith(company.invoiceAccounts[0], company.invoiceAccounts[0].addresses[0])
-      ).to.be.false();
-    });
-  });
-});
+      ).to.be.false()
+    })
+  })
+})

--- a/test/modules/licence-import/load/connectors/index.js
+++ b/test/modules/licence-import/load/connectors/index.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const uuid = require('uuid/v4');
+const uuid = require('uuid/v4')
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { pool } = require('../../../../../src/lib/connectors/db');
-const queries = require('../../../../../src/modules/licence-import/load/connectors/queries');
-const connectors = require('../../../../../src/modules/licence-import/load/connectors');
+const { pool } = require('../../../../../src/lib/connectors/db')
+const queries = require('../../../../../src/modules/licence-import/load/connectors/queries')
+const connectors = require('../../../../../src/modules/licence-import/load/connectors')
 
 const data = {
   licence: {
@@ -133,50 +133,50 @@ const data = {
       externalId: '1:1005'
     }
   }
-};
+}
 
 experiment('modules/licence-import/load/connectors', () => {
   beforeEach(async () => {
-    sandbox.stub(pool, 'query').resolves({ rows: [{}] });
-  });
+    sandbox.stub(pool, 'query').resolves({ rows: [{}] })
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('createDocument', () => {
     beforeEach(async () => {
-      await connectors.createDocument(data.document);
-    });
+      await connectors.createDocument(data.document)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createDocument);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createDocument)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.document.documentRef,
         data.document.startDate,
         data.document.endDate,
         data.document.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createDocumentRole for licence holder', () => {
     beforeEach(async () => {
-      await connectors.createDocumentRole(data.document, data.licenceHolderRole);
-    });
+      await connectors.createDocumentRole(data.document, data.licenceHolderRole)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createDocumentRole);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createDocumentRole)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.document.documentRef,
         data.licenceHolderRole.role,
@@ -186,22 +186,22 @@ experiment('modules/licence-import/load/connectors', () => {
         null,
         data.licenceHolderRole.startDate,
         data.licenceHolderRole.endDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createDocumentRole for billing', () => {
     beforeEach(async () => {
-      await connectors.createDocumentRole(data.document, data.billingRole);
-    });
+      await connectors.createDocumentRole(data.document, data.billingRole)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createDocumentRole);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createDocumentRole)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.document.documentRef,
         data.billingRole.role,
@@ -211,42 +211,42 @@ experiment('modules/licence-import/load/connectors', () => {
         data.billingRole.invoiceAccount.invoiceAccountNumber,
         data.billingRole.startDate,
         data.billingRole.endDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createCompany', () => {
     beforeEach(async () => {
-      await connectors.createCompany(data.company);
-    });
+      await connectors.createCompany(data.company)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createCompany);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createCompany)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.company.name,
         data.company.type,
         data.company.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createAddress', () => {
     beforeEach(async () => {
-      await connectors.createAddress(data.address);
-    });
+      await connectors.createAddress(data.address)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createAddress);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createAddress)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.address.address1,
         data.address.address2,
@@ -257,152 +257,152 @@ experiment('modules/licence-import/load/connectors', () => {
         data.address.postcode,
         data.address.country,
         data.address.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createContact', () => {
     beforeEach(async () => {
-      await connectors.createContact(data.contact);
-    });
+      await connectors.createContact(data.contact)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createContact);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createContact)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.contact.salutation,
         data.contact.initials,
         data.contact.firstName,
         data.contact.lastName,
         data.contact.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createInvoiceAccount', () => {
     beforeEach(async () => {
-      await connectors.createInvoiceAccount(data.company, data.invoiceAccount);
-    });
+      await connectors.createInvoiceAccount(data.company, data.invoiceAccount)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createInvoiceAccount);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createInvoiceAccount)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.invoiceAccount.invoiceAccountNumber,
         data.invoiceAccount.startDate,
         data.invoiceAccount.endDate,
         data.company.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createInvoiceAccountAddress', () => {
     beforeEach(async () => {
-      await connectors.createInvoiceAccountAddress(data.invoiceAccount, data.invoiceAccountAddress);
-    });
+      await connectors.createInvoiceAccountAddress(data.invoiceAccount, data.invoiceAccountAddress)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createInvoiceAccountAddress);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createInvoiceAccountAddress)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.invoiceAccount.invoiceAccountNumber,
         data.invoiceAccountAddress.address.externalId,
         data.invoiceAccountAddress.startDate,
         data.invoiceAccountAddress.endDate,
         data.invoiceAccountAddress.agentCompany.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createCompanyContact', () => {
     beforeEach(async () => {
-      await connectors.createCompanyContact(data.company, data.companyContact);
-    });
+      await connectors.createCompanyContact(data.company, data.companyContact)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createCompanyContact);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createCompanyContact)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.company.externalId,
         data.companyContact.contact.externalId,
         data.companyContact.role,
         data.companyContact.startDate,
         data.companyContact.endDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createCompanyAddress', () => {
     beforeEach(async () => {
-      await connectors.createCompanyAddress(data.company, data.companyAddress);
-    });
+      await connectors.createCompanyAddress(data.company, data.companyAddress)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createCompanyAddress);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createCompanyAddress)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.company.externalId,
         data.companyAddress.address.externalId,
         data.companyAddress.role,
         data.companyAddress.startDate,
         data.companyAddress.endDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createAgreement', () => {
     beforeEach(async () => {
-      await connectors.createAgreement(data.licence, data.agreement);
-    });
+      await connectors.createAgreement(data.licence, data.agreement)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createAgreement);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createAgreement)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.licence.licenceNumber,
         data.agreement.agreementCode,
         data.agreement.startDate,
         data.agreement.endDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('createLicence', () => {
     beforeEach(async () => {
-      await connectors.createLicence(data.licence);
-    });
+      await connectors.createLicence(data.licence)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createLicence);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createLicence)
+    })
 
     test('uses the correct params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.licence.regionCode,
         data.licence.licenceNumber,
@@ -412,16 +412,16 @@ experiment('modules/licence-import/load/connectors', () => {
         data.licence.expiredDate,
         data.licence.lapsedDate,
         data.licence.revokedDate
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('.createLicenceVersion', () => {
-    let version;
-    let licenceId;
+    let version
+    let licenceId
 
     beforeEach(async () => {
-      licenceId = uuid();
+      licenceId = uuid()
 
       version = {
         issue: 100,
@@ -430,18 +430,18 @@ experiment('modules/licence-import/load/connectors', () => {
         startDate: '2000-01-01',
         endDate: null,
         externalId: '1:2:3:4'
-      };
+      }
 
-      await connectors.createLicenceVersion(version, licenceId);
-    });
+      await connectors.createLicenceVersion(version, licenceId)
+    })
 
     test('uses the expected query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createLicenceVersion);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createLicenceVersion)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
 
       expect(params).to.equal([
         licenceId,
@@ -451,16 +451,16 @@ experiment('modules/licence-import/load/connectors', () => {
         version.startDate,
         version.endDate,
         version.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('.createLicenceVersionPurpose', () => {
-    let purpose;
-    let licenceVersionId;
+    let purpose
+    let licenceVersionId
 
     beforeEach(async () => {
-      licenceVersionId = uuid();
+      licenceVersionId = uuid()
 
       purpose = {
         purposePrimary: 'A',
@@ -475,18 +475,18 @@ experiment('modules/licence-import/load/connectors', () => {
         notes: 'notes',
         annualQuantity: 1000,
         externalId: '1:111222'
-      };
+      }
 
-      await connectors.createLicenceVersionPurpose(purpose, licenceVersionId);
-    });
+      await connectors.createLicenceVersionPurpose(purpose, licenceVersionId)
+    })
 
     test('uses the expected query', async () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.createLicenceVersionPurpose);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.createLicenceVersionPurpose)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
 
       expect(params).to.equal([
         licenceVersionId,
@@ -502,64 +502,64 @@ experiment('modules/licence-import/load/connectors', () => {
         purpose.notes,
         purpose.annualQuantity,
         purpose.externalId
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('.getLicenceByRef', () => {
     beforeEach(async () => {
-      await connectors.getLicenceByRef('test-licence-ref');
-    });
+      await connectors.getLicenceByRef('test-licence-ref')
+    })
 
     test('Calls the correct query', () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.getLicenceByRef);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.getLicenceByRef)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
 
-      expect(params).to.equal(['test-licence-ref']);
-    });
-  });
+      expect(params).to.equal(['test-licence-ref'])
+    })
+  })
 
   experiment('.getLicenceByRef', () => {
     beforeEach(async () => {
-      await connectors.flagLicenceForSupplementaryBilling('test-licence-id');
-    });
+      await connectors.flagLicenceForSupplementaryBilling('test-licence-id')
+    })
 
     test('Calls the correct query', () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.flagLicenceForSupplementaryBilling);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.flagLicenceForSupplementaryBilling)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
 
-      expect(params).to.equal(['test-licence-id']);
-    });
-  });
+      expect(params).to.equal(['test-licence-id'])
+    })
+  })
 
   experiment('.cleanupAgreements', () => {
     beforeEach(async () => {
       const lic = {
         ...data.licence,
         agreements: [data.agreement]
-      };
-      await connectors.cleanUpAgreements(lic);
-    });
+      }
+      await connectors.cleanUpAgreements(lic)
+    })
 
     test('Calls the correct query', () => {
-      const [query] = pool.query.lastCall.args;
-      expect(query).to.equal(queries.cleanUpAgreements);
-    });
+      const [query] = pool.query.lastCall.args
+      expect(query).to.equal(queries.cleanUpAgreements)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = pool.query.lastCall.args;
+      const [, params] = pool.query.lastCall.args
       expect(params).to.equal([
         data.licence.licenceNumber,
         ['S127:2019-06-03']
-      ]);
-    });
-  });
-});
+      ])
+    })
+  })
+})

--- a/test/modules/licence-import/load/licence.js
+++ b/test/modules/licence-import/load/licence.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const uuid = require('uuid/v4');
+const uuid = require('uuid/v4')
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { loadLicence } = require('../../../../src/modules/licence-import/load/licence');
-const connectors = require('../../../../src/modules/licence-import/load/connectors');
-const config = require('../../../../config');
+const { loadLicence } = require('../../../../src/modules/licence-import/load/licence')
+const connectors = require('../../../../src/modules/licence-import/load/connectors')
+const config = require('../../../../config')
 
 const createLicence = (expiryDate = null) => ({
   licenceNumber: '123/456',
@@ -101,199 +101,199 @@ const createLicence = (expiryDate = null) => ({
     startDate: '2019-01-01',
     endDate: null
   }]
-});
+})
 
 experiment('modules/licence-import/load/licence', () => {
-  let licence;
-  let licenceId;
-  let licenceVersionId;
-  let purposeId;
+  let licence
+  let licenceId
+  let licenceVersionId
+  let purposeId
 
   beforeEach(async () => {
-    await sandbox.stub(connectors, 'createDocumentRole');
-    await sandbox.stub(connectors, 'createDocument');
+    await sandbox.stub(connectors, 'createDocumentRole')
+    await sandbox.stub(connectors, 'createDocument')
     await sandbox.stub(connectors, 'getLicenceByRef').resolves({
       licence_id: 'test-licence-id',
       expired_date: null,
       lapsed_date: null,
       revoked_date: null
-    });
-    await sandbox.stub(connectors, 'createAgreement');
-    await sandbox.stub(connectors, 'flagLicenceForSupplementaryBilling');
+    })
+    await sandbox.stub(connectors, 'createAgreement')
+    await sandbox.stub(connectors, 'flagLicenceForSupplementaryBilling')
     await sandbox.stub(connectors, 'createLicenceVersion').resolves({
       licence_version_id: licenceVersionId = uuid()
-    });
+    })
     await sandbox.stub(connectors, 'createLicence').resolves({
       licence_id: licenceId = uuid()
-    });
+    })
     await sandbox.stub(connectors, 'createLicenceVersionPurpose').resolves({
       licence_version_purpose_id: purposeId = uuid()
-    });
-    await sandbox.stub(connectors, 'createPurposeCondition').resolves();
-    await sandbox.stub(connectors, 'cleanUpAgreements');
+    })
+    await sandbox.stub(connectors, 'createPurposeCondition').resolves()
+    await sandbox.stub(connectors, 'cleanUpAgreements')
 
-    licence = createLicence();
-  });
+    licence = createLicence()
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('when the flags are enabled in the config', () => {
     beforeEach(async () => {
-      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(true);
-      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(true);
+      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(true)
+      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(true)
 
-      await loadLicence(licence);
-    });
+      await loadLicence(licence)
+    })
 
     test('writes the licence,', async () => {
-      expect(connectors.createLicence.calledWith(licence)).to.be.true();
-    });
+      expect(connectors.createLicence.calledWith(licence)).to.be.true()
+    })
 
     test('creates document', async () => {
       expect(connectors.createDocument.calledWith(
         licence.document
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('creates the licence holder document role', async () => {
       expect(connectors.createDocumentRole.calledWith(
         licence.document, licence.document.roles[0]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('creates the billing document role', async () => {
       expect(connectors.createDocumentRole.calledWith(
         licence.document, licence.document.roles[1]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('cleans up old agreements', async () => {
       expect(connectors.cleanUpAgreements.calledWith(
         licence
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('creates agreements', async () => {
       expect(connectors.createAgreement.calledWith(
         licence, licence.agreements[0]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('creates the licence version', async () => {
-      const [version, savedLicenceId] = connectors.createLicenceVersion.lastCall.args;
+      const [version, savedLicenceId] = connectors.createLicenceVersion.lastCall.args
 
-      expect(version.issue).to.equal(100);
-      expect(version.increment).to.equal(1);
-      expect(version.status).to.equal('current');
-      expect(version.startDate).to.equal('2019-01-01');
-      expect(version.endDate).to.equal(null);
-      expect(version.externalId).to.equal('1:100:100:1');
-      expect(savedLicenceId).to.equal(licenceId);
-    });
+      expect(version.issue).to.equal(100)
+      expect(version.increment).to.equal(1)
+      expect(version.status).to.equal('current')
+      expect(version.startDate).to.equal('2019-01-01')
+      expect(version.endDate).to.equal(null)
+      expect(version.externalId).to.equal('1:100:100:1')
+      expect(savedLicenceId).to.equal(licenceId)
+    })
 
     test('creates the licence version', async () => {
-      const [version, savedLicenceId] = connectors.createLicenceVersion.lastCall.args;
+      const [version, savedLicenceId] = connectors.createLicenceVersion.lastCall.args
 
-      expect(version.issue).to.equal(100);
-      expect(version.increment).to.equal(1);
-      expect(version.status).to.equal('current');
-      expect(version.startDate).to.equal('2019-01-01');
-      expect(version.endDate).to.equal(null);
-      expect(version.externalId).to.equal('1:100:100:1');
-      expect(savedLicenceId).to.equal(licenceId);
-    });
+      expect(version.issue).to.equal(100)
+      expect(version.increment).to.equal(1)
+      expect(version.status).to.equal('current')
+      expect(version.startDate).to.equal('2019-01-01')
+      expect(version.endDate).to.equal(null)
+      expect(version.externalId).to.equal('1:100:100:1')
+      expect(savedLicenceId).to.equal(licenceId)
+    })
 
     test('creates the licence version purpose', async () => {
-      const [purpose, savedId] = connectors.createLicenceVersionPurpose.lastCall.args;
+      const [purpose, savedId] = connectors.createLicenceVersionPurpose.lastCall.args
 
-      expect(savedId).to.equal(licenceVersionId);
-      expect(purpose.purposePrimary).to.equal('A');
-      expect(purpose.purposeSecondary).to.equal('ABC');
-      expect(purpose.purposeUse).to.equal('123');
-      expect(purpose.abstractionPeriodStartDay).to.equal(1);
-      expect(purpose.abstractionPeriodStartMonth).to.equal(1);
-      expect(purpose.abstractionPeriodEndDay).to.equal(2);
-      expect(purpose.abstractionPeriodEndMonth).to.equal(2);
-      expect(purpose.timeLimitedStartDate).to.equal(null);
-      expect(purpose.timeLimitedEndDate).to.equal(null);
-      expect(purpose.notes).to.equal('testing');
-      expect(purpose.annualQuantity).to.equal(100);
-    });
+      expect(savedId).to.equal(licenceVersionId)
+      expect(purpose.purposePrimary).to.equal('A')
+      expect(purpose.purposeSecondary).to.equal('ABC')
+      expect(purpose.purposeUse).to.equal('123')
+      expect(purpose.abstractionPeriodStartDay).to.equal(1)
+      expect(purpose.abstractionPeriodStartMonth).to.equal(1)
+      expect(purpose.abstractionPeriodEndDay).to.equal(2)
+      expect(purpose.abstractionPeriodEndMonth).to.equal(2)
+      expect(purpose.timeLimitedStartDate).to.equal(null)
+      expect(purpose.timeLimitedEndDate).to.equal(null)
+      expect(purpose.notes).to.equal('testing')
+      expect(purpose.annualQuantity).to.equal(100)
+    })
 
     test('creates the licence version purpose condition', async () => {
-      const [condition, savedId] = connectors.createPurposeCondition.lastCall.args;
-      expect(savedId).to.equal(purposeId);
-      expect(condition.code).to.equal('AGG');
-      expect(condition.subcode).to.equal('LLL');
-      expect(condition.param1).to.equal(null);
-      expect(condition.param2).to.equal(null);
-      expect(condition.notes).to.equal(null);
-      expect(condition.externalId).to.equal('123:20');
-      expect(connectors.createPurposeCondition.callCount).to.equal(1);
-    });
+      const [condition, savedId] = connectors.createPurposeCondition.lastCall.args
+      expect(savedId).to.equal(purposeId)
+      expect(condition.code).to.equal('AGG')
+      expect(condition.subcode).to.equal('LLL')
+      expect(condition.param1).to.equal(null)
+      expect(condition.param2).to.equal(null)
+      expect(condition.notes).to.equal(null)
+      expect(condition.externalId).to.equal('123:20')
+      expect(connectors.createPurposeCondition.callCount).to.equal(1)
+    })
 
     test('attempts to grab the licence record', () => {
       expect(connectors.getLicenceByRef.calledWith(
         '123/456'
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     experiment('when there is no change in licence death', () => {
       beforeEach(async () => {
-      });
+      })
       test('does not flag the licence for supplementary billing', () => {
         expect(connectors.flagLicenceForSupplementaryBilling.calledWith(
           'test-licence-id'
-        )).to.be.false();
-      });
-    });
+        )).to.be.false()
+      })
+    })
 
     experiment('when there is a difference in licence death', () => {
       beforeEach(async () => {
-        licence = createLicence(new Date());
-        await loadLicence(licence);
-      });
+        licence = createLicence(new Date())
+        await loadLicence(licence)
+      })
       test('flags the licence for supplementary billing', () => {
         expect(connectors.flagLicenceForSupplementaryBilling.calledWith(
           'test-licence-id'
-        )).to.be.true();
-      });
-    });
-  });
+        )).to.be.true()
+      })
+    })
+  })
 
   experiment('when the isBillingDocumentRoleImportEnabled flag is disabled in the config', () => {
     beforeEach(async () => {
-      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(false);
-      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(true);
+      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(false)
+      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(true)
 
-      await loadLicence(licence);
-    });
+      await loadLicence(licence)
+    })
 
     test('creates the licence holder document role', async () => {
       expect(connectors.createDocumentRole.calledWith(
         licence.document, licence.document.roles[0]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('creates the billing document role', async () => {
       expect(connectors.createDocumentRole.calledWith(
         licence.document, licence.document.roles[1]
-      )).to.be.false();
-    });
-  });
+      )).to.be.false()
+    })
+  })
 
   experiment('when the isInvoiceAccountImportEnabled flag is disabled in the config', () => {
     beforeEach(async () => {
-      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(true);
-      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(false);
+      sandbox.stub(config.import.licences, 'isBillingDocumentRoleImportEnabled').value(true)
+      sandbox.stub(config.import.licences, 'isLicenceAgreementImportEnabled').value(false)
 
-      await loadLicence(licence);
-    });
+      await loadLicence(licence)
+    })
 
     test('does not create agreements', async () => {
-      expect(connectors.createAgreement.called).to.be.false();
-    });
-  });
-});
+      expect(connectors.createAgreement.called).to.be.false()
+    })
+  })
+})

--- a/test/modules/licence-import/plugin.js
+++ b/test/modules/licence-import/plugin.js
@@ -1,16 +1,16 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sandbox = require('sinon').createSandbox();
-const cron = require('node-cron');
-const { plugin } = require('../../../src/modules/licence-import/plugin');
-const jobs = require('../../../src/modules/licence-import/jobs');
-const handlers = require('../../../src/modules/licence-import/handlers');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sandbox = require('sinon').createSandbox()
+const cron = require('node-cron')
+const { plugin } = require('../../../src/modules/licence-import/plugin')
+const jobs = require('../../../src/modules/licence-import/jobs')
+const handlers = require('../../../src/modules/licence-import/handlers')
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
 experiment('modules/licence-import/plugin.js', () => {
-  let server;
+  let server
 
   beforeEach(async () => {
     server = {
@@ -19,116 +19,116 @@ experiment('modules/licence-import/plugin.js', () => {
         publish: sandbox.stub().resolves(),
         onComplete: sandbox.stub().resolves()
       }
-    };
-    sandbox.stub(cron, 'schedule');
-  });
+    }
+    sandbox.stub(cron, 'schedule')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   test('has a plugin name', async () => {
-    expect(plugin.name).to.equal('importLicenceData');
-  });
+    expect(plugin.name).to.equal('importLicenceData')
+  })
 
   test('requires pgBoss plugin', async () => {
-    expect(plugin.dependencies).to.equal(['pgBoss']);
-  });
+    expect(plugin.dependencies).to.equal(['pgBoss'])
+  })
 
   experiment('register', () => {
     experiment('on target environments', () => {
-      const options = { teamSize: 500, teamConcurrency: 1 };
+      const options = { teamSize: 500, teamConcurrency: 1 }
 
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'test'
-        });
-        await plugin.register(server);
-      });
+        })
+        await plugin.register(server)
+      })
 
       test('adds subscriber for delete removed documents job', async () => {
-        const [job, func] = server.messageQueue.subscribe.firstCall.args;
-        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB);
-        expect(func).to.equal(handlers.deleteDocuments);
-      });
+        const [job, func] = server.messageQueue.subscribe.firstCall.args
+        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB)
+        expect(func).to.equal(handlers.deleteDocuments)
+      })
 
       test('adds on complete handler for delete removed documents job', async () => {
-        const [job, func] = server.messageQueue.onComplete.firstCall.args;
-        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB);
-        expect(func).to.be.a.function();
-      });
+        const [job, func] = server.messageQueue.onComplete.firstCall.args
+        expect(job).to.equal(jobs.DELETE_DOCUMENTS_JOB)
+        expect(func).to.be.a.function()
+      })
 
       test('adds on complete handler for import purpose condition types job', async () => {
-        const [job, func] = server.messageQueue.onComplete.secondCall.args;
-        expect(job).to.equal(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB);
-        expect(func).to.be.a.function();
-      });
+        const [job, func] = server.messageQueue.onComplete.secondCall.args
+        expect(job).to.equal(jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB)
+        expect(func).to.be.a.function()
+      })
 
       test('adds on complete handler for import company job', async () => {
-        const [job, func] = server.messageQueue.onComplete.thirdCall.args;
-        expect(job).to.equal(jobs.IMPORT_COMPANIES_JOB);
-        expect(func).to.be.a.function();
-      });
+        const [job, func] = server.messageQueue.onComplete.thirdCall.args
+        expect(job).to.equal(jobs.IMPORT_COMPANIES_JOB)
+        expect(func).to.be.a.function()
+      })
 
       test('adds on complete handler for import company job', async () => {
-        const [job, func] = server.messageQueue.onComplete.getCall(3).args;
-        expect(job).to.equal(jobs.IMPORT_COMPANY_JOB);
-        expect(func).to.be.a.function();
-      });
+        const [job, func] = server.messageQueue.onComplete.getCall(3).args
+        expect(job).to.equal(jobs.IMPORT_COMPANY_JOB)
+        expect(func).to.be.a.function()
+      })
 
       test('adds subscriber for import purpose condition types job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           jobs.IMPORT_PURPOSE_CONDITION_TYPES_JOB, handlers.importPurposeConditionTypes
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('adds subscriber for import companies job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           jobs.IMPORT_COMPANIES_JOB, handlers.importCompanies
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('adds subscriber for import company job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           jobs.IMPORT_COMPANY_JOB, options, handlers.importCompany
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('adds subscriber for import licences job', async () => {
         expect(server.messageQueue.subscribe.calledWith(
           jobs.IMPORT_LICENCES_JOB, handlers.importLicences
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('adds on complete handler for delete removed documents job', async () => {
-        const [job, func] = server.messageQueue.onComplete.lastCall.args;
-        expect(job).to.equal(jobs.IMPORT_LICENCES_JOB);
-        expect(func).to.be.a.function();
-      });
+        const [job, func] = server.messageQueue.onComplete.lastCall.args
+        expect(job).to.equal(jobs.IMPORT_LICENCES_JOB)
+        expect(func).to.be.a.function()
+      })
 
       test('schedules a cron job at 16 on Monday, Wednesday, and Friday in non-production environments', async () => {
         expect(cron.schedule.calledWith(
           '0 16 * * 1,2,3,4,5'
-        )).to.be.true();
-      });
-    });
+        )).to.be.true()
+      })
+    })
 
     experiment('on production', () => {
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'production'
-        });
+        })
 
-        plugin.register(server);
-      });
+        plugin.register(server)
+      })
 
       test('subscribers are bound', async () => {
-        expect(server.messageQueue.subscribe.callCount).to.equal(6);
-      });
+        expect(server.messageQueue.subscribe.callCount).to.equal(6)
+      })
 
       test('cron job is scheduled', async () => {
-        expect(cron.schedule.callCount).to.equal(1);
-      });
-    });
-  });
-});
+        expect(cron.schedule.callCount).to.equal(1)
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/company.js
+++ b/test/modules/licence-import/transform/company.js
@@ -1,10 +1,10 @@
-const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { transformCompany } = require('../../../../src/modules/licence-import/transform/company');
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { transformCompany } = require('../../../../src/modules/licence-import/transform/company')
+const { expect } = require('@hapi/code')
 
-const data = require('./data');
+const data = require('./data')
 const createCompany = () => {
-  const licence = data.createLicence();
+  const licence = data.createLicence()
   return {
     party: data.createPerson(),
     addresses: [
@@ -37,110 +37,110 @@ const createCompany = () => {
       data.createVersion(licence, { ISSUE_NO: '1', INCR_NO: '2', EFF_ST_DATE: '06/07/2015', EFF_END_DATE: '12/08/2015' }),
       data.createVersion(licence, { ISSUE_NO: '2', INCR_NO: '1', EFF_ST_DATE: '13/08/2015', EFF_END_DATE: 'null' })
     ]
-  };
-};
+  }
+}
 
 experiment('modules/licence-import/transform/company.js', () => {
-  let result;
+  let result
 
   experiment('transformCompany', () => {
     experiment('for a company', () => {
       beforeEach(async () => {
-        const companyData = createCompany();
-        result = transformCompany(companyData);
-      });
+        const companyData = createCompany()
+        result = transformCompany(companyData)
+      })
 
       test('company details are mapped correctly', async () => {
-        expect(result.type).to.equal('person');
-        expect(result.name).to.equal('SIR JOHN DOE');
-        expect(result.externalId).to.equal('1:1001');
-      });
+        expect(result.type).to.equal('person')
+        expect(result.name).to.equal('SIR JOHN DOE')
+        expect(result.externalId).to.equal('1:1001')
+      })
 
       test('there should be an invoice account for each distinct IAS account number', async () => {
-        expect(result.invoiceAccounts.length).to.equal(2);
-      });
+        expect(result.invoiceAccounts.length).to.equal(2)
+      })
 
       test('the date ranges of the invoice accounts is determined by the IAS_XFER_DATE', async () => {
-        const [first, second] = result.invoiceAccounts;
-        expect(first.invoiceAccountNumber).to.equal('A1234');
-        expect(first.startDate).to.equal('2015-04-02');
-        expect(first.endDate).to.equal(null);
-        expect(second.invoiceAccountNumber).to.equal('B7890');
-        expect(second.startDate).to.equal('2015-08-13');
-        expect(second.endDate).to.equal(null);
-      });
+        const [first, second] = result.invoiceAccounts
+        expect(first.invoiceAccountNumber).to.equal('A1234')
+        expect(first.startDate).to.equal('2015-04-02')
+        expect(first.endDate).to.equal(null)
+        expect(second.invoiceAccountNumber).to.equal('B7890')
+        expect(second.startDate).to.equal('2015-08-13')
+        expect(second.endDate).to.equal(null)
+      })
 
       test('the first invoice account has the correct address history', async () => {
-        expect(result.invoiceAccounts[0].addresses).to.have.length(2);
-        const [first, second] = result.invoiceAccounts[0].addresses;
-        expect(first.role).to.equal('billing');
-        expect(first.startDate).to.equal('2015-04-02');
-        expect(first.endDate).to.equal('2015-07-05');
-        expect(first.address.externalId).to.equal('1:1000');
-        expect(first.agentCompany.externalId).to.be.null();
-        expect(second.role).to.equal('billing');
-        expect(second.startDate).to.equal('2015-07-06');
-        expect(second.endDate).to.equal(null);
-        expect(second.address.externalId).to.equal('1:1001');
-        expect(second.agentCompany.externalId).to.be.null();
-      });
+        expect(result.invoiceAccounts[0].addresses).to.have.length(2)
+        const [first, second] = result.invoiceAccounts[0].addresses
+        expect(first.role).to.equal('billing')
+        expect(first.startDate).to.equal('2015-04-02')
+        expect(first.endDate).to.equal('2015-07-05')
+        expect(first.address.externalId).to.equal('1:1000')
+        expect(first.agentCompany.externalId).to.be.null()
+        expect(second.role).to.equal('billing')
+        expect(second.startDate).to.equal('2015-07-06')
+        expect(second.endDate).to.equal(null)
+        expect(second.address.externalId).to.equal('1:1001')
+        expect(second.agentCompany.externalId).to.be.null()
+      })
 
       test('the second invoice account has the correct address history', async () => {
-        expect(result.invoiceAccounts[1].addresses).to.have.length(1);
-        const [first] = result.invoiceAccounts[1].addresses;
-        expect(first.role).to.equal('billing');
-        expect(first.startDate).to.equal('2015-08-13');
-        expect(first.endDate).to.equal(null);
-        expect(first.address.externalId).to.equal('1:1001');
-        expect(first.agentCompany.externalId).to.equal('1:1000');
-      });
+        expect(result.invoiceAccounts[1].addresses).to.have.length(1)
+        const [first] = result.invoiceAccounts[1].addresses
+        expect(first.role).to.equal('billing')
+        expect(first.startDate).to.equal('2015-08-13')
+        expect(first.endDate).to.equal(null)
+        expect(first.address.externalId).to.equal('1:1001')
+        expect(first.agentCompany.externalId).to.equal('1:1000')
+      })
 
       test('there is 1 licence-holder address', async () => {
-        const addresses = result.addresses.filter(row => row.role === 'licenceHolder');
-        expect(addresses).to.have.length(1);
-      });
+        const addresses = result.addresses.filter(row => row.role === 'licenceHolder')
+        expect(addresses).to.have.length(1)
+      })
 
       test('the licence-holder address is mapped from the licence versions', async () => {
-        const [address] = result.addresses.filter(row => row.role === 'licenceHolder');
-        expect(address.startDate).to.equal('2015-04-02');
-        expect(address.endDate).to.equal(null);
-        expect(address.address.externalId).to.equal('1:1000');
-      });
+        const [address] = result.addresses.filter(row => row.role === 'licenceHolder')
+        expect(address.startDate).to.equal('2015-04-02')
+        expect(address.endDate).to.equal(null)
+        expect(address.address.externalId).to.equal('1:1000')
+      })
 
       test('there are 2 billing addresses', async () => {
-        const addresses = result.addresses.filter(row => row.role === 'billing');
-        expect(addresses).to.have.length(2);
-      });
+        const addresses = result.addresses.filter(row => row.role === 'billing')
+        expect(addresses).to.have.length(2)
+      })
 
       test('the billing addresses are mapped from the invoice accounts', async () => {
-        const [first, second] = result.addresses.filter(row => row.role === 'billing');
-        expect(first.startDate).to.equal('2015-04-02');
-        expect(first.endDate).to.equal(null);
-        expect(first.address.externalId).to.equal('1:1000');
-        expect(second.startDate).to.equal('2015-07-06');
-        expect(second.endDate).to.equal(null);
-        expect(second.address.externalId).to.equal('1:1001');
-      });
+        const [first, second] = result.addresses.filter(row => row.role === 'billing')
+        expect(first.startDate).to.equal('2015-04-02')
+        expect(first.endDate).to.equal(null)
+        expect(first.address.externalId).to.equal('1:1000')
+        expect(second.startDate).to.equal('2015-07-06')
+        expect(second.endDate).to.equal(null)
+        expect(second.address.externalId).to.equal('1:1001')
+      })
 
       test('there are 2 contacts', async () => {
-        expect(result.contacts).to.have.length(2);
-      });
+        expect(result.contacts).to.have.length(2)
+      })
 
       test('there is a licence-holder contact', async () => {
-        const [first] = result.contacts;
-        expect(first.role).to.equal('licenceHolder');
-        expect(first.startDate).to.equal('2015-04-02');
-        expect(first.endDate).to.equal(null);
-        expect(first.contact.externalId).to.equal('1:1001');
-      });
+        const [first] = result.contacts
+        expect(first.role).to.equal('licenceHolder')
+        expect(first.startDate).to.equal('2015-04-02')
+        expect(first.endDate).to.equal(null)
+        expect(first.contact.externalId).to.equal('1:1001')
+      })
 
       test('there is a billing contact', async () => {
-        const [, second] = result.contacts;
-        expect(second.role).to.equal('billing');
-        expect(second.startDate).to.equal('2015-04-02');
-        expect(second.endDate).to.equal(null);
-        expect(second.contact.externalId).to.equal('1:1001');
-      });
-    });
-  });
-});
+        const [, second] = result.contacts
+        expect(second.role).to.equal('billing')
+        expect(second.startDate).to.equal('2015-04-02')
+        expect(second.endDate).to.equal(null)
+        expect(second.contact.externalId).to.equal('1:1001')
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/data.js
+++ b/test/modules/licence-import/transform/data.js
@@ -8,7 +8,7 @@ const createLicence = overrides => Object.assign({}, {
   REV_DATE: 'null',
   LAPSED_DATE: 'null',
   AREP_EIUC_CODE: 'SOOTH'
-}, overrides);
+}, overrides)
 
 const createVersion = (licence, overrides) => Object.assign({}, {
   AABL_ID: licence.ID,
@@ -20,7 +20,7 @@ const createVersion = (licence, overrides) => Object.assign({}, {
   ACON_AADD_ID: '1000',
   ISSUE_NO: '100',
   INCR_NO: '1'
-}, overrides);
+}, overrides)
 
 const createParty = overrides => Object.assign({}, {
   ID: '1000',
@@ -30,9 +30,9 @@ const createParty = overrides => Object.assign({}, {
   FORENAME: 'null',
   INITIALS: 'null',
   SALUTATION: 'null'
-}, overrides);
+}, overrides)
 
-const createCompany = overrides => Object.assign({}, createParty({ ID: '1000', APAR_TYPE: 'ORG' }), overrides);
+const createCompany = overrides => Object.assign({}, createParty({ ID: '1000', APAR_TYPE: 'ORG' }), overrides)
 const createPerson = overrides => Object.assign({}, createParty({
   ID: '1001',
   APAR_TYPE: 'PER',
@@ -40,7 +40,7 @@ const createPerson = overrides => Object.assign({}, createParty({
   INITIALS: 'J',
   FORENAME: 'JOHN',
   NAME: 'DOE'
-}), overrides);
+}), overrides)
 
 const createAddress = overrides => Object.assign({}, {
   ID: '1000',
@@ -53,13 +53,13 @@ const createAddress = overrides => Object.assign({}, {
   COUNTY: 'TESTINGSHIRE',
   POSTCODE: 'TT1 1TT',
   COUNTRY: 'ENGLAND'
-}, overrides);
+}, overrides)
 
 const createAgreement = overrides => Object.assign({}, {
   AFSA_CODE: 'S130U',
   EFF_ST_DATE: '14/02/2017',
   EFF_END_DATE: '14/02/2018'
-}, overrides);
+}, overrides)
 
 const createInvoiceAccount = overrides => Object.assign({}, {
   FGAC_REGION_CODE: '1',
@@ -70,7 +70,7 @@ const createInvoiceAccount = overrides => Object.assign({}, {
   licence_holder_party_id: '1000',
   licence_holder_party_name: 'Big Co Ltd.',
   invoice_account_party_name: 'Big Co Ltd.'
-}, overrides);
+}, overrides)
 
 const createChargeVersion = (licence, overrides) => Object.assign({}, {
   AABL_ID: licence.ID,
@@ -82,7 +82,7 @@ const createChargeVersion = (licence, overrides) => Object.assign({}, {
   EFF_END_DATE: 'null',
   ACON_APAR_ID: '1000',
   ACON_AADD_ID: '1000'
-}, overrides);
+}, overrides)
 
 const createPurpose = (licence, overrides) => Object.assign({}, {
   ID: '674',
@@ -103,7 +103,7 @@ const createPurpose = (licence, overrides) => Object.assign({}, {
   TIMELTD_ST_DATE: 'null',
   TIMELTD_END_DATE: 'null',
   NOTES: 'null'
-}, overrides);
+}, overrides)
 
 const createCondition = (purpose, overrides) => Object.assign({}, {
   AABP_ID: purpose.ID,
@@ -113,16 +113,16 @@ const createCondition = (purpose, overrides) => Object.assign({}, {
   PARAM2: 'null',
   TEXT: 'The howling wolf watering hole',
   FGAC_REGION_CODE: purpose.FGAC_REGION_CODE
-}, overrides);
+}, overrides)
 
-exports.createAddress = createAddress;
-exports.createAgreement = createAgreement;
-exports.createChargeVersion = createChargeVersion;
-exports.createCompany = createCompany;
-exports.createInvoiceAccount = createInvoiceAccount;
-exports.createLicence = createLicence;
-exports.createParty = createParty;
-exports.createPerson = createPerson;
-exports.createPurpose = createPurpose;
-exports.createCondition = createCondition;
-exports.createVersion = createVersion;
+exports.createAddress = createAddress
+exports.createAgreement = createAgreement
+exports.createChargeVersion = createChargeVersion
+exports.createCompany = createCompany
+exports.createInvoiceAccount = createInvoiceAccount
+exports.createLicence = createLicence
+exports.createParty = createParty
+exports.createPerson = createPerson
+exports.createPurpose = createPurpose
+exports.createCondition = createCondition
+exports.createVersion = createVersion

--- a/test/modules/licence-import/transform/licence.js
+++ b/test/modules/licence-import/transform/licence.js
@@ -1,11 +1,11 @@
-const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { transformLicence } = require('../../../../src/modules/licence-import/transform/licence');
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { transformLicence } = require('../../../../src/modules/licence-import/transform/licence')
+const { expect } = require('@hapi/code')
 
-const data = require('./data');
+const data = require('./data')
 const createSimpleLicence = () => {
-  const licence = data.createLicence();
-  const purpose = data.createPurpose(licence);
+  const licence = data.createLicence()
+  const purpose = data.createPurpose(licence)
 
   return {
     licence,
@@ -34,13 +34,13 @@ const createSimpleLicence = () => {
       data.createCondition(purpose)
     ],
     roles: []
-  };
-};
+  }
+}
 
 const createComplexLicence = () => {
-  const licence = data.createLicence();
-  const purpose1 = data.createPurpose(licence, { AABV_ISSUE_NO: '1', AABV_INCR_NO: '1', APUR_APPR_CODE: 'A' });
-  const purpose2 = data.createPurpose(licence, { AABV_ISSUE_NO: '1', AABV_INCR_NO: '2', APUR_APPR_CODE: 'B' });
+  const licence = data.createLicence()
+  const purpose1 = data.createPurpose(licence, { AABV_ISSUE_NO: '1', AABV_INCR_NO: '1', APUR_APPR_CODE: 'A' })
+  const purpose2 = data.createPurpose(licence, { AABV_ISSUE_NO: '1', AABV_INCR_NO: '2', APUR_APPR_CODE: 'B' })
   return {
     licence,
     versions: [
@@ -81,180 +81,180 @@ const createComplexLicence = () => {
       { ALRT_CODE: 'RT', EFF_ST_DATE: '09/04/2015', EFF_END_DATE: '12/08/2015', ACON_APAR_ID: '1001', ACON_AADD_ID: '1000', FGAC_REGION_CODE: '1' },
       { ALRT_CODE: 'FM', EFF_ST_DATE: '09/04/2015', EFF_END_DATE: '12/08/2015', ACON_APAR_ID: '1001', ACON_AADD_ID: '1000', FGAC_REGION_CODE: '1' }
     ]
-  };
-};
+  }
+}
 
 experiment('modules/licence-import/transform/licence.js', () => {
-  let result;
+  let result
 
   experiment('transformLicence', () => {
     experiment('for a simple licence', () => {
       beforeEach(async () => {
-        const licenceData = createSimpleLicence();
-        result = transformLicence(licenceData);
-      });
+        const licenceData = createSimpleLicence()
+        result = transformLicence(licenceData)
+      })
 
       test('the licence should contain licence details', async () => {
-        expect(result.licenceNumber).to.equal('01/123');
-        expect(result.startDate).to.equal('2016-04-01');
-        expect(result.externalId).to.equal('1:123');
-        expect(result.endDate).to.equal(null);
-      });
+        expect(result.licenceNumber).to.equal('01/123')
+        expect(result.startDate).to.equal('2016-04-01')
+        expect(result.externalId).to.equal('1:123')
+        expect(result.endDate).to.equal(null)
+      })
 
       test('a document is created for the licence', async () => {
-        const { document } = result;
-        expect(document).to.be.an.object();
-        expect(document.documentRef).to.equal('01/123');
-        expect(document.startDate).to.equal('2016-04-01');
-        expect(document.endDate).to.equal(null);
-        expect(document.externalId).to.equal('1:123');
-        expect(document.roles).to.be.an.array();
-      });
+        const { document } = result
+        expect(document).to.be.an.object()
+        expect(document.documentRef).to.equal('01/123')
+        expect(document.startDate).to.equal('2016-04-01')
+        expect(document.endDate).to.equal(null)
+        expect(document.externalId).to.equal('1:123')
+        expect(document.roles).to.be.an.array()
+      })
 
       test('a document role is created for the licence holder', async () => {
-        const [role] = result.document.roles;
-        expect(role.role).to.equal('licenceHolder');
-        expect(role.startDate).to.equal('2016-04-01');
-        expect(role.endDate).to.equal(null);
-        expect(role.company.externalId).to.equal('1:1000');
-        expect(role.contact).to.equal(null);
-        expect(role.address.externalId).to.equal('1:1000');
-      });
+        const [role] = result.document.roles
+        expect(role.role).to.equal('licenceHolder')
+        expect(role.startDate).to.equal('2016-04-01')
+        expect(role.endDate).to.equal(null)
+        expect(role.company.externalId).to.equal('1:1000')
+        expect(role.contact).to.equal(null)
+        expect(role.address.externalId).to.equal('1:1000')
+      })
 
       test('1 role is created', async () => {
-        expect(result.document.roles.length).to.equal(1);
-      });
+        expect(result.document.roles.length).to.equal(1)
+      })
 
       test('there are no document roles for returns', async () => {
-        expect(result.document.roles.map(role => role.role)).to.only.include(['licenceHolder']);
-      });
+        expect(result.document.roles.map(role => role.role)).to.only.include(['licenceHolder'])
+      })
 
       test('there are no licence agreements', async () => {
-        expect(result.agreements).to.equal([]);
-      });
+        expect(result.agreements).to.equal([])
+      })
 
       test('the licence contains versions data', async () => {
-        expect(result.versions.length).to.equal(1);
-        expect(result.versions[0].increment).to.equal(1);
-        expect(result.versions[0].status).to.equal('current');
-      });
+        expect(result.versions.length).to.equal(1)
+        expect(result.versions[0].increment).to.equal(1)
+        expect(result.versions[0].status).to.equal('current')
+      })
 
       test('the licence contains purpose conditions data', async () => {
-        const condition = result.versions[0].purposes[0].conditions[0];
-        expect(result.versions[0].purposes[0].conditions.length).to.equal(1);
-        expect(condition.code).to.equal('AAG');
-        expect(condition.subcode).to.equal('LLL');
-        expect(condition.param1).to.equal(null);
-        expect(condition.param2).to.equal(null);
-        expect(condition.notes).to.equal('The howling wolf watering hole');
-      });
-    });
+        const condition = result.versions[0].purposes[0].conditions[0]
+        expect(result.versions[0].purposes[0].conditions.length).to.equal(1)
+        expect(condition.code).to.equal('AAG')
+        expect(condition.subcode).to.equal('LLL')
+        expect(condition.param1).to.equal(null)
+        expect(condition.param2).to.equal(null)
+        expect(condition.notes).to.equal('The howling wolf watering hole')
+      })
+    })
 
     experiment('for a licence with many versions', () => {
       beforeEach(async () => {
-        const licenceData = createComplexLicence();
-        result = transformLicence(licenceData);
-      });
+        const licenceData = createComplexLicence()
+        result = transformLicence(licenceData)
+      })
 
       test('a single document is created for the licence', async () => {
-        const { document } = result;
-        expect(document).to.be.an.object();
-        expect(result.document.startDate).to.equal('2016-04-01');
-        expect(result.document.endDate).to.be.null();
-      });
+        const { document } = result
+        expect(document).to.be.an.object()
+        expect(result.document.startDate).to.equal('2016-04-01')
+        expect(result.document.endDate).to.be.null()
+      })
 
       test('the document has 4 roles', async () => {
-        expect(result.document.roles.length).to.equal(4);
-      });
+        expect(result.document.roles.length).to.equal(4)
+      })
 
       test('the first licence version is mapped to a licence holder role with dates constrained by the licence start date', async () => {
-        const [role] = result.document.roles;
-        expect(role.role).to.equal('licenceHolder');
-        expect(role.startDate).to.equal('2016-04-01');
-        expect(role.endDate).to.equal('2015-07-05');
-        expect(role.company.externalId).to.equal('1:1000');
-        expect(role.contact).to.equal(null);
-        expect(role.address.externalId).to.equal('1:1000');
-      });
+        const [role] = result.document.roles
+        expect(role.role).to.equal('licenceHolder')
+        expect(role.startDate).to.equal('2016-04-01')
+        expect(role.endDate).to.equal('2015-07-05')
+        expect(role.company.externalId).to.equal('1:1000')
+        expect(role.contact).to.equal(null)
+        expect(role.address.externalId).to.equal('1:1000')
+      })
 
       test('the second licence version is mapped to a licence holder role with dates constrained by the licence start date', async () => {
-        const [, role] = result.document.roles;
-        expect(role.role).to.equal('licenceHolder');
-        expect(role.startDate).to.equal('2016-04-01');
-        expect(role.endDate).to.equal('2015-08-12');
-        expect(role.company.externalId).to.equal('1:1000');
-        expect(role.contact).to.equal(null);
-        expect(role.address.externalId).to.equal('1:1000');
-      });
+        const [, role] = result.document.roles
+        expect(role.role).to.equal('licenceHolder')
+        expect(role.startDate).to.equal('2016-04-01')
+        expect(role.endDate).to.equal('2015-08-12')
+        expect(role.company.externalId).to.equal('1:1000')
+        expect(role.contact).to.equal(null)
+        expect(role.address.externalId).to.equal('1:1000')
+      })
 
       test('the third licence version is mapped to a licence holder role with dates constrained by the licence start date', async () => {
-        const [,, role] = result.document.roles;
-        expect(role.role).to.equal('licenceHolder');
-        expect(role.startDate).to.equal('2016-04-01');
-        expect(role.endDate).to.be.null();
-        expect(role.company.externalId).to.equal('1:1000');
-        expect(role.contact).to.equal(null);
-        expect(role.address.externalId).to.equal('1:1000');
-      });
+        const [,, role] = result.document.roles
+        expect(role.role).to.equal('licenceHolder')
+        expect(role.startDate).to.equal('2016-04-01')
+        expect(role.endDate).to.be.null()
+        expect(role.company.externalId).to.equal('1:1000')
+        expect(role.contact).to.equal(null)
+        expect(role.address.externalId).to.equal('1:1000')
+      })
 
       test('the document has the correct returns to role', async () => {
-        const [,,, role] = result.document.roles;
-        expect(role.role).to.equal('returnsTo');
-        expect(role.startDate).to.equal('2015-04-09');
-        expect(role.endDate).to.equal('2015-08-12');
-      });
+        const [,,, role] = result.document.roles
+        expect(role.role).to.equal('returnsTo')
+        expect(role.startDate).to.equal('2015-04-09')
+        expect(role.endDate).to.equal('2015-08-12')
+      })
 
       test('the two part tariff agreements are merged where date ranges are adjacent', async () => {
-        expect(result.agreements[0].agreementCode).to.equal('S127');
-        expect(result.agreements[0].startDate).to.equal('2015-04-02');
-        expect(result.agreements[0].endDate).to.equal('2015-08-12');
+        expect(result.agreements[0].agreementCode).to.equal('S127')
+        expect(result.agreements[0].startDate).to.equal('2015-04-02')
+        expect(result.agreements[0].endDate).to.equal('2015-08-12')
 
-        expect(result.agreements[1].agreementCode).to.equal('S127');
-        expect(result.agreements[1].startDate).to.equal('2017-07-01');
-        expect(result.agreements[1].endDate).to.equal(null);
-      });
+        expect(result.agreements[1].agreementCode).to.equal('S127')
+        expect(result.agreements[1].startDate).to.equal('2017-07-01')
+        expect(result.agreements[1].endDate).to.equal(null)
+      })
 
       test('the S130 agreement is added', async () => {
-        expect(result.agreements[2].agreementCode).to.equal('S130');
-        expect(result.agreements[2].startDate).to.equal('2015-04-02');
-        expect(result.agreements[2].endDate).to.equal('2015-07-05');
-      });
+        expect(result.agreements[2].agreementCode).to.equal('S130')
+        expect(result.agreements[2].startDate).to.equal('2015-04-02')
+        expect(result.agreements[2].endDate).to.equal('2015-07-05')
+      })
 
       test('the versions contain the purposes', async () => {
-        expect(result.versions[0].purposes.length).to.equal(1);
-        expect(result.versions[1].purposes.length).to.equal(1);
-        expect(result.versions[2].purposes.length).to.equal(2);
+        expect(result.versions[0].purposes.length).to.equal(1)
+        expect(result.versions[1].purposes.length).to.equal(1)
+        expect(result.versions[2].purposes.length).to.equal(2)
 
-        expect(result.versions[0].purposes[0].purposePrimary).to.equal('A');
-        expect(result.versions[1].purposes[0].purposePrimary).to.equal('B');
-        expect(result.versions[2].purposes[0].purposePrimary).to.equal('C');
-        expect(result.versions[2].purposes[1].purposePrimary).to.equal('D');
-      });
+        expect(result.versions[0].purposes[0].purposePrimary).to.equal('A')
+        expect(result.versions[1].purposes[0].purposePrimary).to.equal('B')
+        expect(result.versions[2].purposes[0].purposePrimary).to.equal('C')
+        expect(result.versions[2].purposes[1].purposePrimary).to.equal('D')
+      })
 
       test('the licence contains the correct purpose conditions data', async () => {
-        const condition1 = result.versions[1].purposes[0].conditions[0];
-        const condition2 = result.versions[1].purposes[0].conditions[1];
-        expect(result.versions[1].purposes[0].conditions.length).to.equal(2);
-        expect(condition1.code).to.equal('AAG');
-        expect(condition1.subcode).to.equal('LLL');
-        expect(condition1.param1).to.equal(null);
-        expect(condition1.param2).to.equal(null);
-        expect(condition1.notes).to.equal(null);
+        const condition1 = result.versions[1].purposes[0].conditions[0]
+        const condition2 = result.versions[1].purposes[0].conditions[1]
+        expect(result.versions[1].purposes[0].conditions.length).to.equal(2)
+        expect(condition1.code).to.equal('AAG')
+        expect(condition1.subcode).to.equal('LLL')
+        expect(condition1.param1).to.equal(null)
+        expect(condition1.param2).to.equal(null)
+        expect(condition1.notes).to.equal(null)
 
-        expect(condition2.code).to.equal('ABC');
-        expect(condition2.subcode).to.equal('XYZ');
-        expect(condition2.param1).to.equal('param 1 text');
-        expect(condition2.param2).to.equal('param 2 text');
-        expect(condition2.notes).to.equal('more plain test text');
-      });
-    });
+        expect(condition2.code).to.equal('ABC')
+        expect(condition2.subcode).to.equal('XYZ')
+        expect(condition2.param1).to.equal('param 1 text')
+        expect(condition2.param2).to.equal('param 2 text')
+        expect(condition2.notes).to.equal('more plain test text')
+      })
+    })
 
     experiment('isWaterUndertaker', () => {
       test('is set to false when the AREP_EIUC_CODE does not end with "SWC"', async () => {
-        const rawData = createSimpleLicence();
-        const transformed = transformLicence(rawData);
-        expect(transformed.isWaterUndertaker).to.be.false();
-      });
-    });
-  });
-});
+        const rawData = createSimpleLicence()
+        const transformed = transformLicence(rawData)
+        expect(transformed.isWaterUndertaker).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/agreement.js
+++ b/test/modules/licence-import/transform/mappers/agreement.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const { mapAgreements } = require('../../../../../src/modules/licence-import/transform/mappers/agreement');
+const { mapAgreements } = require('../../../../../src/modules/licence-import/transform/mappers/agreement')
 
 experiment('modules/licence-import/mappers/agreement', () => {
   const createAgreement = (overrides = {}) => ({
@@ -13,56 +13,56 @@ experiment('modules/licence-import/mappers/agreement', () => {
     charge_version_end_date: overrides.chargeVersionEndDate || 'null',
     charge_version_start_date: overrides.chargeVersionStartDate || '01/01/2020',
     version_number: overrides.versionNumber || 1
-  });
+  })
 
   test('maps agreements with no end date', async () => {
-    const result = mapAgreements([createAgreement()]);
-    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: null }]);
-  });
+    const result = mapAgreements([createAgreement()])
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: null }])
+  })
 
   test('maps agreements with an end date', async () => {
-    const result = mapAgreements([createAgreement({ endDate: '01/06/2021' })]);
-    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
-  });
+    const result = mapAgreements([createAgreement({ endDate: '01/06/2021' })])
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }])
+  })
 
   test('maps agreements with a charge version end date', async () => {
-    const result = mapAgreements([createAgreement({ chargeVersionEndDate: '01/06/2021' })]);
-    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
-  });
+    const result = mapAgreements([createAgreement({ chargeVersionEndDate: '01/06/2021' })])
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }])
+  })
 
   test('uses the earliest end date when there is an end date and charge version end date', async () => {
-    const result = mapAgreements([createAgreement({ endDate: '02/07/2021', chargeVersionEndDate: '01/06/2021' })]);
-    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }]);
-  });
+    const result = mapAgreements([createAgreement({ endDate: '02/07/2021', chargeVersionEndDate: '01/06/2021' })])
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-01', endDate: '2021-06-01' }])
+  })
 
   test('merges adjacent date ranges with the same code', async () => {
     const agreements = [
       createAgreement({ code: 'S130', endDate: '01/05/2020', versionNumber: 1 }),
       createAgreement({ endDate: '01/06/2021', versionNumber: 2 }),
       createAgreement({ startDate: '02/06/2021', versionNumber: 3 })
-    ];
-    const result = mapAgreements(agreements);
+    ]
+    const result = mapAgreements(agreements)
     expect(result[0]).to.equal({
       agreementCode: 'S130',
       startDate: '2020-01-01',
       endDate: '2020-05-01'
-    });
-    expect(result[1]).to.equal({ agreementCode: 'S127', startDate: '2020-01-01', endDate: null });
-  });
+    })
+    expect(result[1]).to.equal({ agreementCode: 'S127', startDate: '2020-01-01', endDate: null })
+  })
 
   test('uses the latest start date when the charge version starts after the agreement start date', async () => {
-    const result = mapAgreements([createAgreement({ chargeVersionStartDate: '02/01/2020' })]);
-    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-02', endDate: null }]);
-  });
+    const result = mapAgreements([createAgreement({ chargeVersionStartDate: '02/01/2020' })])
+    expect(result).to.equal([{ agreementCode: 'S127', startDate: '2020-01-02', endDate: null }])
+  })
 
   test('merges duplicate agreements', async () => {
     const agreements = [
       createAgreement(),
       createAgreement()
-    ];
-    const result = mapAgreements(agreements);
-    expect(result).to.be.an.array().length(1);
-  });
+    ]
+    const result = mapAgreements(agreements)
+    expect(result).to.be.an.array().length(1)
+  })
 
   test('merges agreements with different date ranges on different elements', async () => {
     const agreements = [
@@ -71,10 +71,10 @@ experiment('modules/licence-import/mappers/agreement', () => {
       createAgreement({ startDate: '11/03/1993', chargeVersionStartDate: '01/04/2006', chargeVersionEndDate: '31/03/2014', versionNumber: 2 }),
       createAgreement({ startDate: '11/10/1978', chargeVersionStartDate: '01/04/2006', chargeVersionEndDate: '31/03/2014', versionNumber: 2 }),
       createAgreement({ startDate: '01/04/2014', chargeVersionStartDate: '01/04/2014', versionNumber: 4 })
-    ];
-    const result = mapAgreements(agreements);
-    expect(result).to.be.an.array().length(1);
-    expect(result[0].startDate).to.equal('1978-10-11');
-    expect(result[0].endDate).to.equal(null);
-  });
-});
+    ]
+    const result = mapAgreements(agreements)
+    expect(result).to.be.an.array().length(1)
+    expect(result[0].startDate).to.equal('1978-10-11')
+    expect(result[0].endDate).to.equal(null)
+  })
+})

--- a/test/modules/licence-import/transform/mappers/company-addresses.js
+++ b/test/modules/licence-import/transform/mappers/company-addresses.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const { mapCompanyAddresses } = require('../../../../../src/modules/licence-import/transform/mappers/company-address');
+const { mapCompanyAddresses } = require('../../../../../src/modules/licence-import/transform/mappers/company-address')
 
 experiment('modules/licence-import/mappers/company-addresses', () => {
-  let context, result;
+  let context, result
 
   beforeEach(async () => {
     context = {
@@ -30,8 +30,8 @@ experiment('modules/licence-import/mappers/company-addresses', () => {
           }
         }
       }
-    };
-  });
+    }
+  })
 
   experiment('mapCompanyAddresses', () => {
     experiment('for licence roles', async () => {
@@ -48,24 +48,24 @@ experiment('modules/licence-import/mappers/company-addresses', () => {
           EFF_END_DATE: 'null',
           FGAC_REGION_CODE: 1,
           ACON_AADD_ID: 101
-        }], context);
-      });
+        }], context)
+      })
 
       test('maps the first returns to role', async () => {
-        const [role] = result;
-        expect(role.role).to.equal('returnsTo');
-        expect(role.startDate).to.equal('2020-01-01');
-        expect(role.endDate).to.equal('2020-06-01');
-        expect(role.address).to.equal(context.addresses[1][100]);
-      });
+        const [role] = result
+        expect(role.role).to.equal('returnsTo')
+        expect(role.startDate).to.equal('2020-01-01')
+        expect(role.endDate).to.equal('2020-06-01')
+        expect(role.address).to.equal(context.addresses[1][100])
+      })
 
       test('maps the second returns to role', async () => {
-        const [, role] = result;
-        expect(role.role).to.equal('returnsTo');
-        expect(role.startDate).to.equal('2020-06-02');
-        expect(role.endDate).to.equal(null);
-        expect(role.address).to.equal(context.addresses[1][101]);
-      });
-    });
-  });
-});
+        const [, role] = result
+        expect(role.role).to.equal('returnsTo')
+        expect(role.startDate).to.equal('2020-06-02')
+        expect(role.endDate).to.equal(null)
+        expect(role.address).to.equal(context.addresses[1][101])
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/company-contact.js
+++ b/test/modules/licence-import/transform/mappers/company-contact.js
@@ -1,33 +1,33 @@
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const companyContact = require('../../../../../src/modules/licence-import/transform/mappers/company-contact');
+const companyContact = require('../../../../../src/modules/licence-import/transform/mappers/company-contact')
 
-const data = require('../data');
+const data = require('../data')
 
 const createData = () => {
-  const licence = data.createLicence();
+  const licence = data.createLicence()
   return {
     chargeVersions: data.createChargeVersion(licence),
     licenceVersions: data.createVersion(licence),
     contact: {
       externalId: '1:1000'
     }
-  };
-};
+  }
+}
 
 experiment('modules/licence-import/mappers/company-contact', () => {
   experiment('mapCompanyContacts', () => {
     test('when the contact passed in is null, an empty array is always returned', async () => {
-      const { chargeVersions, licenceVersions } = createData();
-      const result = companyContact.mapCompanyContacts(null, chargeVersions, licenceVersions);
-      expect(result).to.equal([]);
-    });
+      const { chargeVersions, licenceVersions } = createData()
+      const result = companyContact.mapCompanyContacts(null, chargeVersions, licenceVersions)
+      expect(result).to.equal([])
+    })
 
     test('when there are no charge versions or licence versions, an empty array is returned', async () => {
-      const { contact } = createData();
-      const result = companyContact.mapCompanyContacts(contact, [], []);
-      expect(result).to.equal([]);
-    });
-  });
-});
+      const { contact } = createData()
+      const result = companyContact.mapCompanyContacts(contact, [], [])
+      expect(result).to.equal([])
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/contact.js
+++ b/test/modules/licence-import/transform/mappers/contact.js
@@ -1,7 +1,7 @@
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const contact = require('../../../../../src/modules/licence-import/transform/mappers/contact');
+const contact = require('../../../../../src/modules/licence-import/transform/mappers/contact')
 
 experiment('modules/licence-import/mappers/contact', () => {
   experiment('mapContact', () => {
@@ -9,9 +9,9 @@ experiment('modules/licence-import/mappers/contact', () => {
       const result = contact.mapContact({
         NAME: 'BIG CO LTD',
         APAR_TYPE: 'ORG'
-      });
-      expect(result).to.equal(null);
-    });
+      })
+      expect(result).to.equal(null)
+    })
 
     test('for a person with no forename, the initials are used as the first name', async () => {
       const result = contact.mapContact({
@@ -22,14 +22,14 @@ experiment('modules/licence-import/mappers/contact', () => {
         FORENAME: 'null',
         INITIALS: 'J',
         APAR_TYPE: 'PER'
-      });
+      })
 
-      expect(result.externalId).to.equal('2:5');
-      expect(result.lastName).to.equal('DOE');
-      expect(result.firstName).to.equal(null);
-      expect(result.initials).to.equal('J');
-      expect(result.salutation).to.equal('MR');
-    });
+      expect(result.externalId).to.equal('2:5')
+      expect(result.lastName).to.equal('DOE')
+      expect(result.firstName).to.equal(null)
+      expect(result.initials).to.equal('J')
+      expect(result.salutation).to.equal('MR')
+    })
 
     test('for a person with a forename, the initials are ignored', async () => {
       const result = contact.mapContact({
@@ -40,12 +40,12 @@ experiment('modules/licence-import/mappers/contact', () => {
         FORENAME: 'JOHN',
         INITIALS: 'J',
         APAR_TYPE: 'PER'
-      });
+      })
 
-      expect(result.externalId).to.equal('2:5');
-      expect(result.lastName).to.equal('DOE');
-      expect(result.firstName).to.equal('JOHN');
-      expect(result.salutation).to.equal('MR');
-    });
-  });
-});
+      expect(result.externalId).to.equal('2:5')
+      expect(result.lastName).to.equal('DOE')
+      expect(result.firstName).to.equal('JOHN')
+      expect(result.salutation).to.equal('MR')
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/date.js
+++ b/test/modules/licence-import/transform/mappers/date.js
@@ -1,20 +1,20 @@
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const date = require('../../../../../src/modules/licence-import/transform/mappers/date');
+const date = require('../../../../../src/modules/licence-import/transform/mappers/date')
 
 experiment('modules/licence-import/mappers/date', () => {
   experiment('mapNaldDate', () => {
     test('a null string is mapped to null', async () => {
-      const result = date.mapNaldDate('null');
-      expect(result).to.equal(null);
-    });
+      const result = date.mapNaldDate('null')
+      expect(result).to.equal(null)
+    })
 
     test('a date in NALD format is mapped to the service format', async () => {
-      const result = date.mapNaldDate('14/02/2019');
-      expect(result).to.equal('2019-02-14');
-    });
-  });
+      const result = date.mapNaldDate('14/02/2019')
+      expect(result).to.equal('2019-02-14')
+    })
+  })
 
   experiment('getMinDate', () => {
     test('the earliest valid date is returned', async () => {
@@ -23,23 +23,23 @@ experiment('modules/licence-import/mappers/date', () => {
         'null',
         '2017-05-06',
         '2019-02-01'
-      ];
+      ]
 
-      const result = date.getMinDate(dates);
-      expect(result).to.equal('2017-05-06');
-    });
+      const result = date.getMinDate(dates)
+      expect(result).to.equal('2017-05-06')
+    })
 
     test('when there are no valid dates, null is returned', async () => {
       const dates = [
         'My birthday',
         'null',
         'Last Thursday'
-      ];
+      ]
 
-      const result = date.getMinDate(dates);
-      expect(result).to.equal(null);
-    });
-  });
+      const result = date.getMinDate(dates)
+      expect(result).to.equal(null)
+    })
+  })
 
   experiment('getMaxDate', () => {
     test('the latest valid date is returned', async () => {
@@ -48,54 +48,54 @@ experiment('modules/licence-import/mappers/date', () => {
         'null',
         '2017-05-06',
         '2019-02-01'
-      ];
+      ]
 
-      const result = date.getMaxDate(dates);
-      expect(result).to.equal('2019-02-01');
-    });
+      const result = date.getMaxDate(dates)
+      expect(result).to.equal('2019-02-01')
+    })
 
     test('when there are no valid dates, null is returned', async () => {
       const dates = [
         'My birthday',
         'null',
         'Last Thursday'
-      ];
+      ]
 
-      const result = date.getMaxDate(dates);
-      expect(result).to.equal(null);
-    });
-  });
+      const result = date.getMaxDate(dates)
+      expect(result).to.equal(null)
+    })
+  })
 
   experiment('mapTransferDate', () => {
     test('converts a full datestamp in NALD format to a date in YYYY-MM-DD format', async () => {
-      const result = date.mapTransferDate('04/12/2015 12:52:00');
-      expect(result).to.equal('2015-12-04');
-    });
-  });
+      const result = date.mapTransferDate('04/12/2015 12:52:00')
+      expect(result).to.equal('2015-12-04')
+    })
+  })
 
   experiment('getPreviousDay', () => {
     test('gets a date 1 day before the specified date', async () => {
-      const result = date.getPreviousDay('2018-06-07');
-      expect(result).to.equal('2018-06-06');
-    });
-  });
+      const result = date.getPreviousDay('2018-06-07')
+      expect(result).to.equal('2018-06-06')
+    })
+  })
 
   experiment('mapTransferDate', () => {
     test('converts a full datestamp in NALD format to a date in YYYY-MM-DD format', async () => {
-      const result = date.mapTransferDate('04/12/2015 12:52:00');
-      expect(result).to.equal('2015-12-04');
-    });
-  });
+      const result = date.mapTransferDate('04/12/2015 12:52:00')
+      expect(result).to.equal('2015-12-04')
+    })
+  })
 
   experiment('mapIsoDateToNald', () => {
     test('maps ISO format to NALD format', async () => {
-      const result = date.mapIsoDateToNald('2018-06-07');
-      expect(result).to.equal('07/06/2018');
-    });
+      const result = date.mapIsoDateToNald('2018-06-07')
+      expect(result).to.equal('07/06/2018')
+    })
 
     test('maps true null to string "null"', async () => {
-      const result = date.mapIsoDateToNald(null);
-      expect(result).to.equal('null');
-    });
-  });
-});
+      const result = date.mapIsoDateToNald(null)
+      expect(result).to.equal('null')
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/documents.js
+++ b/test/modules/licence-import/transform/mappers/documents.js
@@ -1,18 +1,18 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
-const mapper = require('../../../../../src/modules/licence-import/transform/mappers/document');
+const mapper = require('../../../../../src/modules/licence-import/transform/mappers/document')
 
 experiment('modules/licence-import/transform/mappers/document', () => {
   experiment('.mapLicenceToDocument', () => {
-    let licence, document;
+    let licence, document
 
     beforeEach(async () => {
       licence = {
@@ -21,18 +21,18 @@ experiment('modules/licence-import/transform/mappers/document', () => {
         endDate: '2021-01-01',
         externalId: 'external-id',
         _nald: { foo: 'bar' }
-      };
+      }
 
-      document = mapper.mapLicenceToDocument(licence);
-    });
+      document = mapper.mapLicenceToDocument(licence)
+    })
 
     test('maps the licence to a document', async () => {
-      expect(document.documentRef).to.equal(licence.licenceNumber);
-      expect(document.startDate).to.equal(licence.startDate);
-      expect(document.endDate).to.equal(licence.endDate);
-      expect(document.externalId).to.equal(licence.externalId);
-      expect(document.roles).to.be.an.empty().array();
-      expect(document._nald).to.equal(licence._nald);
-    });
-  });
-});
+      expect(document.documentRef).to.equal(licence.licenceNumber)
+      expect(document.startDate).to.equal(licence.startDate)
+      expect(document.endDate).to.equal(licence.endDate)
+      expect(document.externalId).to.equal(licence.externalId)
+      expect(document.roles).to.be.an.empty().array()
+      expect(document._nald).to.equal(licence._nald)
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/licence-purpose.js
+++ b/test/modules/licence-import/transform/mappers/licence-purpose.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
 const {
   beforeEach,
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const data = require('../data');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const data = require('../data')
 
-const { mapLicencePurpose } = require('../../../../../src/modules/licence-import/transform/mappers/licence-purpose');
+const { mapLicencePurpose } = require('../../../../../src/modules/licence-import/transform/mappers/licence-purpose')
 
 experiment('modules/licence-import/transform/mappers/licence-purpose', () => {
   experiment('.mapLicencePurpose', () => {
-    let mapped;
-    let licence;
-    let purpose;
+    let mapped
+    let licence
+    let purpose
 
     beforeEach(async () => {
       licence = {
@@ -22,7 +22,7 @@ experiment('modules/licence-import/transform/mappers/licence-purpose', () => {
         FGAC_REGION_CODE: '6',
         STATUS: 'CURR',
         EFF_ST_DATE: '22/12/1989'
-      };
+      }
 
       purpose = data.createVersion(licence, {
         ID: '112233',
@@ -41,89 +41,89 @@ experiment('modules/licence-import/transform/mappers/licence-purpose', () => {
         TIMELTD_END_DATE: 'null',
         NOTES: 'test notes',
         FGAC_REGION_CODE: '6'
-      });
+      })
 
-      mapped = mapLicencePurpose(purpose);
-    });
+      mapped = mapLicencePurpose(purpose)
+    })
 
     test('maps the issue number', async () => {
-      expect(mapped.issue).to.equal(100);
-    });
+      expect(mapped.issue).to.equal(100)
+    })
 
     test('maps the increment number', async () => {
-      expect(mapped.increment).to.equal(1);
-    });
+      expect(mapped.increment).to.equal(1)
+    })
 
     test('maps the primary purpose', async () => {
-      expect(mapped.purposePrimary).to.equal('A');
-    });
+      expect(mapped.purposePrimary).to.equal('A')
+    })
 
     test('maps the secondary purpose', async () => {
-      expect(mapped.purposeSecondary).to.equal('ABC');
-    });
+      expect(mapped.purposeSecondary).to.equal('ABC')
+    })
 
     test('maps the purpose use', async () => {
-      expect(mapped.purposeUse).to.equal('123');
-    });
+      expect(mapped.purposeUse).to.equal('123')
+    })
 
     test('maps the abstraction period start day', async () => {
-      expect(mapped.abstractionPeriodStartDay).to.equal(20);
-    });
+      expect(mapped.abstractionPeriodStartDay).to.equal(20)
+    })
 
     test('maps the abstraction period start month', async () => {
-      expect(mapped.abstractionPeriodStartMonth).to.equal(10);
-    });
+      expect(mapped.abstractionPeriodStartMonth).to.equal(10)
+    })
 
     test('maps the abstraction period end day', async () => {
-      expect(mapped.abstractionPeriodEndDay).to.equal(21);
-    });
+      expect(mapped.abstractionPeriodEndDay).to.equal(21)
+    })
 
     test('maps the abstraction period end month', async () => {
-      expect(mapped.abstractionPeriodEndMonth).to.equal(11);
-    });
+      expect(mapped.abstractionPeriodEndMonth).to.equal(11)
+    })
 
     test('maps the time limited start date to null when string null', async () => {
-      expect(mapped.timeLimitedStartDate).to.equal(null);
-    });
+      expect(mapped.timeLimitedStartDate).to.equal(null)
+    })
 
     test('maps the time limited end date to null when string null', async () => {
-      expect(mapped.timeLimitedEndDate).to.equal(null);
-    });
+      expect(mapped.timeLimitedEndDate).to.equal(null)
+    })
 
     test('maps the time limited start date when not string null', async () => {
-      purpose.TIMELTD_ST_DATE = '01/01/2000';
-      mapped = mapLicencePurpose(purpose);
-      expect(mapped.timeLimitedStartDate).to.equal('2000-01-01');
-    });
+      purpose.TIMELTD_ST_DATE = '01/01/2000'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.timeLimitedStartDate).to.equal('2000-01-01')
+    })
 
     test('maps the time limited end date when not string null', async () => {
-      purpose.TIMELTD_END_DATE = '01/01/2000';
-      mapped = mapLicencePurpose(purpose);
-      expect(mapped.timeLimitedEndDate).to.equal('2000-01-01');
-    });
+      purpose.TIMELTD_END_DATE = '01/01/2000'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.timeLimitedEndDate).to.equal('2000-01-01')
+    })
 
     test('maps the notes', async () => {
-      expect(mapped.notes).to.equal('test notes');
-    });
+      expect(mapped.notes).to.equal('test notes')
+    })
 
     test('maps the notes to null when string null', async () => {
-      purpose.NOTES = 'null';
-      mapped = mapLicencePurpose(purpose);
-      expect(mapped.notes).to.equal(null);
-    });
+      purpose.NOTES = 'null'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.notes).to.equal(null)
+    })
 
     test('maps the annual quantity', async () => {
-      expect(mapped.annualQuantity).to.equal(1000);
-    });
+      expect(mapped.annualQuantity).to.equal(1000)
+    })
 
     test('maps the notes to null when string null', async () => {
-      purpose.ANNUAL_QTY = 'null';
-      mapped = mapLicencePurpose(purpose);
-      expect(mapped.annualQuantity).to.equal(null);
-    });
+      purpose.ANNUAL_QTY = 'null'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.annualQuantity).to.equal(null)
+    })
 
     test('creates an external id', async () => {
-      expect(mapped.externalId).to.equal('6:112233');
-    });
-  });
-});
+      expect(mapped.externalId).to.equal('6:112233')
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/licence-version.js
+++ b/test/modules/licence-import/transform/mappers/licence-version.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
 const {
   beforeEach,
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const data = require('../data');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const data = require('../data')
 
-const { mapLicenceVersion } = require('../../../../../src/modules/licence-import/transform/mappers/licence-version');
+const { mapLicenceVersion } = require('../../../../../src/modules/licence-import/transform/mappers/licence-version')
 
 experiment('modules/licence-import/transform/mappers/licence-version', () => {
   experiment('.mapLicenceVersion', () => {
-    let mapped;
-    let licence;
-    let version;
+    let mapped
+    let licence
+    let version
 
     beforeEach(async () => {
       licence = {
@@ -22,59 +22,59 @@ experiment('modules/licence-import/transform/mappers/licence-version', () => {
         FGAC_REGION_CODE: '6',
         STATUS: 'CURR',
         EFF_ST_DATE: '22/12/1989'
-      };
+      }
 
       version = data.createVersion(licence, {
         ISSUE_NO: '101',
         INCR_NO: '2',
         EFF_ST_DATE: '22/12/1989',
         EFF_END_DATE: '22/12/1991'
-      });
-      mapped = mapLicenceVersion(version);
-    });
+      })
+      mapped = mapLicenceVersion(version)
+    })
 
     test('maps the issue number', async () => {
-      expect(mapped.issue).to.equal(101);
-    });
+      expect(mapped.issue).to.equal(101)
+    })
 
     test('maps the increment number', async () => {
-      expect(mapped.increment).to.equal(2);
-    });
+      expect(mapped.increment).to.equal(2)
+    })
 
     test('maps the status from CURR to current', async () => {
-      expect(mapped.status).to.equal('current');
-    });
+      expect(mapped.status).to.equal('current')
+    })
 
     test('maps the status from DRAFT to draft', async () => {
-      version = data.createVersion(licence, { STATUS: 'DRAFT' });
-      mapped = mapLicenceVersion(version);
-      expect(mapped.status).to.equal('draft');
-    });
+      version = data.createVersion(licence, { STATUS: 'DRAFT' })
+      mapped = mapLicenceVersion(version)
+      expect(mapped.status).to.equal('draft')
+    })
 
     test('maps the status from SUPER to superseded', async () => {
-      version = data.createVersion(licence, { STATUS: 'SUPER' });
-      mapped = mapLicenceVersion(version);
-      expect(mapped.status).to.equal('superseded');
-    });
+      version = data.createVersion(licence, { STATUS: 'SUPER' })
+      mapped = mapLicenceVersion(version)
+      expect(mapped.status).to.equal('superseded')
+    })
 
     test('maps the start date to the required format', async () => {
-      expect(mapped.startDate).to.equal('1989-12-22');
-    });
+      expect(mapped.startDate).to.equal('1989-12-22')
+    })
 
     test('maps the end date to the required format', async () => {
-      expect(mapped.endDate).to.equal('1991-12-22');
-    });
+      expect(mapped.endDate).to.equal('1991-12-22')
+    })
 
     test('maps the end date when null', async () => {
-      version = data.createVersion(licence, { EFF_END_DATE: 'null' });
-      mapped = mapLicenceVersion(version);
-      expect(mapped.endDate).to.equal(null);
-    });
+      version = data.createVersion(licence, { EFF_END_DATE: 'null' })
+      mapped = mapLicenceVersion(version)
+      expect(mapped.endDate).to.equal(null)
+    })
 
     test('creates an external id', async () => {
       // expected format is FGAC_REGION_CODE:AABL_ID:ISSUE_NO:INCR_NO
-      expect(mapped.externalId).to.equal('6:123:101:2');
-    });
+      expect(mapped.externalId).to.equal('6:123:101:2')
+    })
 
     experiment('when there are purposes', () => {
       beforeEach(async () => {
@@ -82,19 +82,19 @@ experiment('modules/licence-import/transform/mappers/licence-version', () => {
           { issue: 101, increment: 2, notes: '101:2:a' },
           { issue: 101, increment: 2, notes: '101:2:b' },
           { issue: 101, increment: 1, notes: '101:1' }
-        ];
+        ]
 
-        mapped = mapLicenceVersion(version, purposes);
-      });
+        mapped = mapLicenceVersion(version, purposes)
+      })
 
       test('the expected number of purposes are extracted', async () => {
-        expect(mapped.purposes.length).to.equal(2);
-      });
+        expect(mapped.purposes.length).to.equal(2)
+      })
 
       test('only the purposes with matching issue and increment are mapped', async () => {
-        expect(mapped.purposes.find(p => p.notes === '101:2:a')).to.exist();
-        expect(mapped.purposes.find(p => p.notes === '101:2:b')).to.exist();
-      });
-    });
-  });
-});
+        expect(mapped.purposes.find(p => p.notes === '101:2:a')).to.exist()
+        expect(mapped.purposes.find(p => p.notes === '101:2:b')).to.exist()
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/licence.js
+++ b/test/modules/licence-import/transform/mappers/licence.js
@@ -1,28 +1,28 @@
 const {
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const { mapLicence } = require('../../../../../src/modules/licence-import/transform/mappers/licence');
+const { mapLicence } = require('../../../../../src/modules/licence-import/transform/mappers/licence')
 
 experiment('modules/licence-import/transform/mappers/licence', () => {
   experiment('.mapLicence', () => {
     test('sets the licenceNumber', async () => {
-      const licenceNumber = 'test-licence';
-      const input = { LIC_NO: licenceNumber, AREP_EIUC_CODE: 'ANOTH' };
-      const mapped = mapLicence(input);
-      expect(mapped.licenceNumber).to.equal(licenceNumber);
-    });
+      const licenceNumber = 'test-licence'
+      const input = { LIC_NO: licenceNumber, AREP_EIUC_CODE: 'ANOTH' }
+      const mapped = mapLicence(input)
+      expect(mapped.licenceNumber).to.equal(licenceNumber)
+    })
 
     test('sets the startDate when the original effective date is not null', async () => {
-      const input = { ORIG_EFF_DATE: '01/02/2003', AREP_EIUC_CODE: 'ANOTH' };
-      const mapped = mapLicence(input);
-      expect(mapped.startDate).to.equal('2003-02-01');
-    });
+      const input = { ORIG_EFF_DATE: '01/02/2003', AREP_EIUC_CODE: 'ANOTH' }
+      const mapped = mapLicence(input)
+      expect(mapped.startDate).to.equal('2003-02-01')
+    })
 
     test('gets the start date from the earliest non-draft licence version if the original effective date is null', async () => {
-      const licence = { ORIG_EFF_DATE: 'null', AREP_EIUC_CODE: 'ANOTH' };
+      const licence = { ORIG_EFF_DATE: 'null', AREP_EIUC_CODE: 'ANOTH' }
       const licenceVersions = [{
         STATUS: 'DRAFT',
         EFF_ST_DATE: '01/01/2018'
@@ -32,10 +32,10 @@ experiment('modules/licence-import/transform/mappers/licence', () => {
       }, {
         STATUS: 'CURR',
         EFF_ST_DATE: '03/01/2018'
-      }];
-      const mapped = mapLicence(licence, licenceVersions);
-      expect(mapped.startDate).to.equal('2018-01-02');
-    });
+      }]
+      const mapped = mapLicence(licence, licenceVersions)
+      expect(mapped.startDate).to.equal('2018-01-02')
+    })
 
     test('sets the end date to the minimum date', async () => {
       const input = {
@@ -43,80 +43,80 @@ experiment('modules/licence-import/transform/mappers/licence', () => {
         REV_DATE: 'null',
         LAPSED_DATE: '01/01/2005',
         AREP_EIUC_CODE: 'ANOTH'
-      };
+      }
 
-      const mapped = mapLicence(input);
+      const mapped = mapLicence(input)
 
-      expect(mapped.endDate).to.equal('2003-01-01');
-    });
+      expect(mapped.endDate).to.equal('2003-01-01')
+    })
 
     test('sets documents to an empty array', async () => {
-      const input = { AREP_EIUC_CODE: 'ANOTH' };
-      const mapped = mapLicence(input);
-      expect(mapped.documents).to.equal([]);
-    });
+      const input = { AREP_EIUC_CODE: 'ANOTH' }
+      const mapped = mapLicence(input)
+      expect(mapped.documents).to.equal([])
+    })
 
     test('sets agreements to an empty array', async () => {
-      const input = { AREP_EIUC_CODE: 'ANOTH' };
-      const mapped = mapLicence(input);
-      expect(mapped.agreements).to.equal([]);
-    });
+      const input = { AREP_EIUC_CODE: 'ANOTH' }
+      const mapped = mapLicence(input)
+      expect(mapped.agreements).to.equal([])
+    })
 
     test('creates an external id', async () => {
       const input = {
         FGAC_REGION_CODE: 'region',
         ID: 'id',
         AREP_EIUC_CODE: 'ANOTH'
-      };
-      const mapped = mapLicence(input);
-      expect(mapped.externalId).to.equal('region:id');
-    });
+      }
+      const mapped = mapLicence(input)
+      expect(mapped.externalId).to.equal('region:id')
+    })
 
     experiment('.isWaterUndertaker', () => {
       test('is false if the AREP_EIUC_CODE does not end with "SWC"', async () => {
         const input = {
           AREP_EIUC_CODE: 'SOOTH'
-        };
-        const mapped = mapLicence(input);
-        expect(mapped.isWaterUndertaker).to.be.false();
-      });
+        }
+        const mapped = mapLicence(input)
+        expect(mapped.isWaterUndertaker).to.be.false()
+      })
 
       test('is true if the AREP_EIUC_CODE ends with "SWC"', async () => {
         const input = {
           AREP_EIUC_CODE: 'SOSWC'
-        };
-        const mapped = mapLicence(input);
-        expect(mapped.isWaterUndertaker).to.be.true();
-      });
-    });
+        }
+        const mapped = mapLicence(input)
+        expect(mapped.isWaterUndertaker).to.be.true()
+      })
+    })
 
     test('sets the expired date', async () => {
-      const input = { EXPIRY_DATE: '31/10/2012', AREP_EIUC_CODE: 'ANOTH' };
+      const input = { EXPIRY_DATE: '31/10/2012', AREP_EIUC_CODE: 'ANOTH' }
 
-      const mapped = mapLicence(input);
-      expect(mapped.expiredDate).to.equal('2012-10-31');
-    });
+      const mapped = mapLicence(input)
+      expect(mapped.expiredDate).to.equal('2012-10-31')
+    })
 
     test('sets the lapsed date', async () => {
-      const input = { LAPSED_DATE: '01/05/2009', AREP_EIUC_CODE: 'ANOTH' };
+      const input = { LAPSED_DATE: '01/05/2009', AREP_EIUC_CODE: 'ANOTH' }
 
-      const mapped = mapLicence(input);
-      expect(mapped.lapsedDate).to.equal('2009-05-01');
-    });
+      const mapped = mapLicence(input)
+      expect(mapped.lapsedDate).to.equal('2009-05-01')
+    })
 
     test('sets the revoked date', async () => {
-      const input = { REV_DATE: '30/06/2010', AREP_EIUC_CODE: 'ANOTH' };
+      const input = { REV_DATE: '30/06/2010', AREP_EIUC_CODE: 'ANOTH' }
 
-      const mapped = mapLicence(input);
-      expect(mapped.revokedDate).to.equal('2010-06-30');
-    });
+      const mapped = mapLicence(input)
+      expect(mapped.revokedDate).to.equal('2010-06-30')
+    })
 
     experiment('.regions', () => {
       test('sets the historicalAreaCode', async () => {
-        const input = { AREP_AREA_CODE: 'TEST', AREP_EIUC_CODE: 'ANOTH' };
-        const mapped = mapLicence(input);
+        const input = { AREP_AREA_CODE: 'TEST', AREP_EIUC_CODE: 'ANOTH' }
+        const mapped = mapLicence(input)
 
-        expect(mapped.regions.historicalAreaCode).to.equal('TEST');
+        expect(mapped.regions.historicalAreaCode).to.equal('TEST')
       });
 
       [
@@ -142,25 +142,25 @@ experiment('modules/licence-import/transform/mappers/licence', () => {
         test(`sets regionalChargeArea to ${data.expected} for ${data.in}`, async () => {
           const input = {
             AREP_EIUC_CODE: data.in
-          };
-          const mapped = mapLicence(input);
-          expect(mapped.regions.regionalChargeArea).to.equal(data.expected);
-        });
-      });
-    });
+          }
+          const mapped = mapLicence(input)
+          expect(mapped.regions.regionalChargeArea).to.equal(data.expected)
+        })
+      })
+    })
 
     experiment('.regionCode', () => {
       test('copies a numeric value from the source data', async () => {
-        const input = { FGAC_REGION_CODE: 1, AREP_EIUC_CODE: 'ANOTH' };
-        const mapped = mapLicence(input);
-        expect(mapped.regionCode).to.equal(1);
-      });
+        const input = { FGAC_REGION_CODE: 1, AREP_EIUC_CODE: 'ANOTH' }
+        const mapped = mapLicence(input)
+        expect(mapped.regionCode).to.equal(1)
+      })
 
       test('converts a string value from the source data to a number', async () => {
-        const input = { FGAC_REGION_CODE: '1', AREP_EIUC_CODE: 'ANOTH' };
-        const mapped = mapLicence(input);
-        expect(mapped.regionCode).to.equal(1);
-      });
-    });
-  });
-});
+        const input = { FGAC_REGION_CODE: '1', AREP_EIUC_CODE: 'ANOTH' }
+        const mapped = mapLicence(input)
+        expect(mapped.regionCode).to.equal(1)
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/transform/mappers/role.js
+++ b/test/modules/licence-import/transform/mappers/role.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
-const mapper = require('../../../../../src/modules/licence-import/transform/mappers/role');
+const mapper = require('../../../../../src/modules/licence-import/transform/mappers/role')
 
 experiment('modules/licence-import/transform/mappers/role', () => {
   experiment('.mapLicenceHolderRoles', () => {
@@ -48,12 +48,12 @@ experiment('modules/licence-import/transform/mappers/role', () => {
       STATUS: 'CURR',
       ACON_APAR_ID: '123',
       ACON_AADD_ID: '456'
-    }];
+    }]
 
     const document = {
       startDate: '2020-01-01',
       endDate: null
-    };
+    }
 
     const context = {
       parties: {
@@ -73,25 +73,25 @@ experiment('modules/licence-import/transform/mappers/role', () => {
           }
         }
       }
-    };
+    }
 
-    let roles;
+    let roles
 
     beforeEach(async () => {
-      roles = mapper.mapLicenceHolderRoles(document, licenceVersions, context);
-    });
+      roles = mapper.mapLicenceHolderRoles(document, licenceVersions, context)
+    })
 
     test('maps a single valid role', async () => {
-      expect(roles).to.be.an.array().length(1);
-    });
+      expect(roles).to.be.an.array().length(1)
+    })
 
     test('maps the single valid role', async () => {
-      expect(roles[0].role).to.equal('licenceHolder');
-      expect(roles[0].startDate).to.equal('2020-05-01');
-      expect(roles[0].endDate).to.equal(null);
-      expect(roles[0].company).to.equal(context.parties['1']['123'].company);
-      expect(roles[0].contact).to.be.null();
-      expect(roles[0].address).to.equal(context.addresses['1']['456']);
-    });
-  });
-});
+      expect(roles[0].role).to.equal('licenceHolder')
+      expect(roles[0].startDate).to.equal('2020-05-01')
+      expect(roles[0].endDate).to.equal(null)
+      expect(roles[0].company).to.equal(context.parties['1']['123'].company)
+      expect(roles[0].contact).to.be.null()
+      expect(roles[0].address).to.equal(context.addresses['1']['456'])
+    })
+  })
+})

--- a/test/modules/nald-import/controller.js
+++ b/test/modules/nald-import/controller.js
@@ -1,29 +1,29 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const controller = require('../../../src/modules/nald-import/controller');
+const controller = require('../../../src/modules/nald-import/controller')
 
 experiment('modules/nald-import/controller', () => {
-  let request;
-  let h;
-  let code;
+  let request
+  let h
+  let code
 
   beforeEach(async () => {
-    code = sandbox.spy();
+    code = sandbox.spy()
     h = {
       response: sandbox.stub().returns({
         code
       })
-    };
+    }
 
     request = {
       server: {
@@ -31,57 +31,57 @@ experiment('modules/nald-import/controller', () => {
           publish: sandbox.stub().resolves()
         }
       }
-    };
-  });
+    }
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.postImportLicence', () => {
     experiment('when the message is published', () => {
       beforeEach(async () => {
         request.payload = {
           licenceNumber: 'test-licence'
-        };
+        }
 
-        await controller.postImportLicence(request, h);
-      });
+        await controller.postImportLicence(request, h)
+      })
 
       test('the expected message is published', async () => {
-        const [message] = request.server.messageQueue.publish.lastCall.args;
+        const [message] = request.server.messageQueue.publish.lastCall.args
         expect(message).to.equal({
           name: 'nald-import.import-licence',
           data: { licenceNumber: 'test-licence' },
           options: { singletonKey: 'test-licence' }
-        });
-      });
+        })
+      })
 
       test('the message is returned in the response', async () => {
-        const [message] = h.response.lastCall.args;
+        const [message] = h.response.lastCall.args
         expect(message).to.equal({
           name: 'nald-import.import-licence',
           data: { licenceNumber: 'test-licence' },
           options: { singletonKey: 'test-licence' }
-        });
-      });
+        })
+      })
 
       test('a 202 response code is used', async () => {
-        const [statusCode] = code.lastCall.args;
-        expect(statusCode).to.equal(202);
-      });
-    });
+        const [statusCode] = code.lastCall.args
+        expect(statusCode).to.equal(202)
+      })
+    })
 
     experiment('when the message fails to publish', () => {
       test('the error is returned', async () => {
         request.payload = {
           licenceNumber: 'test-licence'
-        };
-        request.server.messageQueue.publish.rejects(new Error('fail'));
-        const err = await expect(controller.postImportLicence(request, h)).to.reject();
+        }
+        request.server.messageQueue.publish.rejects(new Error('fail'))
+        const err = await expect(controller.postImportLicence(request, h)).to.reject()
 
-        expect(err.output.payload.statusCode).to.equal(500);
-      });
-    });
-  });
-});
+        expect(err.output.payload.statusCode).to.equal(500)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/delete-removed-documents-complete.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents-complete.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const deleteRemovedDocumentsCompleteJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents-complete');
+const { logger } = require('../../../../src/logger')
+const deleteRemovedDocumentsCompleteJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents-complete')
 
 const createJob = isFailed => ({
   failed: isFailed,
@@ -14,78 +14,78 @@ const createJob = isFailed => ({
       name: 'nald-import.delete-removed-documents'
     }
   }
-});
+})
 
 experiment('modules/nald-import/jobs/delete-removed-documents-complete', () => {
-  let messageQueue;
+  let messageQueue
 
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
     messageQueue = {
       publish: sandbox.stub(),
       deleteQueue: sandbox.stub()
-    };
-  });
+    }
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.handler', () => {
     experiment('when the job fails', () => {
-      const job = createJob(true);
+      const job = createJob(true)
 
       beforeEach(async () => {
-        await deleteRemovedDocumentsCompleteJob(job, messageQueue);
-      });
+        await deleteRemovedDocumentsCompleteJob(job, messageQueue)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.error.lastCall.args;
-        expect(message).to.equal('Job: nald-import.delete-removed-documents failed, aborting');
-      });
+        const [message] = logger.error.lastCall.args
+        expect(message).to.equal('Job: nald-import.delete-removed-documents failed, aborting')
+      })
 
       test('no further jobs are published', async () => {
-        expect(messageQueue.publish.called).to.be.false();
-      });
-    });
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
 
     experiment('when the job succeeds', () => {
-      const job = createJob(false);
+      const job = createJob(false)
 
       beforeEach(async () => {
-        await deleteRemovedDocumentsCompleteJob(job, messageQueue);
-      });
+        await deleteRemovedDocumentsCompleteJob(job, messageQueue)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.info.lastCall.args;
-        expect(message).to.equal('Handling onComplete job: nald-import.delete-removed-documents');
-      });
+        const [message] = logger.info.lastCall.args
+        expect(message).to.equal('Handling onComplete job: nald-import.delete-removed-documents')
+      })
 
       test('a new job is published to populate the pending imports table', async () => {
-        const [job] = messageQueue.publish.lastCall.args;
-        expect(job.name).to.equal('nald-import.populate-pending-import');
-      });
+        const [job] = messageQueue.publish.lastCall.args
+        expect(job.name).to.equal('nald-import.populate-pending-import')
+      })
 
       experiment('when publishing a new job fails', () => {
-        const err = new Error('oops');
+        const err = new Error('oops')
 
-        const job = createJob(false);
+        const job = createJob(false)
 
         beforeEach(async () => {
-          messageQueue.publish.rejects(err);
-        });
+          messageQueue.publish.rejects(err)
+        })
 
         test('an error message is logged and rethrown', async () => {
-          const func = () => deleteRemovedDocumentsCompleteJob(job, messageQueue);
-          await expect(func()).to.reject();
+          const func = () => deleteRemovedDocumentsCompleteJob(job, messageQueue)
+          await expect(func()).to.reject()
 
-          const [message, error] = logger.error.lastCall.args;
-          expect(message).to.equal('Error handling onComplete job: nald-import.delete-removed-documents');
-          expect(error).to.equal(err);
-        });
-      });
-    });
-  });
-});
+          const [message, error] = logger.error.lastCall.args
+          expect(message).to.equal('Error handling onComplete job: nald-import.delete-removed-documents')
+          expect(error).to.equal(err)
+        })
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/delete-removed-documents.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.js
@@ -1,82 +1,82 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const importService = require('../../../../src/lib/services/import');
-const deleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents');
+const { logger } = require('../../../../src/logger')
+const importService = require('../../../../src/lib/services/import')
+const deleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents')
 
 experiment('modules/nald-import/jobs/delete-removed-documents', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
-    sandbox.stub(importService, 'deleteRemovedDocuments').resolves();
-  });
+    sandbox.stub(importService, 'deleteRemovedDocuments').resolves()
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const job = deleteRemovedDocumentsJob.createMessage();
+      const job = deleteRemovedDocumentsJob.createMessage()
       expect(job).to.equal({
         name: 'nald-import.delete-removed-documents',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.delete-removed-documents'
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.handler', () => {
     experiment('when the job is successful', () => {
       const job = {
         name: 'nald-import.delete-removed-documents'
-      };
+      }
 
       beforeEach(async () => {
-        await deleteRemovedDocumentsJob.handler(job);
-      });
+        await deleteRemovedDocumentsJob.handler(job)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.info.lastCall.args;
-        expect(message).to.equal('Handling job: nald-import.delete-removed-documents');
-      });
+        const [message] = logger.info.lastCall.args
+        expect(message).to.equal('Handling job: nald-import.delete-removed-documents')
+      })
 
       test('deletes the removed documents', async () => {
-        expect(importService.deleteRemovedDocuments.called).to.equal(true);
-      });
-    });
+        expect(importService.deleteRemovedDocuments.called).to.equal(true)
+      })
+    })
 
     experiment('when the job fails', () => {
-      const err = new Error('Oops!');
+      const err = new Error('Oops!')
 
       const job = {
         name: 'nald-import.delete-removed-documents'
-      };
+      }
 
       beforeEach(async () => {
-        importService.deleteRemovedDocuments.throws(err);
-      });
+        importService.deleteRemovedDocuments.throws(err)
+      })
 
       test('logs an error message', async () => {
-        const func = () => deleteRemovedDocumentsJob.handler(job);
-        await expect(func()).to.reject();
+        const func = () => deleteRemovedDocumentsJob.handler(job)
+        await expect(func()).to.reject()
         expect(logger.error.calledWith(
           'Error handling job nald-import.delete-removed-documents', err
-        )).to.equal(true);
-      });
+        )).to.equal(true)
+      })
 
       test('rethrows the error', async () => {
-        const func = () => deleteRemovedDocumentsJob.handler(job);
-        const err = await expect(func()).to.reject();
-        expect(err.message).to.equal('Oops!');
-      });
-    });
-  });
-});
+        const func = () => deleteRemovedDocumentsJob.handler(job)
+        const err = await expect(func()).to.reject()
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/import-licence.js
+++ b/test/modules/nald-import/jobs/import-licence.js
@@ -1,46 +1,46 @@
-'use strict';
+'use strict'
 
 const {
   afterEach,
   beforeEach,
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
+const { logger } = require('../../../../src/logger')
 
-const importLicence = require('../../../../src/modules/nald-import/jobs/import-licence');
-const licenceLoader = require('../../../../src/modules/nald-import/load');
-const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist');
+const importLicence = require('../../../../src/modules/nald-import/jobs/import-licence')
+const licenceLoader = require('../../../../src/modules/nald-import/load')
+const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist')
 
 experiment('modules/nald-import/jobs/import-licence', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
-    sandbox.stub(licenceLoader, 'load');
-    sandbox.stub(assertImportTablesExist, 'assertImportTablesExist');
-  });
+    sandbox.stub(licenceLoader, 'load')
+    sandbox.stub(assertImportTablesExist, 'assertImportTablesExist')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.options', () => {
     test('has teamSize set to 75', async () => {
-      expect(importLicence.options.teamSize).to.equal(75);
-    });
+      expect(importLicence.options.teamSize).to.equal(75)
+    })
 
     test('has teamConcurrency set to 1', async () => {
-      expect(importLicence.options.teamConcurrency).to.equal(1);
-    });
-  });
+      expect(importLicence.options.teamConcurrency).to.equal(1)
+    })
+  })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const job = importLicence.createMessage('test-licence-number');
+      const job = importLicence.createMessage('test-licence-number')
 
       expect(job).to.equal({
         data: {
@@ -48,9 +48,9 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         },
         name: 'nald-import.import-licence',
         options: { singletonKey: 'test-licence-number' }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.handler', () => {
     experiment('when the licence import was successful', () => {
@@ -59,58 +59,58 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         data: {
           licenceNumber: 'test-licence-number'
         }
-      };
+      }
 
       beforeEach(async () => {
-        await importLicence.handler(job);
-      });
+        await importLicence.handler(job)
+      })
 
       test('a message is logged', async () => {
-        const [message, params] = logger.info.lastCall.args;
-        expect(message).to.equal('Handling job: nald-import.import-licence');
+        const [message, params] = logger.info.lastCall.args
+        expect(message).to.equal('Handling job: nald-import.import-licence')
         expect(params).to.equal({
           licenceNumber: 'test-licence-number'
-        });
-      });
+        })
+      })
 
       test('asserts that the import tables exist', async () => {
-        expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true();
-      });
+        expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true()
+      })
 
       test('loads the requested licence', async () => {
-        expect(licenceLoader.load.calledWith('test-licence-number')).to.be.true();
-      });
-    });
+        expect(licenceLoader.load.calledWith('test-licence-number')).to.be.true()
+      })
+    })
 
     experiment('when the licence import fails', () => {
-      const err = new Error('Oops!');
+      const err = new Error('Oops!')
 
       const job = {
         name: 'nald-import.import-licence',
         data: {
           licenceNumber: 'test-licence-number'
         }
-      };
+      }
 
       beforeEach(async () => {
-        assertImportTablesExist.assertImportTablesExist.throws(err);
-      });
+        assertImportTablesExist.assertImportTablesExist.throws(err)
+      })
 
       test('logs an error message', async () => {
-        const func = () => importLicence.handler(job);
-        await expect(func()).to.reject();
+        const func = () => importLicence.handler(job)
+        await expect(func()).to.reject()
         expect(logger.error.calledWith(
           'Error handling job nald-import.import-licence',
           err,
           { licenceNumber: 'test-licence-number' }
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('rethrows the error', async () => {
-        const func = () => importLicence.handler(job);
-        const err = await expect(func()).to.reject();
-        expect(err.message).to.equal('Oops!');
-      });
-    });
-  });
-});
+        const func = () => importLicence.handler(job)
+        const err = await expect(func()).to.reject()
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/populate-pending-import-complete.js
+++ b/test/modules/nald-import/jobs/populate-pending-import-complete.js
@@ -1,9 +1,9 @@
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const populatePendingImportComplete = require('../../../../src/modules/nald-import/jobs/populate-pending-import-complete');
+const { logger } = require('../../../../src/logger')
+const populatePendingImportComplete = require('../../../../src/modules/nald-import/jobs/populate-pending-import-complete')
 
 const createJob = failed => ({
   failed,
@@ -18,82 +18,82 @@ const createJob = failed => ({
       name: 'nald-import.populate-pending-import'
     }
   }
-});
+})
 
 experiment('modules/nald-import/jobs/populate-pending-import-complete', () => {
-  let messageQueue;
+  let messageQueue
 
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
     messageQueue = {
       publish: sandbox.stub()
-    };
-  });
+    }
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.handler', () => {
     experiment('when the job succeeds', () => {
-      const job = createJob(false);
+      const job = createJob(false)
 
       beforeEach(async () => {
-        await populatePendingImportComplete(job, messageQueue);
-      });
+        await populatePendingImportComplete(job, messageQueue)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.info.lastCall.args;
-        expect(message).to.equal('Handling onComplete job: nald-import.populate-pending-import');
-      });
+        const [message] = logger.info.lastCall.args
+        expect(message).to.equal('Handling onComplete job: nald-import.populate-pending-import')
+      })
 
       test('a job is published to import the first licence', async () => {
-        const [job] = messageQueue.publish.firstCall.args;
-        expect(job.data).to.equal({ licenceNumber: 'licence-1' });
-      });
+        const [job] = messageQueue.publish.firstCall.args
+        expect(job.data).to.equal({ licenceNumber: 'licence-1' })
+      })
 
       test('a job is published to import the second licence', async () => {
-        const [job] = messageQueue.publish.lastCall.args;
-        expect(job.data).to.equal({ licenceNumber: 'licence-2' });
-      });
-    });
+        const [job] = messageQueue.publish.lastCall.args
+        expect(job.data).to.equal({ licenceNumber: 'licence-2' })
+      })
+    })
 
     experiment('when the job fails', () => {
-      const job = createJob(true);
+      const job = createJob(true)
 
       beforeEach(async () => {
-        await populatePendingImportComplete(job, messageQueue);
-      });
+        await populatePendingImportComplete(job, messageQueue)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.error.lastCall.args;
-        expect(message).to.equal('Job: nald-import.populate-pending-import failed, aborting');
-      });
+        const [message] = logger.error.lastCall.args
+        expect(message).to.equal('Job: nald-import.populate-pending-import failed, aborting')
+      })
 
       test('no further jobs are published', async () => {
-        expect(messageQueue.publish.called).to.be.false();
-      });
-    });
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
 
     experiment('when publishing a new job fails', () => {
-      const err = new Error('oops');
+      const err = new Error('oops')
 
-      const job = createJob(false);
+      const job = createJob(false)
 
       beforeEach(async () => {
-        messageQueue.publish.rejects(err);
-      });
+        messageQueue.publish.rejects(err)
+      })
 
       test('an error message is logged and rethrown', async () => {
-        const func = () => populatePendingImportComplete(job, messageQueue);
-        await expect(func()).to.reject();
+        const func = () => populatePendingImportComplete(job, messageQueue)
+        await expect(func()).to.reject()
 
-        const [message, error] = logger.error.lastCall.args;
-        expect(message).to.equal('Error handling onComplete job: nald-import.populate-pending-import');
-        expect(error).to.equal(err);
-      });
-    });
-  });
-});
+        const [message, error] = logger.error.lastCall.args
+        expect(message).to.equal('Error handling onComplete job: nald-import.populate-pending-import')
+        expect(error).to.equal(err)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/populate-pending-import.js
+++ b/test/modules/nald-import/jobs/populate-pending-import.js
@@ -1,66 +1,66 @@
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const importService = require('../../../../src/lib/services/import');
-const populatePendingImport = require('../../../../src/modules/nald-import/jobs/populate-pending-import');
-const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist');
+const { logger } = require('../../../../src/logger')
+const importService = require('../../../../src/lib/services/import')
+const populatePendingImport = require('../../../../src/modules/nald-import/jobs/populate-pending-import')
+const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist')
 
 experiment('modules/nald-import/jobs/populate-pending-import', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
-    sandbox.stub(assertImportTablesExist, 'assertImportTablesExist');
+    sandbox.stub(assertImportTablesExist, 'assertImportTablesExist')
 
     sandbox.stub(importService, 'getLicenceNumbers').resolves([
       'licence-1-id',
       'licence-2-id'
-    ]);
-  });
+    ])
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const job = populatePendingImport.createMessage();
+      const job = populatePendingImport.createMessage()
       expect(job).to.equal({
         name: 'nald-import.populate-pending-import',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.populate-pending-import'
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.handler', () => {
-    let result;
+    let result
 
     experiment('when the job is successful', () => {
       const job = {
         name: 'nald-import.populate-pending-import'
-      };
+      }
 
       beforeEach(async () => {
-        result = await populatePendingImport.handler(job);
-      });
+        result = await populatePendingImport.handler(job)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.info.lastCall.args;
-        expect(message).to.equal('Handling job: nald-import.populate-pending-import');
-      });
+        const [message] = logger.info.lastCall.args
+        expect(message).to.equal('Handling job: nald-import.populate-pending-import')
+      })
 
       test('asserts that the import tables exist', async () => {
-        expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true();
-      });
+        expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true()
+      })
 
       test('retrieves the licence numbers', async () => {
-        expect(importService.getLicenceNumbers.called).to.be.true();
-      });
+        expect(importService.getLicenceNumbers.called).to.be.true()
+      })
 
       test('resolves with an array of licence numbers to import', async () => {
         expect(result).to.equal({
@@ -68,34 +68,34 @@ experiment('modules/nald-import/jobs/populate-pending-import', () => {
             'licence-1-id',
             'licence-2-id'
           ]
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the job fails', () => {
-      const err = new Error('Oops!');
+      const err = new Error('Oops!')
 
       const job = {
         name: 'nald-import.populate-pending-import'
-      };
+      }
 
       beforeEach(async () => {
-        assertImportTablesExist.assertImportTablesExist.throws(err);
-      });
+        assertImportTablesExist.assertImportTablesExist.throws(err)
+      })
 
       test('logs an error message', async () => {
-        const func = () => populatePendingImport.handler(job);
-        await expect(func()).to.reject();
+        const func = () => populatePendingImport.handler(job)
+        await expect(func()).to.reject()
         expect(logger.error.calledWith(
           'Error handling job nald-import.populate-pending-import', err
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('rethrows the error', async () => {
-        const func = () => populatePendingImport.handler(job);
-        const err = await expect(func()).to.reject();
-        expect(err.message).to.equal('Oops!');
-      });
-    });
-  });
-});
+        const func = () => populatePendingImport.handler(job)
+        const err = await expect(func()).to.reject()
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/s3-download-complete.js
+++ b/test/modules/nald-import/jobs/s3-download-complete.js
@@ -1,9 +1,9 @@
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const s3DownloadComplete = require('../../../../src/modules/nald-import/jobs/s3-download-complete');
+const { logger } = require('../../../../src/logger')
+const s3DownloadComplete = require('../../../../src/modules/nald-import/jobs/s3-download-complete')
 
 const createJob = (isFailed, isRequired) => ({
   failed: isFailed,
@@ -15,113 +15,113 @@ const createJob = (isFailed, isRequired) => ({
       isRequired
     }
   }
-});
+})
 
 experiment('modules/nald-import/jobs/s3-download-import-complete', () => {
-  let messageQueue;
+  let messageQueue
 
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
     messageQueue = {
       publish: sandbox.stub(),
       deleteQueue: sandbox.stub()
-    };
-  });
+    }
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.handler', () => {
     experiment('when the job fails', () => {
-      const job = createJob(true);
+      const job = createJob(true)
 
       beforeEach(async () => {
-        await s3DownloadComplete(job, messageQueue);
-      });
+        await s3DownloadComplete(job, messageQueue)
+      })
 
       test('a message is logged', async () => {
-        const [message] = logger.error.lastCall.args;
-        expect(message).to.equal('Job: nald-import.s3-download failed, aborting');
-      });
+        const [message] = logger.error.lastCall.args
+        expect(message).to.equal('Job: nald-import.s3-download failed, aborting')
+      })
 
       test('no further jobs are published', async () => {
-        expect(messageQueue.publish.called).to.be.false();
-      });
-    });
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
 
     experiment('when the job succeeds', () => {
       experiment('and an import is required', () => {
-        const job = createJob(false, true);
+        const job = createJob(false, true)
 
         beforeEach(async () => {
-          await s3DownloadComplete(job, messageQueue);
-        });
+          await s3DownloadComplete(job, messageQueue)
+        })
 
         test('a message is logged', async () => {
-          const [message] = logger.info.lastCall.args;
-          expect(message).to.equal('Handling onComplete job: nald-import.s3-download');
-        });
+          const [message] = logger.info.lastCall.args
+          expect(message).to.equal('Handling onComplete job: nald-import.s3-download')
+        })
 
         test('existing import.licence job queue is deleted', async () => {
-          expect(messageQueue.deleteQueue.calledWith('nald-import.import-licence')).to.be.true();
-        });
+          expect(messageQueue.deleteQueue.calledWith('nald-import.import-licence')).to.be.true()
+        })
 
         test('existing import.populate-pending-import job queue is deleted', async () => {
-          expect(messageQueue.deleteQueue.calledWith('nald-import.populate-pending-import')).to.be.true();
-        });
+          expect(messageQueue.deleteQueue.calledWith('nald-import.populate-pending-import')).to.be.true()
+        })
 
         test('existing nald-import.delete-removed-documents job queue is deleted', async () => {
-          expect(messageQueue.deleteQueue.calledWith('nald-import.delete-removed-documents')).to.be.true();
-        });
+          expect(messageQueue.deleteQueue.calledWith('nald-import.delete-removed-documents')).to.be.true()
+        })
 
         test('a new job is published to delete any removed documents', async () => {
-          const [job] = messageQueue.publish.lastCall.args;
-          expect(job.name).to.equal('nald-import.delete-removed-documents');
-        });
-      });
+          const [job] = messageQueue.publish.lastCall.args
+          expect(job.name).to.equal('nald-import.delete-removed-documents')
+        })
+      })
 
       experiment('and an import is not required', () => {
-        const job = createJob(false, false);
+        const job = createJob(false, false)
 
         beforeEach(async () => {
-          await s3DownloadComplete(job, messageQueue);
-        });
+          await s3DownloadComplete(job, messageQueue)
+        })
 
         test('a message is logged', async () => {
-          const [message] = logger.info.lastCall.args;
-          expect(message).to.equal('Aborting onComplete job: nald-import.s3-download');
-        });
+          const [message] = logger.info.lastCall.args
+          expect(message).to.equal('Aborting onComplete job: nald-import.s3-download')
+        })
 
         test('job queues are not deleted', async () => {
-          expect(messageQueue.deleteQueue.called).to.be.false();
-        });
+          expect(messageQueue.deleteQueue.called).to.be.false()
+        })
 
         test('a new job is not published', async () => {
-          expect(messageQueue.publish.called).to.be.false();
-        });
-      });
+          expect(messageQueue.publish.called).to.be.false()
+        })
+      })
 
       experiment('when publishing a new job fails', () => {
-        const err = new Error('oops');
+        const err = new Error('oops')
 
-        const job = createJob(false, true);
+        const job = createJob(false, true)
 
         beforeEach(async () => {
-          messageQueue.publish.rejects(err);
-        });
+          messageQueue.publish.rejects(err)
+        })
 
         test('an error message is logged and rethrown', async () => {
-          const func = () => s3DownloadComplete(job, messageQueue);
-          await expect(func()).to.reject();
+          const func = () => s3DownloadComplete(job, messageQueue)
+          await expect(func()).to.reject()
 
-          const [message, error] = logger.error.lastCall.args;
-          expect(message).to.equal('Error handling onComplete job: nald-import.s3-download');
-          expect(error).to.equal(err);
-        });
-      });
-    });
-  });
-});
+          const [message, error] = logger.error.lastCall.args
+          expect(message).to.equal('Error handling onComplete job: nald-import.s3-download')
+          expect(error).to.equal(err)
+        })
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/jobs/s3-download.js
+++ b/test/modules/nald-import/jobs/s3-download.js
@@ -1,197 +1,197 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { logger } = require('../../../../src/logger');
-const extractService = require('../../../../src/modules/nald-import/services/extract-service.js');
-const applicationStateService = require('../../../../src/lib/services/application-state-service.js');
-const s3Service = require('../../../../src/modules/nald-import/services/s3-service.js');
+const { logger } = require('../../../../src/logger')
+const extractService = require('../../../../src/modules/nald-import/services/extract-service.js')
+const applicationStateService = require('../../../../src/lib/services/application-state-service.js')
+const s3Service = require('../../../../src/modules/nald-import/services/s3-service.js')
 
-const s3Download = require('../../../../src/modules/nald-import/jobs/s3-download');
-const config = require('../../../../config');
+const s3Download = require('../../../../src/modules/nald-import/jobs/s3-download')
+const config = require('../../../../config')
 
 const testDownloadOccurs = () => {
   test('a message is logged', async () => {
-    const [message] = logger.info.lastCall.args;
-    expect(message).to.equal('Handling job: nald-import.s3-download');
-  });
+    const [message] = logger.info.lastCall.args
+    expect(message).to.equal('Handling job: nald-import.s3-download')
+  })
 
   test('updates the application state with the new etag', async () => {
-    expect(applicationStateService.save.firstCall.args).to.equal(['nald-import', { etag: 'test-etag', isDownloaded: false }]);
-  });
+    expect(applicationStateService.save.firstCall.args).to.equal(['nald-import', { etag: 'test-etag', isDownloaded: false }])
+  })
 
   test('downloads and extracts from S3 bucket', async () => {
-    expect(extractService.downloadAndExtract.called).to.be.true();
-  });
+    expect(extractService.downloadAndExtract.called).to.be.true()
+  })
 
   test('updates the application state when file imported', async () => {
-    expect(applicationStateService.save.secondCall.args).to.equal(['nald-import', { etag: 'test-etag', isDownloaded: true }]);
-  });
-};
+    expect(applicationStateService.save.secondCall.args).to.equal(['nald-import', { etag: 'test-etag', isDownloaded: true }])
+  })
+}
 
 experiment('modules/nald-import/jobs/s3-download', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
-    sandbox.stub(extractService, 'downloadAndExtract');
+    sandbox.stub(extractService, 'downloadAndExtract')
 
-    sandbox.stub(applicationStateService, 'get');
-    sandbox.stub(applicationStateService, 'save');
+    sandbox.stub(applicationStateService, 'get')
+    sandbox.stub(applicationStateService, 'save')
 
-    sandbox.stub(s3Service, 'getEtag').resolves('test-etag');
+    sandbox.stub(s3Service, 'getEtag').resolves('test-etag')
 
-    sandbox.stub(config.import.nald, 'isEtagCheckEnabled').value(true);
-  });
+    sandbox.stub(config.import.nald, 'isEtagCheckEnabled').value(true)
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const job = s3Download.createMessage();
+      const job = s3Download.createMessage()
       expect(job).to.equal({
         name: 'nald-import.s3-download',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.s3-download'
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.handler', () => {
-    let result;
+    let result
 
     const job = {
       name: 'nald-import.s3-download'
-    };
+    }
 
     experiment('when there is no import state stored', () => {
       beforeEach(async () => {
-        applicationStateService.get.resolves({});
-        result = await s3Download.handler(job);
-      });
+        applicationStateService.get.resolves({})
+        result = await s3Download.handler(job)
+      })
 
-      testDownloadOccurs();
+      testDownloadOccurs()
 
       test('the handler resolves with the expected values', async () => {
         expect(result).to.equal({
           etag: 'test-etag',
           state: {},
           isRequired: true
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the import state indicates download did not complete', () => {
       beforeEach(async () => {
         applicationStateService.get.resolves({
           etag: 'test-etag',
           isDownloaded: false
-        });
-        result = await s3Download.handler(job);
-      });
+        })
+        result = await s3Download.handler(job)
+      })
 
-      testDownloadOccurs();
+      testDownloadOccurs()
 
       test('the handler resolves with the expected values', async () => {
         expect(result).to.equal({
           etag: 'test-etag',
           state: { etag: 'test-etag', isDownloaded: false },
           isRequired: true
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the import state indicates etag has changed', () => {
       beforeEach(async () => {
         applicationStateService.get.resolves({
           etag: 'some-old-etag',
           isDownloaded: true
-        });
-        result = await s3Download.handler(job);
-      });
+        })
+        result = await s3Download.handler(job)
+      })
 
-      testDownloadOccurs();
+      testDownloadOccurs()
 
       test('the handler resolves with the expected values', async () => {
         expect(result).to.equal({
           etag: 'test-etag',
           state: { etag: 'some-old-etag', isDownloaded: true },
           isRequired: true
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the import state indicates etag has not changed', () => {
       beforeEach(async () => {
         applicationStateService.get.resolves({
           etag: 'test-etag',
           isDownloaded: true
-        });
-        result = await s3Download.handler(job);
-      });
+        })
+        result = await s3Download.handler(job)
+      })
 
       test('the application state is not updated', async () => {
-        expect(applicationStateService.save.called).to.be.false();
-      });
+        expect(applicationStateService.save.called).to.be.false()
+      })
 
       test('the file is not imported from S3', async () => {
-        expect(extractService.downloadAndExtract.called).to.be.false();
-      });
+        expect(extractService.downloadAndExtract.called).to.be.false()
+      })
 
       test('the handler resolves with the expected values', async () => {
         expect(result).to.equal({
           etag: 'test-etag',
           state: { etag: 'test-etag', isDownloaded: true },
           isRequired: false
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the config disables etag check and the etag has not changed', () => {
       beforeEach(async () => {
-        sandbox.stub(config.import.nald, 'isEtagCheckEnabled').value(false);
+        sandbox.stub(config.import.nald, 'isEtagCheckEnabled').value(false)
         applicationStateService.get.resolves({
           etag: 'test-etag',
           isDownloaded: true
-        });
-        result = await s3Download.handler(job);
-      });
+        })
+        result = await s3Download.handler(job)
+      })
 
       test('the handler resolves with the expected values', async () => {
         expect(result).to.equal({
           etag: 'test-etag',
           state: { etag: 'test-etag', isDownloaded: true },
           isRequired: true
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the job fails', () => {
-      const err = new Error('Oops!');
+      const err = new Error('Oops!')
 
       beforeEach(async () => {
-        s3Service.getEtag.throws(err);
-      });
+        s3Service.getEtag.throws(err)
+      })
 
       test('logs an error message', async () => {
-        const func = () => s3Download.handler(job);
-        await expect(func()).to.reject();
+        const func = () => s3Download.handler(job)
+        await expect(func()).to.reject()
         expect(logger.error.calledWith(
           'Error handling job nald-import.s3-download', err
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('rethrows the error', async () => {
-        const func = () => s3Download.handler(job);
-        const err = await expect(func()).to.reject();
-        expect(err.message).to.equal('Oops!');
-      });
-    });
-  });
-});
+        const func = () => s3Download.handler(job)
+        const err = await expect(func()).to.reject()
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/lib/assert-import-tables-exist.js
+++ b/test/modules/nald-import/lib/assert-import-tables-exist.js
@@ -1,42 +1,42 @@
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist');
-const coreQueries = require('../../../../src/modules/nald-import/lib/nald-queries/core');
-const { NALDImportTablesError } = require('../../../../src/modules/nald-import/lib/errors');
+const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist')
+const coreQueries = require('../../../../src/modules/nald-import/lib/nald-queries/core')
+const { NALDImportTablesError } = require('../../../../src/modules/nald-import/lib/errors')
 
 experiment('modules/nald-import/lib/assert-import-tables-exist', () => {
   beforeEach(async () => {
-    sandbox.stub(coreQueries, 'importTableExists');
-  });
+    sandbox.stub(coreQueries, 'importTableExists')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.assertImportTablesExist', () => {
     experiment('when tables exist', () => {
       beforeEach(async () => {
-        coreQueries.importTableExists.resolves(true);
-      });
+        coreQueries.importTableExists.resolves(true)
+      })
 
       test('resolves undefined', async () => {
-        const result = await assertImportTablesExist.assertImportTablesExist();
-        expect(result).to.be.undefined();
-      });
-    });
+        const result = await assertImportTablesExist.assertImportTablesExist()
+        expect(result).to.be.undefined()
+      })
+    })
 
     experiment('when tables do not exist', () => {
       beforeEach(async () => {
-        coreQueries.importTableExists.resolves(false);
-      });
+        coreQueries.importTableExists.resolves(false)
+      })
 
       test('rejects with a NALDImportTablesError error', async () => {
-        const func = () => assertImportTablesExist.assertImportTablesExist();
-        const err = await expect(func()).to.reject();
-        expect(err instanceof NALDImportTablesError);
-      });
-    });
-  });
-});
+        const func = () => assertImportTablesExist.assertImportTablesExist()
+        const err = await expect(func()).to.reject()
+        expect(err instanceof NALDImportTablesError)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/lib/due-date.js
+++ b/test/modules/nald-import/lib/due-date.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const sandbox = require('sinon').createSandbox();
-const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox()
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const dueDate = require('../../../../src/modules/nald-import/lib/due-date');
-const returnsQueries = require('../../../../src/modules/nald-import/lib/nald-queries/returns');
+const dueDate = require('../../../../src/modules/nald-import/lib/due-date')
+const returnsQueries = require('../../../../src/modules/nald-import/lib/nald-queries/returns')
 
 experiment('modules/nald-import/lib/due-date', () => {
   experiment('getDueDate', () => {
@@ -36,79 +36,79 @@ experiment('modules/nald-import/lib/due-date', () => {
         FORM_PRODN_MONTH: '66',
         VERS_NO: '100'
       }
-    };
+    }
 
     experiment('for a split log cycle', () => {
-      const endDate = '2019-01-01';
+      const endDate = '2019-01-01'
 
       beforeEach(async () => {
-        sandbox.stub(returnsQueries, 'getReturnVersionReason').resolves([]);
-      });
+        sandbox.stub(returnsQueries, 'getReturnVersionReason').resolves([])
+      })
 
       afterEach(async () => {
-        sandbox.restore();
-      });
+        sandbox.restore()
+      })
 
       test('returns 28 days after split end date if the return version end date is null', async () => {
-        const result = await dueDate.getDueDate(endDate, formats.nullEndDate);
-        expect(result).to.equal('2019-01-29');
-      });
+        const result = await dueDate.getDueDate(endDate, formats.nullEndDate)
+        expect(result).to.equal('2019-01-29')
+      })
 
       test('returns 28 days after split end date if the return version end date is different to the split end date', async () => {
-        const result = await dueDate.getDueDate(endDate, formats.differentEndDate);
-        expect(result).to.equal('2019-01-29');
-      });
+        const result = await dueDate.getDueDate(endDate, formats.differentEndDate)
+        expect(result).to.equal('2019-01-29')
+      })
 
       experiment('when the returns version end date equals the split end date', () => {
         test('the getReturnVersionReason query is called with licence ID, region, and the incremented return version number', async () => {
-          await dueDate.getDueDate(endDate, formats.summerProductionMonth);
-          const { args } = returnsQueries.getReturnVersionReason.lastCall;
-          expect(args).to.equal(['licence_id_1', 'region_1', 101]);
-        });
+          await dueDate.getDueDate(endDate, formats.summerProductionMonth)
+          const { args } = returnsQueries.getReturnVersionReason.lastCall
+          expect(args).to.equal(['licence_id_1', 'region_1', 101])
+        })
 
         experiment('and the mod log reason is in VARF, VARM, AMND, NAME, REDS, SPAC, SPAN, XCORR', () => {
           beforeEach(async () => {
             returnsQueries.getReturnVersionReason.resolves([{
               AMRE_CODE: 'VARF'
-            }]);
-          });
+            }])
+          })
 
           test('returns 28 days after cycle end date for summer production month', async () => {
-            const result = await dueDate.getDueDate(endDate, formats.summerProductionMonth);
-            expect(result).to.equal('2019-11-28');
-          });
+            const result = await dueDate.getDueDate(endDate, formats.summerProductionMonth)
+            expect(result).to.equal('2019-11-28')
+          })
 
           test('returns 28 days after cycle end date for winter production month', async () => {
-            const result = await dueDate.getDueDate(endDate, formats.winterProductionMonth);
-            expect(result).to.equal('2019-04-28');
-          });
-        });
+            const result = await dueDate.getDueDate(endDate, formats.winterProductionMonth)
+            expect(result).to.equal('2019-04-28')
+          })
+        })
 
         experiment('and the mod log reason is not in VARF, VARM, AMND, NAME, REDS, SPAC, SPAN, XCORR', () => {
           beforeEach(async () => {
             returnsQueries.getReturnVersionReason.resolves([{
               AMRE_CODE: 'NO-MATCH'
-            }]);
-          });
+            }])
+          })
 
           test('returns 28 days after split end date for summer production month', async () => {
-            const result = await dueDate.getDueDate(endDate, formats.summerProductionMonth);
-            expect(result).to.equal('2019-01-29');
-          });
+            const result = await dueDate.getDueDate(endDate, formats.summerProductionMonth)
+            expect(result).to.equal('2019-01-29')
+          })
 
           test('returns 28 days after split end date for winter production month', async () => {
-            const result = await dueDate.getDueDate(endDate, formats.winterProductionMonth);
-            expect(result).to.equal('2019-01-29');
-          });
-        });
-      });
-    });
+            const result = await dueDate.getDueDate(endDate, formats.winterProductionMonth)
+            expect(result).to.equal('2019-01-29')
+          })
+        })
+      })
+    })
 
     experiment('for the cycle ending 2020-03-31 affected by coronavirus', () => {
       test('the due date is 2020-10-16', async () => {
-        const result = await dueDate.getDueDate('2020-03-31', formats.nullEndDate);
-        expect(result).to.equal('2020-10-16');
-      });
-    });
-  });
-});
+        const result = await dueDate.getDueDate('2020-03-31', formats.nullEndDate)
+        expect(result).to.equal('2020-10-16')
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/lib/end-date.js
+++ b/test/modules/nald-import/lib/end-date.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-const { expect } = require('@hapi/code');
-const { experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code')
+const { experiment, test } = exports.lab = require('@hapi/lab').script()
 
-const { getEndDate } = require('../../../../src/modules/nald-import/lib/end-date');
+const { getEndDate } = require('../../../../src/modules/nald-import/lib/end-date')
 
 experiment('modules/nald-import/lib/end-date', () => {
   experiment('getEndDate', () => {
     test('returns undefined if no end date set', async () => {
-      const result = getEndDate({});
-      expect(result).to.be.undefined();
-    });
+      const result = getEndDate({})
+      expect(result).to.be.undefined()
+    })
 
     test('returns expiry date if set', async () => {
       const result = getEndDate({
         EXPIRY_DATE: '01/04/2019'
-      });
-      expect(result).to.be.equal('2019-04-01');
-    });
+      })
+      expect(result).to.be.equal('2019-04-01')
+    })
 
     test('returns lapsed date if set', async () => {
       const result = getEndDate({
         LAPSED_DATE: '03/09/2019'
-      });
-      expect(result).to.be.equal('2019-09-03');
-    });
+      })
+      expect(result).to.be.equal('2019-09-03')
+    })
 
     test('returns revoked date if set', async () => {
       const result = getEndDate({
         REV_DATE: '31/12/2017'
-      });
-      expect(result).to.be.equal('2017-12-31');
-    });
+      })
+      expect(result).to.be.equal('2017-12-31')
+    })
 
     test('ignores null string', async () => {
       const result = getEndDate({
         LAPSED_DATE: 'null',
         REV_DATE: '31/12/2017'
-      });
-      expect(result).to.be.equal('2017-12-31');
-    });
+      })
+      expect(result).to.be.equal('2017-12-31')
+    })
 
     test('returns minumum date if all set', async () => {
       const result = getEndDate({
         EXPIRY_DATE: '01/04/2019',
         LAPSED_DATE: '03/09/2019',
         REV_DATE: '31/12/2017'
-      });
-      expect(result).to.be.equal('2017-12-31');
-    });
-  });
-});
+      })
+      expect(result).to.be.equal('2017-12-31')
+    })
+  })
+})

--- a/test/modules/nald-import/lib/errors.js
+++ b/test/modules/nald-import/lib/errors.js
@@ -1,49 +1,49 @@
-'use strict';
+'use strict'
 
-const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const errors = require('../../../../src/modules/nald-import/lib/errors');
+const errors = require('../../../../src/modules/nald-import/lib/errors')
 
 experiment('modules/nald-import/lib/errors', () => {
-  let err;
+  let err
 
   experiment('LicenceNotFoundError', () => {
     beforeEach(async () => {
-      err = new errors.LicenceNotFoundError('oops');
-    });
+      err = new errors.LicenceNotFoundError('oops')
+    })
     test('has the correct name', async () => {
-      expect(err.name).to.equal('LicenceNotFoundError');
-    });
+      expect(err.name).to.equal('LicenceNotFoundError')
+    })
 
     test('has the correct message', async () => {
-      expect(err.message).to.equal('oops');
-    });
-  });
+      expect(err.message).to.equal('oops')
+    })
+  })
 
   experiment('MetaDataError', () => {
     beforeEach(async () => {
-      err = new errors.MetaDataError('oops');
-    });
+      err = new errors.MetaDataError('oops')
+    })
     test('has the correct name', async () => {
-      expect(err.name).to.equal('MetaDataError');
-    });
+      expect(err.name).to.equal('MetaDataError')
+    })
 
     test('has the correct message', async () => {
-      expect(err.message).to.equal('oops');
-    });
-  });
+      expect(err.message).to.equal('oops')
+    })
+  })
 
   experiment('NALDImportTablesError', () => {
     beforeEach(async () => {
-      err = new errors.NALDImportTablesError('oops');
-    });
+      err = new errors.NALDImportTablesError('oops')
+    })
     test('has the correct name', async () => {
-      expect(err.name).to.equal('NALDImportTablesError');
-    });
+      expect(err.name).to.equal('NALDImportTablesError')
+    })
 
     test('has the correct message', async () => {
-      expect(err.message).to.equal('oops');
-    });
-  });
-});
+      expect(err.message).to.equal('oops')
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/addresses.js
+++ b/test/modules/nald-import/lib/nald-queries/addresses.js
@@ -1,41 +1,41 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const addresses = require('../../../../../src/modules/nald-import/lib/nald-queries/addresses');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/addresses');
+const addresses = require('../../../../../src/modules/nald-import/lib/nald-queries/addresses')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/addresses')
 
 experiment('modules/nald-import/lib/nald-queries/addresses', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getAddress', () => {
     beforeEach(async () => {
-      await addresses.getAddress('test-address-id', 'test-region-id');
-    });
+      await addresses.getAddress('test-address-id', 'test-region-id')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getAddress);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getAddress)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-address-id', 'test-region-id']);
-    });
-  });
-});
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-address-id', 'test-region-id'])
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/cache.js
+++ b/test/modules/nald-import/lib/nald-queries/cache.js
@@ -1,94 +1,94 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache');
-const { logger } = require('../../../../../src/logger');
+const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
+const { logger } = require('../../../../../src/logger')
 
 experiment('modules/nald-import/lib/nald-queries/cache', () => {
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-  });
+    sandbox.stub(logger, 'info')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.createId', () => {
     test('makes the id using the key and params', async () => {
-      const key = 'key';
+      const key = 'key'
       const params = {
         regionCode: 1,
         licenceNumber: '123'
-      };
+      }
 
-      const id = cache.createId(key, params);
+      const id = cache.createId(key, params)
 
-      expect(id.id).to.equal('key:regionCode:1:licenceNumber:123');
-    });
+      expect(id.id).to.equal('key:regionCode:1:licenceNumber:123')
+    })
 
     test('includes the params', async () => {
-      const key = 'key';
+      const key = 'key'
       const params = {
         regionCode: 1,
         licenceNumber: '123'
-      };
+      }
 
-      const id = cache.createId(key, params);
+      const id = cache.createId(key, params)
 
-      expect(id.regionCode).to.equal(1);
-      expect(id.licenceNumber).to.equal('123');
-    });
-  });
+      expect(id.regionCode).to.equal(1)
+      expect(id.licenceNumber).to.equal('123')
+    })
+  })
 
   experiment('.createCachedQuery', () => {
-    let server;
-    let spy;
+    let server
+    let spy
 
     beforeEach(async () => {
-      spy = sandbox.spy();
+      spy = sandbox.spy()
       server = {
         cache: sandbox.spy()
-      };
+      }
 
-      cache.createCachedQuery(server, 'test-method', spy);
-    });
+      cache.createCachedQuery(server, 'test-method', spy)
+    })
 
     test('uses the method name for the cache segment', async () => {
-      const [cacheArg] = server.cache.lastCall.args;
-      expect(cacheArg.segment).to.equal('test-method');
-    });
+      const [cacheArg] = server.cache.lastCall.args
+      expect(cacheArg.segment).to.equal('test-method')
+    })
 
     test('sets a cache duration of five minutes', async () => {
-      const [cacheArg] = server.cache.lastCall.args;
-      expect(cacheArg.expiresIn).to.equal(5 * 60 * 1000);
-    });
+      const [cacheArg] = server.cache.lastCall.args
+      expect(cacheArg.expiresIn).to.equal(5 * 60 * 1000)
+    })
 
     test('sets a generate timeout of five seconds', async () => {
-      const [cacheArg] = server.cache.lastCall.args;
-      expect(cacheArg.generateTimeout).to.equal(5 * 1000);
-    });
+      const [cacheArg] = server.cache.lastCall.args
+      expect(cacheArg.generateTimeout).to.equal(5 * 1000)
+    })
 
     test('configures the generate function', async () => {
-      const [cacheArg] = server.cache.lastCall.args;
-      const generate = cacheArg.generateFunc;
+      const [cacheArg] = server.cache.lastCall.args
+      const generate = cacheArg.generateFunc
 
-      generate({ id: 123 });
+      generate({ id: 123 })
 
-      const loggerArgs = logger.info.lastCall.args;
-      expect(loggerArgs[0]).to.equal('Accessing database for test-method');
-      expect(loggerArgs[1]).to.equal({ id: 123 });
+      const loggerArgs = logger.info.lastCall.args
+      expect(loggerArgs[0]).to.equal('Accessing database for test-method')
+      expect(loggerArgs[1]).to.equal({ id: 123 })
 
-      expect(spy.calledWith({ id: 123 })).to.equal(true);
-    });
-  });
-});
+      expect(spy.calledWith({ id: 123 })).to.equal(true)
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/cams.js
+++ b/test/modules/nald-import/lib/nald-queries/cams.js
@@ -1,62 +1,62 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const cams = require('../../../../../src/modules/nald-import/lib/nald-queries/cams');
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/cams');
+const cams = require('../../../../../src/modules/nald-import/lib/nald-queries/cams')
+const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/cams')
 
 experiment('modules/nald-import/lib/queries/cams', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery');
-    sandbox.stub(cache, 'createCachedQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+    sandbox.stub(cache, 'createCachedQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('._createCamsCache', async () => {
     test('creates a cache with the expected method name', async () => {
-      cams._createCamsCache();
-      const [, methodName] = cache.createCachedQuery.lastCall.args;
-      expect(methodName).to.equal('getCams');
-    });
+      cams._createCamsCache()
+      const [, methodName] = cache.createCachedQuery.lastCall.args
+      expect(methodName).to.equal('getCams')
+    })
 
     test('creates a cache with the required generate func', async () => {
-      cams._createCamsCache();
-      const [, , generate] = cache.createCachedQuery.lastCall.args;
-      const id = { code: 'test-code', regionCode: 'test-region-code' };
+      cams._createCamsCache()
+      const [, , generate] = cache.createCachedQuery.lastCall.args
+      const id = { code: 'test-code', regionCode: 'test-region-code' }
 
-      await generate(id);
+      await generate(id)
 
-      const [query, params] = db.dbQuery.lastCall.args;
+      const [query, params] = db.dbQuery.lastCall.args
 
-      expect(query).to.equal(sql.getCams);
-      expect(params).to.equal(['test-code', 'test-region-code']);
-    });
-  });
+      expect(query).to.equal(sql.getCams)
+      expect(params).to.equal(['test-code', 'test-region-code'])
+    })
+  })
 
   experiment('.getCams', () => {
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(cams._getCamsCache, 'get');
+      sandbox.stub(cams._getCamsCache, 'get')
 
-      await cams.getCams('test-code', 'test-region');
+      await cams.getCams('test-code', 'test-region')
 
-      const [id] = cams._getCamsCache.get.lastCall.args;
+      const [id] = cams._getCamsCache.get.lastCall.args
 
-      expect(id.id).to.equal('cams:code:test-code:regionCode:test-region');
-      expect(id.code).to.equal('test-code');
-      expect(id.regionCode).to.equal('test-region');
-    });
-  });
-});
+      expect(id.id).to.equal('cams:code:test-code:regionCode:test-region')
+      expect(id.code).to.equal('test-code')
+      expect(id.regionCode).to.equal('test-region')
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/core.js
+++ b/test/modules/nald-import/lib/nald-queries/core.js
@@ -1,56 +1,56 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const core = require('../../../../../src/modules/nald-import/lib/nald-queries/core');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/core');
+const core = require('../../../../../src/modules/nald-import/lib/nald-queries/core')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/core')
 
 experiment('modules/nald-import/lib/nald-queries/core', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery').resolves([]);
-  });
+    sandbox.stub(db, 'dbQuery').resolves([])
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.importTableExists', () => {
     test('uses the correct query', async () => {
-      await core.importTableExists();
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.importTableExists);
-    });
+      await core.importTableExists()
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.importTableExists)
+    })
 
     experiment('when there are no import table', () => {
       test('false is returned', async () => {
-        const result = await core.importTableExists();
-        expect(result).to.equal(false);
-      });
-    });
+        const result = await core.importTableExists()
+        expect(result).to.equal(false)
+      })
+    })
 
     experiment('when all the import tables are not present yet', () => {
       test('false is returned', async () => {
-        db.dbQuery.resolves([{ count: 50 }]);
-        const result = await core.importTableExists();
-        expect(result).to.equal(false);
-      });
-    });
+        db.dbQuery.resolves([{ count: 50 }])
+        const result = await core.importTableExists()
+        expect(result).to.equal(false)
+      })
+    })
 
     experiment('when all the import tables are present', () => {
       test('true is returned', async () => {
-        db.dbQuery.resolves([{ count: 128 }]);
-        const result = await core.importTableExists();
-        expect(result).to.equal(true);
-      });
-    });
-  });
-});
+        db.dbQuery.resolves([{ count: 128 }])
+        const result = await core.importTableExists()
+        expect(result).to.equal(true)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/licences.js
+++ b/test/modules/nald-import/lib/nald-queries/licences.js
@@ -1,85 +1,85 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const licences = require('../../../../../src/modules/nald-import/lib/nald-queries/licences');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/licences');
+const licences = require('../../../../../src/modules/nald-import/lib/nald-queries/licences')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/licences')
 
 experiment('modules/nald-import/lib/nald-queries/licences', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery').resolves([]);
-  });
+    sandbox.stub(db, 'dbQuery').resolves([])
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getLicence', () => {
     beforeEach(async () => {
-      await licences.getLicence('123');
-    });
+      await licences.getLicence('123')
+    })
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getLicence);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getLicence)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['123']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['123'])
+    })
+  })
 
   experiment('.getCurrentVersion', () => {
     beforeEach(async () => {
-      await licences.getCurrentVersion('licence-id', 'region-code');
-    });
+      await licences.getCurrentVersion('licence-id', 'region-code')
+    })
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getCurrentVersion);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getCurrentVersion)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['licence-id', 'region-code']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['licence-id', 'region-code'])
+    })
+  })
 
   experiment('.getVersions', () => {
     beforeEach(async () => {
-      await licences.getVersions('licence-id', 'region-code');
-    });
+      await licences.getVersions('licence-id', 'region-code')
+    })
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getVersions);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getVersions)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['licence-id', 'region-code']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['licence-id', 'region-code'])
+    })
+  })
 
   experiment('.getCurrentFormats', () => {
     beforeEach(async () => {
-      await licences.getCurrentFormats('licence-id', 'region-code');
-    });
+      await licences.getCurrentFormats('licence-id', 'region-code')
+    })
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getCurrentFormats);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getCurrentFormats)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['licence-id', 'region-code']);
-    });
-  });
-});
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['licence-id', 'region-code'])
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/parties.js
+++ b/test/modules/nald-import/lib/nald-queries/parties.js
@@ -1,113 +1,113 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const parties = require('../../../../../src/modules/nald-import/lib/nald-queries/parties');
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/parties');
+const parties = require('../../../../../src/modules/nald-import/lib/nald-queries/parties')
+const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/parties')
 
 experiment('modules/nald-import/lib/queries/parties', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery');
-    sandbox.stub(cache, 'createCachedQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+    sandbox.stub(cache, 'createCachedQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('._createPartiesCache', async () => {
     test('creates a cache with the expected method name', async () => {
-      parties._createPartiesCache();
-      const [, methodName] = cache.createCachedQuery.lastCall.args;
-      expect(methodName).to.equal('getParties');
-    });
+      parties._createPartiesCache()
+      const [, methodName] = cache.createCachedQuery.lastCall.args
+      expect(methodName).to.equal('getParties')
+    })
 
     test('creates a cache with the required generate func', async () => {
-      parties._createPartiesCache();
-      const [, , generate] = cache.createCachedQuery.lastCall.args;
-      const id = { partyId: 'test-party', regionCode: 'test-region' };
+      parties._createPartiesCache()
+      const [, , generate] = cache.createCachedQuery.lastCall.args
+      const id = { partyId: 'test-party', regionCode: 'test-region' }
 
-      await generate(id);
+      await generate(id)
 
-      const [query, params] = db.dbQuery.lastCall.args;
+      const [query, params] = db.dbQuery.lastCall.args
 
-      expect(query).to.equal(sql.getParties);
-      expect(params).to.equal(['test-party', 'test-region']);
-    });
-  });
+      expect(query).to.equal(sql.getParties)
+      expect(params).to.equal(['test-party', 'test-region'])
+    })
+  })
 
   experiment('.getParties', () => {
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(parties._getPartiesCache, 'get');
+      sandbox.stub(parties._getPartiesCache, 'get')
 
-      await parties.getParties('test-party', 'test-region');
+      await parties.getParties('test-party', 'test-region')
 
-      const [id] = parties._getPartiesCache.get.lastCall.args;
+      const [id] = parties._getPartiesCache.get.lastCall.args
 
-      expect(id.id).to.equal('parties:partyId:test-party:regionCode:test-region');
-      expect(id.partyId).to.equal('test-party');
-      expect(id.regionCode).to.equal('test-region');
-    });
-  });
+      expect(id.id).to.equal('parties:partyId:test-party:regionCode:test-region')
+      expect(id.partyId).to.equal('test-party')
+      expect(id.regionCode).to.equal('test-region')
+    })
+  })
 
   experiment('._createPartyContactsCache', async () => {
     test('creates a cache with the expected method name', async () => {
-      parties._createPartyContactsCache();
-      const [, methodName] = cache.createCachedQuery.lastCall.args;
-      expect(methodName).to.equal('getPartyContacts');
-    });
+      parties._createPartyContactsCache()
+      const [, methodName] = cache.createCachedQuery.lastCall.args
+      expect(methodName).to.equal('getPartyContacts')
+    })
 
     test('creates a cache with the required generate func', async () => {
-      parties._createPartyContactsCache();
-      const [, , generate] = cache.createCachedQuery.lastCall.args;
-      const id = { partyId: 'test-party', regionCode: 'test-region' };
+      parties._createPartyContactsCache()
+      const [, , generate] = cache.createCachedQuery.lastCall.args
+      const id = { partyId: 'test-party', regionCode: 'test-region' }
 
-      await generate(id);
+      await generate(id)
 
-      const [query, params] = db.dbQuery.lastCall.args;
+      const [query, params] = db.dbQuery.lastCall.args
 
-      expect(query).to.equal(sql.getPartyContacts);
-      expect(params).to.equal(['test-party', 'test-region']);
-    });
-  });
+      expect(query).to.equal(sql.getPartyContacts)
+      expect(params).to.equal(['test-party', 'test-region'])
+    })
+  })
 
   experiment('.getPartyContacts', () => {
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(parties._getPartyContactsCache, 'get');
+      sandbox.stub(parties._getPartyContactsCache, 'get')
 
-      await parties.getPartyContacts('test-party', 'test-region');
+      await parties.getPartyContacts('test-party', 'test-region')
 
-      const [id] = parties._getPartyContactsCache.get.lastCall.args;
+      const [id] = parties._getPartyContactsCache.get.lastCall.args
 
-      expect(id.id).to.equal('partyContacts:partyId:test-party:regionCode:test-region');
-      expect(id.partyId).to.equal('test-party');
-      expect(id.regionCode).to.equal('test-region');
-    });
-  });
+      expect(id.id).to.equal('partyContacts:partyId:test-party:regionCode:test-region')
+      expect(id.partyId).to.equal('test-party')
+      expect(id.regionCode).to.equal('test-region')
+    })
+  })
 
   experiment('.getParty', () => {
     beforeEach(async () => {
-      await parties.getParty('test-party', 'test-region');
-    });
+      await parties.getParty('test-party', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getParty);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getParty)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-party', 'test-region']);
-    });
-  });
-});
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-party', 'test-region'])
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/purposes.js
+++ b/test/modules/nald-import/lib/nald-queries/purposes.js
@@ -1,129 +1,129 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const purposes = require('../../../../../src/modules/nald-import/lib/nald-queries/purposes');
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/purposes');
+const purposes = require('../../../../../src/modules/nald-import/lib/nald-queries/purposes')
+const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/purposes')
 
 experiment('modules/nald-import/lib/queries/purposes', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery');
-    sandbox.stub(cache, 'createCachedQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+    sandbox.stub(cache, 'createCachedQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getPurpose', () => {
     experiment('._createPurposeCache', async () => {
       test('creates a cache with the expected method name', async () => {
-        purposes._createPurposeCache();
-        const [, methodName] = cache.createCachedQuery.lastCall.args;
-        expect(methodName).to.equal('getPurpose');
-      });
+        purposes._createPurposeCache()
+        const [, methodName] = cache.createCachedQuery.lastCall.args
+        expect(methodName).to.equal('getPurpose')
+      })
 
       test('creates a cache with the required generate func', async () => {
-        purposes._createPurposeCache();
-        const [, , generate] = cache.createCachedQuery.lastCall.args;
-        const id = { primary: 'test-1', secondary: 'test-2', tertiary: 'test-3' };
+        purposes._createPurposeCache()
+        const [, , generate] = cache.createCachedQuery.lastCall.args
+        const id = { primary: 'test-1', secondary: 'test-2', tertiary: 'test-3' }
 
-        await generate(id);
+        await generate(id)
 
-        const [query, params] = db.dbQuery.lastCall.args;
+        const [query, params] = db.dbQuery.lastCall.args
 
-        expect(query).to.equal(sql.getPurpose);
-        expect(params).to.equal(['test-1', 'test-2', 'test-3']);
-      });
-    });
+        expect(query).to.equal(sql.getPurpose)
+        expect(params).to.equal(['test-1', 'test-2', 'test-3'])
+      })
+    })
 
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(purposes._getPurposeCache, 'get');
+      sandbox.stub(purposes._getPurposeCache, 'get')
 
-      await purposes.getPurpose({ primary: 'test-1', secondary: 'test-2', tertiary: 'test-3' });
+      await purposes.getPurpose({ primary: 'test-1', secondary: 'test-2', tertiary: 'test-3' })
 
-      const [id] = purposes._getPurposeCache.get.lastCall.args;
+      const [id] = purposes._getPurposeCache.get.lastCall.args
 
-      expect(id.id).to.equal('purpose:primary:test-1:secondary:test-2:tertiary:test-3');
-      expect(id.primary).to.equal('test-1');
-      expect(id.secondary).to.equal('test-2');
-      expect(id.tertiary).to.equal('test-3');
-    });
-  });
+      expect(id.id).to.equal('purpose:primary:test-1:secondary:test-2:tertiary:test-3')
+      expect(id.primary).to.equal('test-1')
+      expect(id.secondary).to.equal('test-2')
+      expect(id.tertiary).to.equal('test-3')
+    })
+  })
 
   experiment('.getPurposes', () => {
     experiment('when called with an increment and issue number', () => {
       test('passes the expected params', async () => {
-        await purposes.getPurposes('test-lic', 'test-reg', 'test-iss', 'test-inc');
-        const [, params] = db.dbQuery.lastCall.args;
-        expect(params).to.equal(['test-lic', 'test-reg', 'test-iss', 'test-inc']);
-      });
-    });
+        await purposes.getPurposes('test-lic', 'test-reg', 'test-iss', 'test-inc')
+        const [, params] = db.dbQuery.lastCall.args
+        expect(params).to.equal(['test-lic', 'test-reg', 'test-iss', 'test-inc'])
+      })
+    })
 
     experiment('when called without an increment and issue number', () => {
       test('passes the expected params', async () => {
-        await purposes.getPurposes('test-lic', 'test-reg');
-        const [, params] = db.dbQuery.lastCall.args;
-        expect(params).to.equal(['test-lic', 'test-reg']);
-      });
-    });
-  });
+        await purposes.getPurposes('test-lic', 'test-reg')
+        const [, params] = db.dbQuery.lastCall.args
+        expect(params).to.equal(['test-lic', 'test-reg'])
+      })
+    })
+  })
 
   experiment('.getPurposePoints', () => {
     beforeEach(async () => {
-      await purposes.getPurposePoints('test-purpose', 'test-region');
-    });
+      await purposes.getPurposePoints('test-purpose', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getPurposePoints);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getPurposePoints)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-purpose', 'test-region']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-purpose', 'test-region'])
+    })
+  })
 
   experiment('.getPurposePointLicenceAgreements', () => {
     beforeEach(async () => {
-      await purposes.getPurposePointLicenceAgreements('test-id', 'test-region');
-    });
+      await purposes.getPurposePointLicenceAgreements('test-id', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getPurposePointLicenceAgreements);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getPurposePointLicenceAgreements)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-id', 'test-region']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-id', 'test-region'])
+    })
+  })
 
   experiment('.getPurposePointLicenceConditions', () => {
     beforeEach(async () => {
-      await purposes.getPurposePointLicenceConditions('test-id', 'test-region');
-    });
+      await purposes.getPurposePointLicenceConditions('test-id', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getPurposePointLicenceConditions);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getPurposePointLicenceConditions)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-id', 'test-region']);
-    });
-  });
-});
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-id', 'test-region'])
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/returns.js
+++ b/test/modules/nald-import/lib/nald-queries/returns.js
@@ -1,258 +1,258 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const returns = require('../../../../../src/modules/nald-import/lib/nald-queries/returns');
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/returns');
+const returns = require('../../../../../src/modules/nald-import/lib/nald-queries/returns')
+const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/returns')
 
 experiment('modules/nald-import/lib/queries/returns', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery');
-    sandbox.stub(cache, 'createCachedQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+    sandbox.stub(cache, 'createCachedQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getFormats', () => {
     beforeEach(async () => {
-      await returns.getFormats('test-lic');
-    });
+      await returns.getFormats('test-lic')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getFormats);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getFormats)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-lic']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-lic'])
+    })
+  })
 
   experiment('.getFormatPurposes', () => {
     beforeEach(async () => {
-      await returns.getFormatPurposes('test-format', 'test-region');
-    });
+      await returns.getFormatPurposes('test-format', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getFormatPurposes);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getFormatPurposes)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-format', 'test-region']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-format', 'test-region'])
+    })
+  })
 
   experiment('.getFormatPoints', () => {
     beforeEach(async () => {
-      await returns.getFormatPoints('test-format', 'test-region');
-    });
+      await returns.getFormatPoints('test-format', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getFormatPoints);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getFormatPoints)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-format', 'test-region']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-format', 'test-region'])
+    })
+  })
 
   experiment('.getLogs', () => {
     beforeEach(async () => {
-      await returns.getLogs('test-format', 'test-region');
-    });
+      await returns.getLogs('test-format', 'test-region')
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getLogs);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getLogs)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-format', 'test-region']);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-format', 'test-region'])
+    })
+  })
 
   experiment('.getLines', () => {
-    let formatId;
-    let regionCode;
-    let dateFrom;
-    let dateTo;
+    let formatId
+    let regionCode
+    let dateFrom
+    let dateTo
 
     beforeEach(async () => {
-      formatId = 'test-format-id';
-      regionCode = 'test-region-code';
-      dateFrom = 'test-date-from';
-      dateTo = 'test-date-to';
-      await returns.getLines(formatId, regionCode, dateFrom, dateTo);
-    });
+      formatId = 'test-format-id'
+      regionCode = 'test-region-code'
+      dateFrom = 'test-date-from'
+      dateTo = 'test-date-to'
+      await returns.getLines(formatId, regionCode, dateFrom, dateTo)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getLines);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getLines)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal([formatId, regionCode, dateFrom, dateTo]);
-    });
-  });
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal([formatId, regionCode, dateFrom, dateTo])
+    })
+  })
 
   experiment('.getLogLines', () => {
-    let formatId;
-    let regionCode;
-    let logDateFrom;
+    let formatId
+    let regionCode
+    let logDateFrom
 
     beforeEach(async () => {
-      formatId = 'test-format-id';
-      regionCode = 'test-region-code';
-      logDateFrom = '01/01/2000';
+      formatId = 'test-format-id'
+      regionCode = 'test-region-code'
+      logDateFrom = '01/01/2000'
 
-      await returns.getLogLines(formatId, regionCode, logDateFrom);
-    });
+      await returns.getLogLines(formatId, regionCode, logDateFrom)
+    })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getLogLines);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getLogLines)
+    })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
+      const [, params] = db.dbQuery.lastCall.args
       expect(params).to.equal([
         formatId,
         regionCode,
         '20000101000000'
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('.isNilReturn', () => {
-    let formatId;
-    let regionCode;
-    let dateFrom;
-    let dateTo;
+    let formatId
+    let regionCode
+    let dateFrom
+    let dateTo
 
     beforeEach(async () => {
-      formatId = 'test-format-id';
-      regionCode = 'test-region-code';
-      dateFrom = 'test-date-from';
-      dateTo = 'test-date-to';
+      formatId = 'test-format-id'
+      regionCode = 'test-region-code'
+      dateFrom = 'test-date-from'
+      dateTo = 'test-date-to'
 
-      db.dbQuery.resolves([{ total_qty: 0 }]);
-    });
+      db.dbQuery.resolves([{ total_qty: 0 }])
+    })
 
     test('uses the correct query', async () => {
-      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo);
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.isNilReturn);
-    });
+      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.isNilReturn)
+    })
 
     test('passes the expected params to the database query', async () => {
-      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo);
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal([formatId, regionCode, dateFrom, dateTo]);
-    });
+      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal([formatId, regionCode, dateFrom, dateTo])
+    })
 
     test('returns true if the total quantity is zero', async () => {
-      db.dbQuery.resolves([{ total_qty: 0 }]);
-      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo);
-      expect(result).to.equal(true);
-    });
+      db.dbQuery.resolves([{ total_qty: 0 }])
+      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      expect(result).to.equal(true)
+    })
 
     test('returns false if the total quantity is not zero', async () => {
-      db.dbQuery.resolves([{ total_qty: 1 }]);
-      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo);
-      expect(result).to.equal(false);
-    });
-  });
+      db.dbQuery.resolves([{ total_qty: 1 }])
+      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      expect(result).to.equal(false)
+    })
+  })
 
   experiment('.getSplitDate', () => {
-    let licenceNumber;
+    let licenceNumber
 
     beforeEach(async () => {
-      licenceNumber = 'test-licence-number';
+      licenceNumber = 'test-licence-number'
 
-      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }]);
-    });
+      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }])
+    })
 
     test('uses the correct query', async () => {
-      await returns.getSplitDate(licenceNumber);
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getSplitDate);
-    });
+      await returns.getSplitDate(licenceNumber)
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getSplitDate)
+    })
 
     test('passes the expected params to the database query', async () => {
-      await returns.getSplitDate(licenceNumber);
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal([licenceNumber]);
-    });
+      await returns.getSplitDate(licenceNumber)
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal([licenceNumber])
+    })
 
     test('returns the date if there are result rows', async () => {
-      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }]);
-      const result = await returns.getSplitDate(licenceNumber);
-      expect(result).to.equal('2000-01-01');
-    });
+      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }])
+      const result = await returns.getSplitDate(licenceNumber)
+      expect(result).to.equal('2000-01-01')
+    })
 
     test('returns null if there are no result rows', async () => {
-      db.dbQuery.resolves([]);
-      const result = await returns.getSplitDate(licenceNumber);
-      expect(result).to.equal(null);
-    });
-  });
+      db.dbQuery.resolves([])
+      const result = await returns.getSplitDate(licenceNumber)
+      expect(result).to.equal(null)
+    })
+  })
 
   experiment('.getReturnVersionReason', () => {
     experiment('._createReturnVersionReasonCache', async () => {
       test('creates a cache with the expected method name', async () => {
-        returns._createReturnVersionReasonCache();
-        const [, methodName] = cache.createCachedQuery.lastCall.args;
-        expect(methodName).to.equal('getReturnVersionReason');
-      });
+        returns._createReturnVersionReasonCache()
+        const [, methodName] = cache.createCachedQuery.lastCall.args
+        expect(methodName).to.equal('getReturnVersionReason')
+      })
 
       test('creates a cache with the required generate func', async () => {
-        returns._createReturnVersionReasonCache();
-        const [, , generate] = cache.createCachedQuery.lastCall.args;
+        returns._createReturnVersionReasonCache()
+        const [, , generate] = cache.createCachedQuery.lastCall.args
         const id = {
           licenceId: 'test-licence',
           regionCode: 'test-region',
           versionNumber: 'test-version'
-        };
+        }
 
-        await generate(id);
+        await generate(id)
 
-        const [query, params] = db.dbQuery.lastCall.args;
+        const [query, params] = db.dbQuery.lastCall.args
 
-        expect(query).to.equal(sql.getReturnVersionReason);
-        expect(params).to.equal(['test-licence', 'test-version', 'test-region']);
-      });
-    });
+        expect(query).to.equal(sql.getReturnVersionReason)
+        expect(params).to.equal(['test-licence', 'test-version', 'test-region'])
+      })
+    })
 
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(returns._getReturnVersionReasonCache, 'get');
+      sandbox.stub(returns._getReturnVersionReasonCache, 'get')
 
-      await returns.getReturnVersionReason('test-licence', 'test-region', 'test-version');
+      await returns.getReturnVersionReason('test-licence', 'test-region', 'test-version')
 
-      const [id] = returns._getReturnVersionReasonCache.get.lastCall.args;
+      const [id] = returns._getReturnVersionReasonCache.get.lastCall.args
 
-      expect(id.id).to.equal('returnVersionReason:licenceId:test-licence:regionCode:test-region:versionNumber:test-version');
-      expect(id.licenceId).to.equal('test-licence');
-      expect(id.regionCode).to.equal('test-region');
-      expect(id.versionNumber).to.equal('test-version');
-    });
-  });
-});
+      expect(id.id).to.equal('returnVersionReason:licenceId:test-licence:regionCode:test-region:versionNumber:test-version')
+      expect(id.licenceId).to.equal('test-licence')
+      expect(id.regionCode).to.equal('test-region')
+      expect(id.versionNumber).to.equal('test-version')
+    })
+  })
+})

--- a/test/modules/nald-import/lib/nald-queries/roles.js
+++ b/test/modules/nald-import/lib/nald-queries/roles.js
@@ -1,40 +1,40 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const roles = require('../../../../../src/modules/nald-import/lib/nald-queries/roles');
-const db = require('../../../../../src/modules/nald-import/lib/db');
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/roles');
+const roles = require('../../../../../src/modules/nald-import/lib/nald-queries/roles')
+const db = require('../../../../../src/modules/nald-import/lib/db')
+const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/roles')
 
 experiment('modules/nald-import/lib/nald-queries/roles', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery').resolves([]);
-  });
+    sandbox.stub(db, 'dbQuery').resolves([])
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getRoles', () => {
     beforeEach(async () => {
-      await roles.getRoles('test-id', 'test-region');
-    });
+      await roles.getRoles('test-id', 'test-region')
+    })
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args;
-      expect(query).to.equal(sql.getRoles);
-    });
+      const [query] = db.dbQuery.lastCall.args
+      expect(query).to.equal(sql.getRoles)
+    })
 
     test('passes the expected params', async () => {
-      const [, params] = db.dbQuery.lastCall.args;
-      expect(params).to.equal(['test-id', 'test-region']);
-    });
-  });
-});
+      const [, params] = db.dbQuery.lastCall.args
+      expect(params).to.equal(['test-id', 'test-region'])
+    })
+  })
+})

--- a/test/modules/nald-import/lib/persist-returns.js
+++ b/test/modules/nald-import/lib/persist-returns.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
-const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const { v4: uuid } = require('uuid');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const { v4: uuid } = require('uuid')
 
-const returnsApi = require('../../../../src/lib/connectors/returns');
-const db = require('../../../../src/modules/nald-import/lib/db');
-const persistReturns = require('../../../../src/modules/nald-import/lib/persist-returns');
+const returnsApi = require('../../../../src/lib/connectors/returns')
+const db = require('../../../../src/modules/nald-import/lib/db')
+const persistReturns = require('../../../../src/modules/nald-import/lib/persist-returns')
 
 const naldReturn = {
   return_id: 'v1:123:456',
@@ -24,7 +24,7 @@ const naldReturn = {
   received_date: '2017-11-24',
   return_requirement: '012345',
   due_date: '2017-11-28'
-};
+}
 
 const digitalServiceReturn = {
   return_id: 'v1:234:789',
@@ -40,101 +40,100 @@ const digitalServiceReturn = {
   received_date: '2018-11-24',
   return_requirement: '67890',
   due_date: '2018-11-28'
-};
+}
 
 experiment('test/modules/nald-import/lib/persist-returns', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery').resolves([{}]);
+    sandbox.stub(db, 'dbQuery').resolves([{}])
 
-    sandbox.stub(returnsApi.returns, 'findOne');
-    sandbox.stub(returnsApi.returns, 'create');
-    sandbox.stub(returnsApi.returns, 'updateOne');
+    sandbox.stub(returnsApi.returns, 'findOne')
+    sandbox.stub(returnsApi.returns, 'create')
+    sandbox.stub(returnsApi.returns, 'updateOne')
 
     sandbox.stub(returnsApi.versions, 'create').resolves({
       data: {
         version_id: uuid(),
         return_id: 'v1:234:789'
       }
-    }); ;
-    sandbox.stub(returnsApi.versions, 'updateOne');
+    })
+    sandbox.stub(returnsApi.versions, 'updateOne')
 
-    sandbox.stub(returnsApi.lines, 'create');
-  });
+    sandbox.stub(returnsApi.lines, 'create')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.returnExists', () => {
     test('returns true if return exists', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn });
-      const exists = await persistReturns.returnExists('01/123');
-      expect(exists).to.equal(true);
-    });
+      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
+      const exists = await persistReturns.returnExists('01/123')
+      expect(exists).to.equal(true)
+    })
 
     test('returns false if return does not exist', async () => {
-      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null });
-      const exists = await persistReturns.returnExists('01/123');
-      expect(exists).to.equal(false);
-    });
-  });
+      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
+      const exists = await persistReturns.returnExists('01/123')
+      expect(exists).to.equal(false)
+    })
+  })
 
   experiment('.getUpdateRow', () => {
     test('updates metadata, status, date received and due date for a past return', async () => {
-      const data = persistReturns.getUpdateRow(naldReturn);
+      const data = persistReturns.getUpdateRow(naldReturn)
       expect(data).to.equal({
         status: 'completed',
         metadata: JSON.stringify({ param: 'value', version: '1' }),
         received_date: '2017-11-24',
         due_date: '2017-11-28'
-      });
-    });
+      })
+    })
 
     test('updates metadata and due date only for a return managed by the digital service', async () => {
-      const data = persistReturns.getUpdateRow(digitalServiceReturn);
+      const data = persistReturns.getUpdateRow(digitalServiceReturn)
       expect(data).to.equal({
         metadata: { param: 'value', version: '1' },
         due_date: '2018-11-28'
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('.createOrUpdateReturn', () => {
     test('creates a row if the record is not present', async () => {
-      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null });
-      returnsApi.returns.create.resolves({ error: null });
+      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
+      returnsApi.returns.create.resolves({ error: null })
 
-      await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01');
+      await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall.args[0]).to.equal(naldReturn);
-      expect(returnsApi.returns.updateOne.firstCall).to.equal(null);
-    });
+      expect(returnsApi.returns.create.firstCall.args[0]).to.equal(naldReturn)
+      expect(returnsApi.returns.updateOne.firstCall).to.equal(null)
+    })
 
     test('updates a NALD return if the record is present', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: naldReturn });
-      returnsApi.returns.updateOne.resolves({ error: null });
-      await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01');
+      returnsApi.returns.findOne.resolves({ error: null, data: naldReturn })
+      returnsApi.returns.updateOne.resolves({ error: null })
+      await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall).to.equal(null);
+      expect(returnsApi.returns.create.firstCall).to.equal(null)
       expect(returnsApi.returns.updateOne.firstCall.args).to.equal([naldReturn.return_id, {
         metadata: naldReturn.metadata,
         status: naldReturn.status,
         received_date: naldReturn.received_date,
         due_date: naldReturn.due_date
-      }]);
-    });
+      }])
+    })
 
     test('updates a digital service return metadata only if the record is present', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn });
-      returnsApi.returns.updateOne.resolves({ error: null });
-      await persistReturns.createOrUpdateReturn(digitalServiceReturn, '2018-01-01');
+      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
+      returnsApi.returns.updateOne.resolves({ error: null })
+      await persistReturns.createOrUpdateReturn(digitalServiceReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall).to.equal(null);
+      expect(returnsApi.returns.create.firstCall).to.equal(null)
       expect(returnsApi.returns.updateOne.firstCall.args).to.equal([digitalServiceReturn.return_id, {
         metadata: digitalServiceReturn.metadata,
         due_date: digitalServiceReturn.due_date
-      }]);
-    });
-  });
+      }])
+    })
+  })
 })
-;

--- a/test/modules/nald-import/lib/transform-crm.js
+++ b/test/modules/nald-import/lib/transform-crm.js
@@ -1,23 +1,23 @@
-'use strict';
+'use strict'
 
 const {
   beforeEach,
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const moment = require('moment');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const moment = require('moment')
 
-const transformCrm = require('../../../../src/modules/nald-import/transform-crm');
+const transformCrm = require('../../../../src/modules/nald-import/transform-crm')
 
 experiment('modules/nald-import/lib/transform-crm', () => {
   experiment('.buildCRMMetadata', () => {
     test('returns a default object if the current version is falsy', async () => {
-      const meta = transformCrm.buildCRMMetadata();
+      const meta = transformCrm.buildCRMMetadata()
       expect(meta).to.equal({
         IsCurrent: false
-      });
-    });
+      })
+    })
 
     test('IsCurrent is true if the currentVersion is supplied', async () => {
       const currentVersion = {
@@ -25,26 +25,26 @@ experiment('modules/nald-import/lib/transform-crm', () => {
         version_effective_date: moment().subtract(1, 'month').format('YYYYMMDD'),
         party: {},
         address: {}
-      };
+      }
 
-      const meta = transformCrm.buildCRMMetadata(currentVersion);
-      expect(meta.IsCurrent).to.be.true();
-      expect(meta.Expires).to.equal(currentVersion.expiry_date);
-      expect(meta.Modified).to.equal(currentVersion.version_effective_date);
-    });
-  });
+      const meta = transformCrm.buildCRMMetadata(currentVersion)
+      expect(meta.IsCurrent).to.be.true()
+      expect(meta.Expires).to.equal(currentVersion.expiry_date)
+      expect(meta.Modified).to.equal(currentVersion.version_effective_date)
+    })
+  })
 
   experiment('.contactsFormatter', () => {
     experiment('when the current version is null', () => {
       test('an empty array is returned', async () => {
-        const contacts = transformCrm.contactsFormatter(null, []);
-        expect(contacts).to.equal([]);
-      });
-    });
+        const contacts = transformCrm.contactsFormatter(null, [])
+        expect(contacts).to.equal([])
+      })
+    })
 
     experiment('when the current version is present without a licence role', () => {
-      let currentVersion;
-      let roles;
+      let currentVersion
+      let roles
 
       beforeEach(async () => {
         currentVersion = {
@@ -66,31 +66,31 @@ experiment('modules/nald-import/lib/transform-crm', () => {
               ]
             }
           ]
-        };
+        }
 
-        roles = [];
-      });
+        roles = []
+      })
 
       test('the licence holder is added to the contacts', async () => {
-        const contacts = transformCrm.contactsFormatter(currentVersion, roles);
-        const licenceHolder = contacts[0];
-        expect(licenceHolder.role).to.equal('Licence holder');
-        expect(licenceHolder.type).to.equal('Person');
-        expect(licenceHolder.forename).to.equal('forename');
-        expect(licenceHolder.name).to.equal('name');
-        expect(licenceHolder.addressLine1).to.equal('test-1');
-      });
+        const contacts = transformCrm.contactsFormatter(currentVersion, roles)
+        const licenceHolder = contacts[0]
+        expect(licenceHolder.role).to.equal('Licence holder')
+        expect(licenceHolder.type).to.equal('Person')
+        expect(licenceHolder.forename).to.equal('forename')
+        expect(licenceHolder.name).to.equal('name')
+        expect(licenceHolder.addressLine1).to.equal('test-1')
+      })
 
       test('the roles are added after the licence holder', async () => {
-        const contacts = transformCrm.contactsFormatter(currentVersion, roles);
-        const role = contacts[1];
-        expect(role).to.equal(undefined);
-      });
-    });
-  });
+        const contacts = transformCrm.contactsFormatter(currentVersion, roles)
+        const role = contacts[1]
+        expect(role).to.equal(undefined)
+      })
+    })
+  })
   experiment('when the current version is present with a licence role', () => {
-    let currentVersion;
-    let roles;
+    let currentVersion
+    let roles
 
     beforeEach(async () => {
       currentVersion = {
@@ -112,7 +112,7 @@ experiment('modules/nald-import/lib/transform-crm', () => {
             ]
           }
         ]
-      };
+      }
 
       roles = [
         {
@@ -128,26 +128,26 @@ experiment('modules/nald-import/lib/transform-crm', () => {
             NAME: 'forname4role'
           }
         }
-      ];
-    });
+      ]
+    })
 
     test('the licence holder is added to the contacts', async () => {
-      const contacts = transformCrm.contactsFormatter(currentVersion, roles);
-      const licenceHolder = contacts[0];
-      expect(licenceHolder.role).to.equal('Licence holder');
-      expect(licenceHolder.type).to.equal('Person');
-      expect(licenceHolder.forename).to.equal('forename');
-      expect(licenceHolder.name).to.equal('name');
-      expect(licenceHolder.addressLine1).to.equal('test-1');
-    });
+      const contacts = transformCrm.contactsFormatter(currentVersion, roles)
+      const licenceHolder = contacts[0]
+      expect(licenceHolder.role).to.equal('Licence holder')
+      expect(licenceHolder.type).to.equal('Person')
+      expect(licenceHolder.forename).to.equal('forename')
+      expect(licenceHolder.name).to.equal('name')
+      expect(licenceHolder.addressLine1).to.equal('test-1')
+    })
 
     test('the roles are added after the licence holder', async () => {
-      const contacts = transformCrm.contactsFormatter(currentVersion, roles);
-      const role = contacts[1];
-      expect(role.role).to.equal('For returns');
-      expect(role.type).to.equal('Person');
-      expect(role.name).to.equal('forname4role');
-      expect(role.addressLine1).to.equal('test-1');
-    });
-  });
-});
+      const contacts = transformCrm.contactsFormatter(currentVersion, roles)
+      const role = contacts[1]
+      expect(role.role).to.equal('For returns')
+      expect(role.type).to.equal('Person')
+      expect(role.name).to.equal('forname4role')
+      expect(role.addressLine1).to.equal('test-1')
+    })
+  })
+})

--- a/test/modules/nald-import/lib/transform-returns-helpers.js
+++ b/test/modules/nald-import/lib/transform-returns-helpers.js
@@ -1,84 +1,84 @@
-'use strict';
+'use strict'
 
-const { beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const moment = require('moment');
-moment.locale('en-gb');
+const { beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const moment = require('moment')
+moment.locale('en-gb')
 
-const transformReturnHelpers = require('../../../../src/modules/nald-import/lib/transform-returns-helpers');
+const transformReturnHelpers = require('../../../../src/modules/nald-import/lib/transform-returns-helpers')
 
 experiment('modules/nald-import/lib/transform-return-helpers', () => {
   experiment('.mapPeriod', () => {
     test('Test mapping of NALD returns periods codes', async () => {
-      expect(transformReturnHelpers.mapPeriod('D')).to.equal('day');
-      expect(transformReturnHelpers.mapPeriod('W')).to.equal('week');
-      expect(transformReturnHelpers.mapPeriod('M')).to.equal('month');
-      expect(transformReturnHelpers.mapPeriod('Q')).to.equal('quarter');
-      expect(transformReturnHelpers.mapPeriod('A')).to.equal('year');
-      expect(transformReturnHelpers.mapPeriod('x')).to.equal(undefined);
-    });
-  });
+      expect(transformReturnHelpers.mapPeriod('D')).to.equal('day')
+      expect(transformReturnHelpers.mapPeriod('W')).to.equal('week')
+      expect(transformReturnHelpers.mapPeriod('M')).to.equal('month')
+      expect(transformReturnHelpers.mapPeriod('Q')).to.equal('quarter')
+      expect(transformReturnHelpers.mapPeriod('A')).to.equal('year')
+      expect(transformReturnHelpers.mapPeriod('x')).to.equal(undefined)
+    })
+  })
 
   experiment('.mapReceivedDate', () => {
     test('with no logs', async () => {
-      const logs = [];
-      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal(null);
-    });
+      const logs = []
+      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal(null)
+    })
 
     test('with a null string value', async () => {
-      const logs = [{ RECD_DATE: '01/01/2017' }, { RECD_DATE: 'null' }];
-      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal(null);
-    });
+      const logs = [{ RECD_DATE: '01/01/2017' }, { RECD_DATE: 'null' }]
+      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal(null)
+    })
 
     test('with valid dates', async () => {
-      const logs = [{ RECD_DATE: '25/12/2017' }, { RECD_DATE: '04/01/2017' }];
-      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal('2017-12-25');
-    });
-  });
+      const logs = [{ RECD_DATE: '25/12/2017' }, { RECD_DATE: '04/01/2017' }]
+      expect(transformReturnHelpers.mapReceivedDate(logs)).to.equal('2017-12-25')
+    })
+  })
 
   experiment('.addDate', () => {
     test('add a date if within range', async () => {
-      expect(transformReturnHelpers.addDate([], '2018-12-01', '2018-01-01', '2018-12-31')).to.equal(['2018-12-01']);
-    });
+      expect(transformReturnHelpers.addDate([], '2018-12-01', '2018-01-01', '2018-12-31')).to.equal(['2018-12-01'])
+    })
     test('dont add a date if before start date', async () => {
-      expect(transformReturnHelpers.addDate([], '2017-12-01', '2018-01-01', '2018-12-31')).to.equal([]);
-    });
+      expect(transformReturnHelpers.addDate([], '2017-12-01', '2018-01-01', '2018-12-31')).to.equal([])
+    })
     test('dont add a date if after end date', async () => {
-      expect(transformReturnHelpers.addDate([], '2018-12-05', '2018-01-01', '2018-11-31')).to.equal([]);
-    });
+      expect(transformReturnHelpers.addDate([], '2018-12-05', '2018-01-01', '2018-11-31')).to.equal([])
+    })
     test('dont add a date if on start date', async () => {
-      expect(transformReturnHelpers.addDate([], '2017-12-01', '2017-12-01', '2018-12-31')).to.equal([]);
-    });
+      expect(transformReturnHelpers.addDate([], '2017-12-01', '2017-12-01', '2018-12-31')).to.equal([])
+    })
     test('dont add a date if on end date', async () => {
-      expect(transformReturnHelpers.addDate([], '2018-11-31', '2018-01-01', '2018-11-31')).to.equal([]);
-    });
+      expect(transformReturnHelpers.addDate([], '2018-11-31', '2018-01-01', '2018-11-31')).to.equal([])
+    })
     test('dont add duplicate dates', async () => {
-      let dates = [];
-      dates = transformReturnHelpers.addDate(dates, '2018-12-01', '2018-01-01', '2018-12-31');
-      dates = transformReturnHelpers.addDate(dates, '2018-12-01', '2018-01-01', '2018-12-31');
-      expect(dates).to.equal(['2018-12-01']);
-    });
-  });
+      let dates = []
+      dates = transformReturnHelpers.addDate(dates, '2018-12-01', '2018-01-01', '2018-12-31')
+      dates = transformReturnHelpers.addDate(dates, '2018-12-01', '2018-01-01', '2018-12-31')
+      expect(dates).to.equal(['2018-12-01'])
+    })
+  })
 
   experiment('.getReturnCycles', () => {
     test('getReturnCycles - single financial year, current version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-04-01', '2015-03-31', '2014-04-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-04-01', '2015-03-31', '2014-04-01', false)
       expect(cycles).to.equal([{
         startDate: '2014-04-01',
         endDate: '2015-03-31',
         isCurrent: true
-      }]);
-    });
+      }])
+    })
     test('getReturnCycles - single financial year, expired version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-04-01', '2015-03-31', '2016-04-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-04-01', '2015-03-31', '2016-04-01', false)
       expect(cycles).to.equal([{
         startDate: '2014-04-01',
         endDate: '2015-03-31',
         isCurrent: false
-      }]);
-    });
+      }])
+    })
     test('getReturnCycles - part financial years, current version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2010-04-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2010-04-01', false)
       expect(cycles).to.equal([
         {
           startDate: '2014-06-01',
@@ -89,11 +89,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-04-01',
           endDate: '2015-07-01',
           isCurrent: true
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part financial years, expired version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2018-04-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2018-04-01', false)
       expect(cycles).to.equal([
         {
           startDate: '2014-06-01',
@@ -104,11 +104,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-04-01',
           endDate: '2015-07-01',
           isCurrent: false
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part financial years, expiry on period start', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2015-04-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2015-04-01', false)
       expect(cycles).to.equal([
         {
           startDate: '2014-06-01',
@@ -119,11 +119,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-04-01',
           endDate: '2015-07-01',
           isCurrent: true
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part financial years, expiry part-way through period', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2015-06-01', false);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2015-06-01', false)
       expect(cycles).to.equal([
         {
           startDate: '2014-06-01',
@@ -139,27 +139,27 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-06-01',
           endDate: '2015-07-01',
           isCurrent: true
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - single summer year, current version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-11-01', '2015-10-31', '2014-11-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-11-01', '2015-10-31', '2014-11-01', true)
       expect(cycles).to.equal([{
         startDate: '2014-11-01',
         endDate: '2015-10-31',
         isCurrent: true
-      }]);
-    });
+      }])
+    })
     test('getReturnCycles - single summer year, expired version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-11-01', '2015-10-31', '2016-04-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-11-01', '2015-10-31', '2016-04-01', true)
       expect(cycles).to.equal([{
         startDate: '2014-11-01',
         endDate: '2015-10-31',
         isCurrent: false
-      }]);
-    });
+      }])
+    })
     test('getReturnCycles - part summer years, current version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-12-01', '2010-04-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-12-01', '2010-04-01', true)
       expect(cycles).to.equal([
         {
           startDate: '2014-06-01',
@@ -175,11 +175,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-11-01',
           endDate: '2015-12-01',
           isCurrent: true
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part summer years, expired version', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2018-04-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2015-07-01', '2018-04-01', true)
 
       expect(cycles).to.equal([
         {
@@ -191,11 +191,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2014-11-01',
           endDate: '2015-07-01',
           isCurrent: false
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part summer years, expiry on period start', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2016-07-01', '2015-11-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2016-07-01', '2015-11-01', true)
 
       expect(cycles).to.equal([
         {
@@ -212,11 +212,11 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-11-01',
           endDate: '2016-07-01',
           isCurrent: true
-        }]);
-    });
+        }])
+    })
 
     test('getReturnCycles - part summer years, expiry part-way through period', async () => {
-      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2016-07-01', '2015-06-01', true);
+      const cycles = transformReturnHelpers.getReturnCycles('2014-06-01', '2016-07-01', '2015-06-01', true)
 
       expect(cycles).to.equal([
         {
@@ -238,44 +238,44 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
           startDate: '2015-11-01',
           endDate: '2016-07-01',
           isCurrent: true
-        }]);
-    });
-  });
+        }])
+    })
+  })
 
   experiment('.getStatus', () => {
     test('returns completed if received date set in NALD', async () => {
-      expect(transformReturnHelpers.getStatus('2018-03-31')).to.equal('completed');
-    });
+      expect(transformReturnHelpers.getStatus('2018-03-31')).to.equal('completed')
+    })
     test('returns due if no received date set in NALD', async () => {
-      expect(transformReturnHelpers.getStatus(null)).to.equal('due');
-    });
-  });
+      expect(transformReturnHelpers.getStatus(null)).to.equal('due')
+    })
+  })
 
   experiment('.getFormatStartDate', () => {
     test('It should return version start date when time limited date is null', async () => {
       const format = {
         EFF_ST_DATE: '03/05/2017',
         TIMELTD_ST_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-05-03');
-    });
+      }
+      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-05-03')
+    })
 
     test('It should return version start date if after time limited start date', async () => {
       const format = {
         EFF_ST_DATE: '03/05/2017',
         TIMELTD_ST_DATE: '01/05/2016'
-      };
-      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-05-03');
-    });
+      }
+      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-05-03')
+    })
 
     test('It should return time limited start date if after version start date', async () => {
       const format = {
         EFF_ST_DATE: '03/05/2017',
         TIMELTD_ST_DATE: '04/12/2017'
-      };
-      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-12-04');
-    });
-  });
+      }
+      expect(transformReturnHelpers.getFormatStartDate(format)).to.equal('2017-12-04')
+    })
+  })
 
   experiment('.getFormatEndDate', () => {
     test('returns null when all dates are null', async () => {
@@ -285,9 +285,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal(null);
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal(null)
+    })
 
     test('returns effective end date if time limited date is null', async () => {
       const format = {
@@ -296,9 +296,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-22');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-22')
+    })
 
     test('returns effective end date if time limited date is after effective end date', async () => {
       const format = {
@@ -307,9 +307,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-22');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-22')
+    })
 
     test('returns time limited end date if effective end date is null', async () => {
       const format = {
@@ -318,9 +318,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-23');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-23')
+    })
     test('returns time limited end date if before effective end date', async () => {
       const format = {
         EFF_END_DATE: '25/04/2015',
@@ -328,9 +328,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: 'null'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-23');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2014-02-23')
+    })
 
     test('returns the licence expiry date is not null', async () => {
       const format = {
@@ -339,9 +339,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: '01/01/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
 
     test('returns the licence revocation date is not null', async () => {
       const format = {
@@ -350,9 +350,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: '02/02/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-02-02');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-02-02')
+    })
 
     test('returns the licence lapsed date if not null', async () => {
       const format = {
@@ -361,9 +361,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_LAPSED_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_EXPIRY_DATE: '01/01/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
 
     test('returns the earliest date of licence has multiple dates', async () => {
       const format = {
@@ -372,9 +372,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_REVOKED_DATE: '01/01/2018',
         LICENCE_LAPSED_DATE: '02/02/2018',
         LICENCE_EXPIRY_DATE: '03/03/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
 
     test('returns time limited end date if before the licence dates', async () => {
       const format = {
@@ -383,9 +383,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_REVOKED_DATE: '02/02/2018',
         LICENCE_LAPSED_DATE: '03/03/2018',
         LICENCE_EXPIRY_DATE: '04/04/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
 
     test('returns effective end date if before the licence dates', async () => {
       const format = {
@@ -394,9 +394,9 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_REVOKED_DATE: '02/02/2018',
         LICENCE_LAPSED_DATE: '03/03/2018',
         LICENCE_EXPIRY_DATE: '04/04/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
 
     test('returns the licence lapsed date if before effective end date', async () => {
       const format = {
@@ -405,10 +405,10 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: '01/01/2018',
         LICENCE_EXPIRY_DATE: '04/04/2018'
-      };
-      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01');
-    });
-  });
+      }
+      expect(transformReturnHelpers.getFormatEndDate(format)).to.equal('2018-01-01')
+    })
+  })
 
   experiment('.getFormatCycles', () => {
     test('It should calculate summer cycle', async () => {
@@ -421,15 +421,15 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_EXPIRY_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: 'null'
-      };
-      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01');
+      }
+      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01')
 
       expect(cycles).to.equal([
         { startDate: '2016-05-23', endDate: '2016-10-31', isCurrent: true },
         { startDate: '2016-11-01', endDate: '2017-10-31', isCurrent: true },
         { startDate: '2017-11-01', endDate: '2018-03-30', isCurrent: true }
-      ]);
-    });
+      ])
+    })
 
     test('It should calculate winter cycle', async () => {
       const format = {
@@ -441,14 +441,14 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_EXPIRY_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: 'null'
-      };
-      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01');
+      }
+      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01')
 
       expect(cycles).to.equal([
         { startDate: '2016-05-23', endDate: '2017-03-31', isCurrent: true },
         { startDate: '2017-04-01', endDate: '2018-03-30', isCurrent: true }
-      ]);
-    });
+      ])
+    })
 
     test('It should split cycles on current licence version start date', async () => {
       const format = {
@@ -460,15 +460,15 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_EXPIRY_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: 'null'
-      };
-      const cycles = transformReturnHelpers.getFormatCycles(format, '2017-06-01');
+      }
+      const cycles = transformReturnHelpers.getFormatCycles(format, '2017-06-01')
 
       expect(cycles).to.equal([
         { startDate: '2016-05-23', endDate: '2017-03-31', isCurrent: false },
         { startDate: '2017-04-01', endDate: '2017-05-31', isCurrent: false },
         { startDate: '2017-06-01', endDate: '2018-03-30', isCurrent: true }
-      ]);
-    });
+      ])
+    })
 
     test('It should observe time limited start/end dates for summer cycle', async () => {
       const format = {
@@ -480,15 +480,15 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_EXPIRY_DATE: 'null',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: 'null'
-      };
-      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01');
+      }
+      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01')
 
       expect(cycles).to.equal([
         { startDate: '2016-05-25', endDate: '2016-10-31', isCurrent: true },
         { startDate: '2016-11-01', endDate: '2017-10-31', isCurrent: true },
         { startDate: '2017-11-01', endDate: '2018-03-28', isCurrent: true }
-      ]);
-    });
+      ])
+    })
 
     test('a licence ended date is respected and the cycles are reduced in length', async () => {
     // here the licence has expired before the version end date
@@ -501,19 +501,19 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         LICENCE_EXPIRY_DATE: '01/01/2017',
         LICENCE_REVOKED_DATE: 'null',
         LICENCE_LAPSED_DATE: 'null'
-      };
+      }
 
-      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01');
+      const cycles = transformReturnHelpers.getFormatCycles(format, '2014-04-01')
 
       expect(cycles).to.equal([
         { startDate: '2016-05-23', endDate: '2016-10-31', isCurrent: true },
         { startDate: '2016-11-01', endDate: '2017-01-01', isCurrent: true }
-      ]);
-    });
-  });
+      ])
+    })
+  })
 
   experiment('.formatReturnMetadata', () => {
-    let metadata;
+    let metadata
 
     const getPurpose = alias => ({
       APUR_APPR_CODE: 'W',
@@ -523,7 +523,7 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
       primary_purpose: 'primary',
       secondary_purpose: 'secondary',
       tertiary_purpose: 'tertiary'
-    });
+    })
 
     const formatData = {
       TPT_FLAG: 'N',
@@ -538,66 +538,66 @@ experiment('modules/nald-import/lib/transform-return-helpers', () => {
         getPurpose(' null ')
       ],
       points: []
-    };
+    }
 
     beforeEach(async () => {
-      metadata = transformReturnHelpers.formatReturnMetadata(formatData);
-    });
+      metadata = transformReturnHelpers.formatReturnMetadata(formatData)
+    })
 
     test('the purposes contain the alias', async () => {
-      expect(metadata.purposes[0].alias).to.equal('Water alias');
-      expect(metadata.purposes[1].alias).to.equal('Agri alias');
-    });
+      expect(metadata.purposes[0].alias).to.equal('Water alias')
+      expect(metadata.purposes[1].alias).to.equal('Agri alias')
+    })
 
     test('null aliases are ignored', async () => {
-      expect(metadata.purposes[2].alias).to.be.undefined();
-      expect(metadata.purposes[3].alias).to.be.undefined();
-      expect(metadata.purposes[4].alias).to.be.undefined();
-      expect(metadata.purposes[5].alias).to.be.undefined();
-    });
+      expect(metadata.purposes[2].alias).to.be.undefined()
+      expect(metadata.purposes[3].alias).to.be.undefined()
+      expect(metadata.purposes[4].alias).to.be.undefined()
+      expect(metadata.purposes[5].alias).to.be.undefined()
+    })
 
     test('the area code is added to the metadata', async () => {
-      expect(metadata.nald.areaCode).to.equal('KAEA');
-    });
+      expect(metadata.nald.areaCode).to.equal('KAEA')
+    })
 
     test('adds an isTwoPartTariff flag', async () => {
-      expect(metadata.isTwoPartTariff).to.be.false();
-    });
+      expect(metadata.isTwoPartTariff).to.be.false()
+    })
 
     test('adds an isSummer flag', async () => {
-      expect(metadata.isSummer).to.be.true();
-    });
+      expect(metadata.isSummer).to.be.true()
+    })
 
     experiment('isUpload flag', () => {
       const createFormat = month => transformReturnHelpers.formatReturnMetadata({
         ...metadata,
         FORM_PRODN_MONTH: month
-      });
+      })
 
       test('sets isUpload true for form production month 45', async () => {
-        const data = createFormat(45);
-        expect(data.isUpload).to.equal(true);
-      });
+        const data = createFormat(45)
+        expect(data.isUpload).to.equal(true)
+      })
 
       test('sets isUpload true for form production month 46', async () => {
-        const data = createFormat(46);
-        expect(data.isUpload).to.equal(true);
-      });
+        const data = createFormat(46)
+        expect(data.isUpload).to.equal(true)
+      })
 
       test('sets isUpload true for form production month 65', async () => {
-        const data = createFormat(65);
-        expect(data.isUpload).to.equal(true);
-      });
+        const data = createFormat(65)
+        expect(data.isUpload).to.equal(true)
+      })
 
       test('sets isUpload true for form production month 66', async () => {
-        const data = createFormat(66);
-        expect(data.isUpload).to.equal(true);
-      });
+        const data = createFormat(66)
+        expect(data.isUpload).to.equal(true)
+      })
 
       test('sets isUpload false for other months', async () => {
-        const data = createFormat(67);
-        expect(data.isUpload).to.equal(false);
-      });
-    });
-  });
-});
+        const data = createFormat(67)
+        expect(data.isUpload).to.equal(false)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/mappers/charge-versions.js
+++ b/test/modules/nald-import/mappers/charge-versions.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const mapper = require('../../../../src/modules/nald-import/mappers/charge-versions');
+const mapper = require('../../../../src/modules/nald-import/mappers/charge-versions')
 
-const NALD_GAP_ID = 'nald-gap-id';
-const STATUS_SUPERSEDED = 'superseded';
-const STATUS_CURRENT = 'current';
-const WATER_LICENCE_ID = '00000000-0000-0000-0000-000000000000';
+const NALD_GAP_ID = 'nald-gap-id'
+const STATUS_SUPERSEDED = 'superseded'
+const STATUS_CURRENT = 'current'
+const WATER_LICENCE_ID = '00000000-0000-0000-0000-000000000000'
 
 const getLicence = (overrides = {}) => ({
   ID: '1',
@@ -17,53 +17,53 @@ const getLicence = (overrides = {}) => ({
   FGAC_REGION_CODE: '1',
   start_date: '2018-01-01',
   end_date: overrides.end_date || null
-});
+})
 
 experiment('modules/nald-import/mappers/charge-versions.js', () => {
-  let result;
+  let result
 
   experiment('.mapNALDChargeVersionsToWRLS', () => {
     experiment('when the are no NALD charge versions, and licence has no end date', () => {
       beforeEach(async () => {
-        const licence = getLicence();
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, [], NALD_GAP_ID);
-      });
+        const licence = getLicence()
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, [], NALD_GAP_ID)
+      })
 
       test('there is a single charge version', async () => {
-        expect(result).to.be.an.array().length(1);
-      });
+        expect(result).to.be.an.array().length(1)
+      })
 
       test('the charge version is a NALD gap with same date range as licence', async () => {
-        const [cv] = result;
-        expect(cv.is_nald_gap).to.be.true();
-        expect(cv.start_date).to.equal('2018-01-01');
-        expect(cv.end_date).to.equal(null);
-        expect(cv.status).to.equal(STATUS_CURRENT);
-      });
-    });
+        const [cv] = result
+        expect(cv.is_nald_gap).to.be.true()
+        expect(cv.start_date).to.equal('2018-01-01')
+        expect(cv.end_date).to.equal(null)
+        expect(cv.status).to.equal(STATUS_CURRENT)
+      })
+    })
 
     experiment('when the are no NALD charge versions, and licence has an end date', () => {
       beforeEach(async () => {
-        const licence = getLicence({ end_date: '2020-01-01' });
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, [], NALD_GAP_ID);
-      });
+        const licence = getLicence({ end_date: '2020-01-01' })
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, [], NALD_GAP_ID)
+      })
 
       test('there is a single charge version', async () => {
-        expect(result).to.be.an.array().length(1);
-      });
+        expect(result).to.be.an.array().length(1)
+      })
 
       test('the charge version is a NALD gap with same date range as licence', async () => {
-        const [cv] = result;
-        expect(cv.is_nald_gap).to.be.true();
-        expect(cv.start_date).to.equal('2018-01-01');
-        expect(cv.end_date).to.equal('2020-01-01');
-        expect(cv.status).to.equal(STATUS_CURRENT);
-      });
-    });
+        const [cv] = result
+        expect(cv.is_nald_gap).to.be.true()
+        expect(cv.start_date).to.equal('2018-01-01')
+        expect(cv.end_date).to.equal('2020-01-01')
+        expect(cv.status).to.equal(STATUS_CURRENT)
+      })
+    })
 
     experiment('when there are gaps in a charge version history', () => {
       beforeEach(async () => {
-        const licence = getLicence();
+        const licence = getLicence()
         const chargeVersions = [
           {
             external_id: '1:1:1',
@@ -81,58 +81,58 @@ experiment('modules/nald-import/mappers/charge-versions.js', () => {
             end_date: '2020-01-01',
             licence_id: WATER_LICENCE_ID
           }
-        ];
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID);
-      });
+        ]
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID)
+      })
 
       test('there are 5 charge versions', async () => {
-        expect(result).to.be.an.array().length(5);
-      });
+        expect(result).to.be.an.array().length(5)
+      })
 
       test('the 0th element is a NALD gap inserted from the licence start date to the first charge version', async () => {
-        const cv = result[0];
-        expect(cv.is_nald_gap).to.be.true();
-        expect(cv.start_date).to.equal('2018-01-01');
-        expect(cv.end_date).to.equal('2018-01-31');
-        expect(cv.status).to.equal(STATUS_CURRENT);
-      });
+        const cv = result[0]
+        expect(cv.is_nald_gap).to.be.true()
+        expect(cv.start_date).to.equal('2018-01-01')
+        expect(cv.end_date).to.equal('2018-01-31')
+        expect(cv.status).to.equal(STATUS_CURRENT)
+      })
 
       test('the 1st element is the first NALD charge version', async () => {
-        const cv = result[1];
-        expect(cv.change_reason_id).to.be.undefined();
-        expect(cv.external_id).to.equal('1:1:1');
-        expect(cv.status).to.equal(STATUS_CURRENT);
-        expect(cv.licence_id).to.equal(WATER_LICENCE_ID);
-      });
+        const cv = result[1]
+        expect(cv.change_reason_id).to.be.undefined()
+        expect(cv.external_id).to.equal('1:1:1')
+        expect(cv.status).to.equal(STATUS_CURRENT)
+        expect(cv.licence_id).to.equal(WATER_LICENCE_ID)
+      })
 
       test('the 2nd element is a NALD gap inserted between non-adjacent charge versions', async () => {
-        const cv = result[2];
-        expect(cv.is_nald_gap).to.be.true();
-        expect(cv.start_date).to.equal('2019-01-02');
-        expect(cv.end_date).to.equal('2019-01-31');
-        expect(cv.status).to.equal(STATUS_CURRENT);
-      });
+        const cv = result[2]
+        expect(cv.is_nald_gap).to.be.true()
+        expect(cv.start_date).to.equal('2019-01-02')
+        expect(cv.end_date).to.equal('2019-01-31')
+        expect(cv.status).to.equal(STATUS_CURRENT)
+      })
 
       test('the 3rd element is the second NALD charge version', async () => {
-        const cv = result[3];
-        expect(cv.change_reason_id).to.be.undefined();
-        expect(cv.external_id).to.equal('1:1:2');
-        expect(cv.status).to.equal(STATUS_CURRENT);
-        expect(cv.licence_id).to.equal(WATER_LICENCE_ID);
-      });
+        const cv = result[3]
+        expect(cv.change_reason_id).to.be.undefined()
+        expect(cv.external_id).to.equal('1:1:2')
+        expect(cv.status).to.equal(STATUS_CURRENT)
+        expect(cv.licence_id).to.equal(WATER_LICENCE_ID)
+      })
 
       test('the 4th element is a NALD gap inserted from the last charge version to the licence end date', async () => {
-        const cv = result[4];
-        expect(cv.is_nald_gap).to.be.true();
-        expect(cv.start_date).to.equal('2020-01-02');
-        expect(cv.end_date).to.equal(null);
-        expect(cv.status).to.equal(STATUS_CURRENT);
-      });
-    });
+        const cv = result[4]
+        expect(cv.is_nald_gap).to.be.true()
+        expect(cv.start_date).to.equal('2020-01-02')
+        expect(cv.end_date).to.equal(null)
+        expect(cv.status).to.equal(STATUS_CURRENT)
+      })
+    })
 
     experiment('when a charge version is marked in error', () => {
       beforeEach(async () => {
-        const licence = getLicence();
+        const licence = getLicence()
         const chargeVersions = [
           {
             external_id: '1:1:1',
@@ -151,36 +151,36 @@ experiment('modules/nald-import/mappers/charge-versions.js', () => {
             end_date: null,
             licence_id: WATER_LICENCE_ID
           }
-        ];
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID);
-      });
+        ]
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID)
+      })
 
       test('there are 2 charge versions', async () => {
-        expect(result).to.be.an.array().length(2);
-      });
+        expect(result).to.be.an.array().length(2)
+      })
 
       test('the 0th element is mapped to "superseded"', async () => {
-        const cv = result[0];
-        expect(cv.change_reason_id).to.be.undefined();
-        expect(cv.start_date).to.equal('2018-01-01');
-        expect(cv.end_date).to.equal('2018-01-01');
-        expect(cv.status).to.equal(STATUS_SUPERSEDED);
-        expect(cv.licence_id).to.equal(WATER_LICENCE_ID);
-      });
+        const cv = result[0]
+        expect(cv.change_reason_id).to.be.undefined()
+        expect(cv.start_date).to.equal('2018-01-01')
+        expect(cv.end_date).to.equal('2018-01-01')
+        expect(cv.status).to.equal(STATUS_SUPERSEDED)
+        expect(cv.licence_id).to.equal(WATER_LICENCE_ID)
+      })
 
       test('the 1st element is mapped to "current"', async () => {
-        const cv = result[1];
-        expect(cv.change_reason_id).to.be.undefined();
-        expect(cv.start_date).to.equal('2018-01-01');
-        expect(cv.end_date).to.equal(null);
-        expect(cv.status).to.equal(STATUS_CURRENT);
-        expect(cv.licence_id).to.equal(WATER_LICENCE_ID);
-      });
-    });
+        const cv = result[1]
+        expect(cv.change_reason_id).to.be.undefined()
+        expect(cv.start_date).to.equal('2018-01-01')
+        expect(cv.end_date).to.equal(null)
+        expect(cv.status).to.equal(STATUS_CURRENT)
+        expect(cv.licence_id).to.equal(WATER_LICENCE_ID)
+      })
+    })
 
     experiment('when a charge version pre-dates the licence start date', () => {
       beforeEach(async () => {
-        const licence = getLicence();
+        const licence = getLicence()
         const chargeVersions = [
           {
             external_id: '1:1:1',
@@ -198,20 +198,20 @@ experiment('modules/nald-import/mappers/charge-versions.js', () => {
             end_date: null,
             licence_id: WATER_LICENCE_ID
           }
-        ];
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID);
-      });
+        ]
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID)
+      })
 
       test('does not insert nald gap charge versions', async () => {
-        expect(result).to.be.an.array().length(2);
-        const ids = result.map(row => row.external_id);
-        expect(ids).to.only.include(['1:1:1', '1:1:2']);
-      });
-    });
+        expect(result).to.be.an.array().length(2)
+        const ids = result.map(row => row.external_id)
+        expect(ids).to.only.include(['1:1:1', '1:1:2'])
+      })
+    })
 
     experiment('when a charge version has the same start and end dates, and the same start date as the following charge version', () => {
       beforeEach(async () => {
-        const licence = getLicence();
+        const licence = getLicence()
         const chargeVersions = [
           {
             external_id: '1:1:1',
@@ -229,25 +229,25 @@ experiment('modules/nald-import/mappers/charge-versions.js', () => {
             end_date: null,
             licence_id: WATER_LICENCE_ID
           }
-        ];
-        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID);
-      });
+        ]
+        result = mapper.mapNALDChargeVersionsToWRLS(licence, chargeVersions, NALD_GAP_ID)
+      })
 
       test('there are 2 charge versions', async () => {
-        expect(result).to.be.an.array().length(2);
-      });
+        expect(result).to.be.an.array().length(2)
+      })
 
       test('the first charge version has its dates unchanged', async () => {
-        expect(result[0].start_date).to.equal('2018-01-01');
-        expect(result[0].end_date).to.equal('2018-01-01');
-        expect(result[0].status).to.equal(STATUS_SUPERSEDED);
-      });
+        expect(result[0].start_date).to.equal('2018-01-01')
+        expect(result[0].end_date).to.equal('2018-01-01')
+        expect(result[0].status).to.equal(STATUS_SUPERSEDED)
+      })
 
       test('the second charge version has its dates unchanged', async () => {
-        expect(result[1].start_date).to.equal('2018-01-01');
-        expect(result[1].end_date).to.equal(null);
-        expect(result[1].status).to.equal(STATUS_CURRENT);
-      });
-    });
-  });
-});
+        expect(result[1].start_date).to.equal('2018-01-01')
+        expect(result[1].end_date).to.equal(null)
+        expect(result[1].status).to.equal(STATUS_CURRENT)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/nald.js
+++ b/test/modules/nald-import/nald.js
@@ -1,21 +1,21 @@
-const { before, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const hapi = require('@hapi/hapi');
-const server = new hapi.Server();
+const { before, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const hapi = require('@hapi/hapi')
+const server = new hapi.Server()
 
-const licenceCreator = require('../../../scripts/licence-creator/index.js');
-const { copyTestFiles } = require('../../../src/modules/nald-import/services/extract-service.js');
-const routes = Object.values(require('../../../src/modules/nald-import/routes'));
+const licenceCreator = require('../../../scripts/licence-creator/index.js')
+const { copyTestFiles } = require('../../../src/modules/nald-import/services/extract-service.js')
+const routes = Object.values(require('../../../src/modules/nald-import/routes'))
 
-let licenceData;
+let licenceData
 
 experiment('Test NALD import', () => {
   before(async () => {
-    await server.route(routes);
+    await server.route(routes)
 
     // Generate dummy NALD data
-    await licenceCreator();
-    await copyTestFiles();
+    await licenceCreator()
+    await copyTestFiles()
 
     // Load dummy licence JSON
     const request2 = {
@@ -24,115 +24,115 @@ experiment('Test NALD import', () => {
       headers: {
         Authorization: process.env.JWT_TOKEN
       }
-    };
-    const res = await server.inject(request2);
-    licenceData = JSON.parse(res.payload);
-  });
+    }
+    const res = await server.inject(request2)
+    licenceData = JSON.parse(res.payload)
+  })
 
   test('Test licence number', async () => {
-    expect(licenceData.LIC_NO).to.equal('12/34/56/78');
-  });
+    expect(licenceData.LIC_NO).to.equal('12/34/56/78')
+  })
 
   test('Test start date', async () => {
-    expect(licenceData.ORIG_EFF_DATE).to.equal('01/01/2018');
-  });
+    expect(licenceData.ORIG_EFF_DATE).to.equal('01/01/2018')
+  })
 
   test('Test start date', async () => {
-    expect(licenceData.ORIG_EFF_DATE).to.equal('01/01/2018');
-  });
+    expect(licenceData.ORIG_EFF_DATE).to.equal('01/01/2018')
+  })
 
   test('Test expiry date', async () => {
-    expect(licenceData.EXPIRY_DATE).to.equal('01/01/2220');
-  });
+    expect(licenceData.EXPIRY_DATE).to.equal('01/01/2220')
+  })
 
   test('Test current version', async () => {
-    expect(licenceData.data.current_version.licence.STATUS).to.equal('CURR');
-  });
+    expect(licenceData.data.current_version.licence.STATUS).to.equal('CURR')
+  })
 
   test('Test party count', async () => {
-    expect(licenceData.data.current_version.licence.party.length).to.equal(1);
-  });
+    expect(licenceData.data.current_version.licence.party.length).to.equal(1)
+  })
 
   test('Test party details', async () => {
-    const [party] = licenceData.data.current_version.licence.party;
-    expect(party.APAR_TYPE).to.equal('PER');
-    expect(party.FORENAME).to.equal('John');
-    expect(party.NAME).to.equal('Doe');
-  });
+    const [party] = licenceData.data.current_version.licence.party
+    expect(party.APAR_TYPE).to.equal('PER')
+    expect(party.FORENAME).to.equal('John')
+    expect(party.NAME).to.equal('Doe')
+  })
 
   test('Test address', async () => {
-    const { address } = licenceData.data.current_version;
-    expect(address.ADDR_LINE_1).to.equal('Daisy cow farm');
-  });
+    const { address } = licenceData.data.current_version
+    expect(address.ADDR_LINE_1).to.equal('Daisy cow farm')
+  })
 
   test('Test purpose count', async () => {
-    const { purposes } = licenceData.data.current_version;
-    expect(purposes.length).to.equal(1);
-  });
+    const { purposes } = licenceData.data.current_version
+    expect(purposes.length).to.equal(1)
+  })
 
   test('Test purpose', async () => {
-    const purpose = licenceData.data.current_version.purposes[0].purpose[0];
-    expect(purpose.purpose_primary.CODE).to.equal('A');
-    expect(purpose.purpose_secondary.CODE).to.equal('AGR');
-    expect(purpose.purpose_tertiary.CODE).to.equal('140');
-  });
+    const purpose = licenceData.data.current_version.purposes[0].purpose[0]
+    expect(purpose.purpose_primary.CODE).to.equal('A')
+    expect(purpose.purpose_secondary.CODE).to.equal('AGR')
+    expect(purpose.purpose_tertiary.CODE).to.equal('140')
+  })
 
   test('Test point count', async () => {
-    const { purposePoints } = licenceData.data.current_version.purposes[0];
-    expect(purposePoints.length).to.equal(1);
-  });
+    const { purposePoints } = licenceData.data.current_version.purposes[0]
+    expect(purposePoints.length).to.equal(1)
+  })
 
   test('Test point', async () => {
-    const [point] = licenceData.data.current_version.purposes[0].purposePoints;
-    expect(point.means_of_abstraction.CODE).to.equal('UNP');
-    expect(point.point_detail.NGR1_SHEET).to.equal('SP');
-    expect(point.point_detail.NGR1_EAST).to.equal('123');
-    expect(point.point_detail.NGR1_NORTH).to.equal('456');
-    expect(point.point_detail.LOCAL_NAME).to.equal('TEST BOREHOLE');
-    expect(point.point_source.CODE).to.equal('GWSOS');
-  });
+    const [point] = licenceData.data.current_version.purposes[0].purposePoints
+    expect(point.means_of_abstraction.CODE).to.equal('UNP')
+    expect(point.point_detail.NGR1_SHEET).to.equal('SP')
+    expect(point.point_detail.NGR1_EAST).to.equal('123')
+    expect(point.point_detail.NGR1_NORTH).to.equal('456')
+    expect(point.point_detail.LOCAL_NAME).to.equal('TEST BOREHOLE')
+    expect(point.point_source.CODE).to.equal('GWSOS')
+  })
 
   test('Test agreement', async () => {
-    const [agreement] = licenceData.data.current_version.purposes[0].licenceAgreements;
-    expect(agreement.EFF_ST_DATE).to.equal('01/01/2018');
-  });
+    const [agreement] = licenceData.data.current_version.purposes[0].licenceAgreements
+    expect(agreement.EFF_ST_DATE).to.equal('01/01/2018')
+  })
 
   test('Test condition count', async () => {
-    const conditions = licenceData.data.current_version.purposes[0].licenceConditions;
-    expect(conditions.length).to.equal(1);
-  });
+    const conditions = licenceData.data.current_version.purposes[0].licenceConditions
+    expect(conditions.length).to.equal(1)
+  })
 
   test('Test condition', async () => {
-    const [condition] = licenceData.data.current_version.purposes[0].licenceConditions;
-    expect(condition.ACIN_CODE).to.equal('CES');
-    expect(condition.ACIN_SUBCODE).to.equal('FLOW');
-    expect(condition.PARAM1).to.equal('AUTHOR');
-    expect(condition.PARAM2).to.equal('17.5');
-  });
+    const [condition] = licenceData.data.current_version.purposes[0].licenceConditions
+    expect(condition.ACIN_CODE).to.equal('CES')
+    expect(condition.ACIN_SUBCODE).to.equal('FLOW')
+    expect(condition.PARAM1).to.equal('AUTHOR')
+    expect(condition.PARAM2).to.equal('17.5')
+  })
 
   test('Test role count', async () => {
-    const { roles } = licenceData.data;
-    expect(roles.length).to.equal(1);
-  });
+    const { roles } = licenceData.data
+    expect(roles.length).to.equal(1)
+  })
 
   test('Test role detail', async () => {
-    const [role] = licenceData.data.roles;
-    const { role_detail: roleDetail, role_type: roleType, role_party: roleParty } = role;
-    expect(roleDetail.ALRT_CODE).to.equal('LC');
-    expect(roleType.CODE).to.equal('LC');
-    expect(roleType.DESCR).to.equal('Licence contact');
-    expect(roleParty.APAR_TYPE).to.equal('PER');
-    expect(roleParty.NAME).to.equal('Doe');
-    expect(roleParty.FORENAME).to.equal('John');
-  });
+    const [role] = licenceData.data.roles
+    const { role_detail: roleDetail, role_type: roleType, role_party: roleParty } = role
+    expect(roleDetail.ALRT_CODE).to.equal('LC')
+    expect(roleType.CODE).to.equal('LC')
+    expect(roleType.DESCR).to.equal('Licence contact')
+    expect(roleParty.APAR_TYPE).to.equal('PER')
+    expect(roleParty.NAME).to.equal('Doe')
+    expect(roleParty.FORENAME).to.equal('John')
+  })
 
   test('Test role address', async () => {
-    const [role] = licenceData.data.roles;
-    const { role_address: roleAddress } = role;
-    expect(roleAddress.ADDR_LINE_1).to.equal('Daisy cow farm');
-    expect(roleAddress.ADDR_LINE_2).to.equal('Long road');
-    expect(roleAddress.TOWN).to.equal('Daisybury');
-    expect(roleAddress.COUNTY).to.equal('Testingshire');
-    expect(roleAddress.POSTCODE).to.equal('TT1 1TT');
-  });
-});
+    const [role] = licenceData.data.roles
+    const { role_address: roleAddress } = role
+    expect(roleAddress.ADDR_LINE_1).to.equal('Daisy cow farm')
+    expect(roleAddress.ADDR_LINE_2).to.equal('Long road')
+    expect(roleAddress.TOWN).to.equal('Daisybury')
+    expect(roleAddress.COUNTY).to.equal('Testingshire')
+    expect(roleAddress.POSTCODE).to.equal('TT1 1TT')
+  })
+})

--- a/test/modules/nald-import/plugin.js
+++ b/test/modules/nald-import/plugin.js
@@ -3,18 +3,18 @@ const {
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const cron = require('node-cron');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const cron = require('node-cron')
 
-const config = require('../../../config');
-const { plugin } = require('../../../src/modules/nald-import/plugin');
-const jobs = require('../../../src/modules/nald-import/jobs');
+const config = require('../../../config')
+const { plugin } = require('../../../src/modules/nald-import/plugin')
+const jobs = require('../../../src/modules/nald-import/jobs')
 
 experiment('modules/nald-import/plugin', () => {
-  let server;
+  let server
 
   beforeEach(async () => {
     server = {
@@ -23,127 +23,127 @@ experiment('modules/nald-import/plugin', () => {
         subscribe: sandbox.stub(),
         onComplete: sandbox.stub()
       }
-    };
-    sandbox.stub(cron, 'schedule');
+    }
+    sandbox.stub(cron, 'schedule')
 
-    sandbox.stub(jobs.s3Download, 'onCompleteHandler');
-    sandbox.stub(jobs.populatePendingImport, 'onCompleteHandler');
-    sandbox.stub(jobs.deleteRemovedDocuments, 'onCompleteHandler');
-  });
+    sandbox.stub(jobs.s3Download, 'onCompleteHandler')
+    sandbox.stub(jobs.populatePendingImport, 'onCompleteHandler')
+    sandbox.stub(jobs.deleteRemovedDocuments, 'onCompleteHandler')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   test('plugin has a name', async () => {
-    expect(plugin.name).to.equal('importNaldData');
-  });
+    expect(plugin.name).to.equal('importNaldData')
+  })
 
   experiment('when the plugin is registered', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(false);
-      await plugin.register(server);
-    });
+      sandbox.stub(config, 'isProduction').value(false)
+      await plugin.register(server)
+    })
 
     test('registers s3Download job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(0).args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(0).args
 
-      expect(jobName).to.equal(jobs.s3Download.job.jobName);
-      expect(options).to.equal({});
-      expect(handler).to.equal(jobs.s3Download.job.handler);
-    });
+      expect(jobName).to.equal(jobs.s3Download.job.jobName)
+      expect(options).to.equal({})
+      expect(handler).to.equal(jobs.s3Download.job.handler)
+    })
 
     test('registers s3Download onComplete handler', async () => {
-      const completedJob = { id: 'testing' };
+      const completedJob = { id: 'testing' }
 
-      const [jobName, func] = server.messageQueue.onComplete.getCall(0).args;
-      func(completedJob);
+      const [jobName, func] = server.messageQueue.onComplete.getCall(0).args
+      func(completedJob)
 
-      expect(jobName).to.equal(jobs.s3Download.job.jobName);
+      expect(jobName).to.equal(jobs.s3Download.job.jobName)
       expect(jobs.s3Download.onCompleteHandler.calledWith(
         completedJob,
         server.messageQueue
-      )).to.equal(true);
-    });
+      )).to.equal(true)
+    })
 
     test('registers deleteRemovedDocuments job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(1).args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(1).args
 
-      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName);
-      expect(options).to.equal({});
-      expect(handler).to.equal(jobs.deleteRemovedDocuments.job.handler);
-    });
+      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName)
+      expect(options).to.equal({})
+      expect(handler).to.equal(jobs.deleteRemovedDocuments.job.handler)
+    })
 
     test('registers deleteRemovedDocuments onComplete handler', async () => {
-      const completedJob = { id: 'testing' };
+      const completedJob = { id: 'testing' }
 
-      const [jobName, func] = server.messageQueue.onComplete.getCall(1).args;
-      func(completedJob);
+      const [jobName, func] = server.messageQueue.onComplete.getCall(1).args
+      func(completedJob)
 
-      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName);
+      expect(jobName).to.equal(jobs.deleteRemovedDocuments.job.jobName)
       expect(jobs.deleteRemovedDocuments.onCompleteHandler.calledWith(
         completedJob,
         server.messageQueue
-      )).to.equal(true);
-    });
+      )).to.equal(true)
+    })
 
     test('registers populatePendingImport job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(2).args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(2).args
 
-      expect(jobName).to.equal(jobs.populatePendingImport.job.jobName);
-      expect(options).to.equal({});
-      expect(handler).to.equal(jobs.populatePendingImport.job.handler);
-    });
+      expect(jobName).to.equal(jobs.populatePendingImport.job.jobName)
+      expect(options).to.equal({})
+      expect(handler).to.equal(jobs.populatePendingImport.job.handler)
+    })
 
     test('registers populatePendingImport onComplete handler', async () => {
-      const completedJob = { id: 'testing' };
+      const completedJob = { id: 'testing' }
 
-      const [jobName, func] = server.messageQueue.onComplete.getCall(2).args;
-      func(completedJob);
+      const [jobName, func] = server.messageQueue.onComplete.getCall(2).args
+      func(completedJob)
 
-      expect(jobName).to.equal(jobs.populatePendingImport.job.jobName);
+      expect(jobName).to.equal(jobs.populatePendingImport.job.jobName)
       expect(jobs.populatePendingImport.onCompleteHandler.calledWith(
         completedJob,
         server.messageQueue
-      )).to.equal(true);
-    });
+      )).to.equal(true)
+    })
 
     test('registers importLicence job', async () => {
-      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(3).args;
+      const [jobName, options, handler] = server.messageQueue.subscribe.getCall(3).args
 
-      expect(jobName).to.equal(jobs.importLicence.job.jobName);
-      expect(options).to.equal(jobs.importLicence.job.options);
-      expect(handler).to.equal(jobs.importLicence.job.handler);
-    });
-  });
+      expect(jobName).to.equal(jobs.importLicence.job.jobName)
+      expect(options).to.equal(jobs.importLicence.job.options)
+      expect(handler).to.equal(jobs.importLicence.job.handler)
+    })
+  })
 
   experiment('in production', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(true);
+      sandbox.stub(config, 'isProduction').value(true)
       sandbox.stub(process, 'env').value({
         NODE_ENV: 'production'
-      });
-      await plugin.register(server);
-    });
+      })
+      await plugin.register(server)
+    })
 
     test('schedules cron job to run at 0100 everyday', async () => {
-      const [schedule] = cron.schedule.firstCall.args;
-      expect(schedule).to.equal('0 1 * * *');
-    });
-  });
+      const [schedule] = cron.schedule.firstCall.args
+      expect(schedule).to.equal('0 1 * * *')
+    })
+  })
 
   experiment('in non-production', async () => {
     beforeEach(async () => {
-      sandbox.stub(config, 'isProduction').value(false);
+      sandbox.stub(config, 'isProduction').value(false)
       sandbox.stub(process, 'env').value({
         NODE_ENV: 'qa'
-      });
-      await plugin.register(server);
-    });
+      })
+      await plugin.register(server)
+    })
 
     test('schedules cron job to run every hour', async () => {
-      const [schedule] = cron.schedule.firstCall.args;
-      expect(schedule).to.equal('0 */1 * * *');
-    });
-  });
-});
+      const [schedule] = cron.schedule.firstCall.args
+      expect(schedule).to.equal('0 */1 * * *')
+    })
+  })
+})

--- a/test/modules/nald-import/services/application-state-service.js
+++ b/test/modules/nald-import/services/application-state-service.js
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const applicationStateConnector = require('../../../../src/lib/connectors/water/application-state');
-const applicationStateService = require('../../../../src/lib/services/application-state-service');
+const applicationStateConnector = require('../../../../src/lib/connectors/water/application-state')
+const applicationStateService = require('../../../../src/lib/services/application-state-service')
 
 experiment('modules/nald-import/services/application-state-service', () => {
   beforeEach(async () => {
@@ -15,38 +15,38 @@ experiment('modules/nald-import/services/application-state-service', () => {
       data: {
         etag: 'test-etag'
       }
-    });
-    sandbox.stub(applicationStateConnector, 'postState');
-  });
+    })
+    sandbox.stub(applicationStateConnector, 'postState')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.get', () => {
-    let result;
+    let result
 
     beforeEach(async () => {
-      result = await applicationStateService.get('nald-import');
-    });
+      result = await applicationStateService.get('nald-import')
+    })
 
     test('the application state connector is called with the correct key', async () => {
-      expect(applicationStateConnector.getState.calledWith('nald-import')).to.be.true();
-    });
+      expect(applicationStateConnector.getState.calledWith('nald-import')).to.be.true()
+    })
 
     test('resolves with the data', async () => {
-      expect(result).to.equal({ etag: 'test-etag' });
-    });
-  });
+      expect(result).to.equal({ etag: 'test-etag' })
+    })
+  })
 
   experiment('.save', () => {
     beforeEach(async () => {
-      await applicationStateService.save('a-new-etag', { isDownloaded: true });
-    });
+      await applicationStateService.save('a-new-etag', { isDownloaded: true })
+    })
 
     test('isDownloaded is set to the value provided', async () => {
-      const [, data] = applicationStateConnector.postState.lastCall.args;
-      expect(data.isDownloaded).to.be.true();
-    });
-  });
-});
+      const [, data] = applicationStateConnector.postState.lastCall.args
+      expect(data.isDownloaded).to.be.true()
+    })
+  })
+})

--- a/test/modules/nald-import/services/charge-version-metadata-import.js
+++ b/test/modules/nald-import/services/charge-version-metadata-import.js
@@ -1,23 +1,23 @@
-'use strict';
+'use strict'
 
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
-const chargeVersionMetadataImport = require('../../../../src/modules/nald-import/services/charge-version-metadata-import');
-const { pool } = require('../../../../src/lib/connectors/db');
+const chargeVersionMetadataImport = require('../../../../src/modules/nald-import/services/charge-version-metadata-import')
+const { pool } = require('../../../../src/lib/connectors/db')
 
 const queries = {
   charging: require('../../../../src/modules/nald-import/lib/nald-queries/charge-versions'),
   chargeVersionMetadata: require('../../../../src/modules/nald-import/lib/nald-queries/charge-versions-metadata')
-};
+}
 
-const REGION_CODE = 1;
-const LICENCE_ID = 'test-licence-id';
-const LICENCE_NUMBER = '01/234/ABC';
-const START_DATE = '2019-01-01';
-const WATER_LICENCE_ID = '00000000-0000-0000-0000-000000000000';
+const REGION_CODE = 1
+const LICENCE_ID = 'test-licence-id'
+const LICENCE_NUMBER = '01/234/ABC'
+const START_DATE = '2019-01-01'
+const WATER_LICENCE_ID = '00000000-0000-0000-0000-000000000000'
 
 const chargeVersionRow = {
   start_date: START_DATE,
@@ -36,7 +36,7 @@ const chargeVersionRow = {
   region: REGION_CODE,
   licence_id: WATER_LICENCE_ID,
   is_nald_gap: false
-};
+}
 
 const licence = {
   ID: LICENCE_ID,
@@ -45,16 +45,16 @@ const licence = {
   start_date: START_DATE,
   end_date: null,
   licence_id: WATER_LICENCE_ID
-};
+}
 
 experiment('modules/charging-import/services/charge-version-import.js', () => {
   beforeEach(async () => {
-    sandbox.stub(pool, 'query');
-  });
+    sandbox.stub(pool, 'query')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.importChargeVersions', () => {
     beforeEach(async () => {
@@ -64,17 +64,17 @@ experiment('modules/charging-import/services/charge-version-import.js', () => {
         rows: [
           chargeVersionRow
         ]
-      });
+      })
 
-      await chargeVersionMetadataImport.importChargeVersionMetadataForLicence(licence);
-    });
+      await chargeVersionMetadataImport.importChargeVersionMetadataForLicence(licence)
+    })
 
     test('the charge versions are fetched for the licence region and ID', async () => {
       expect(pool.query.calledWith(
         queries.charging.getNonDraftChargeVersionsForLicence,
         [REGION_CODE, LICENCE_ID]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('the mapped charge versions are persisted', async () => {
       expect(pool.query.calledWith(
@@ -87,16 +87,16 @@ experiment('modules/charging-import/services/charge-version-import.js', () => {
           chargeVersionRow.status,
           chargeVersionRow.is_nald_gap
         ]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('unwanted charge versions are cleaned up', async () => {
-      const [query, params] = pool.query.lastCall.args;
-      expect(query).to.equal('delete from water_import.charge_versions_metadata where external_id like $1 and external_id not in ($2)');
+      const [query, params] = pool.query.lastCall.args
+      expect(query).to.equal('delete from water_import.charge_versions_metadata where external_id like $1 and external_id not in ($2)')
       expect(params).to.equal([
         `${licence.FGAC_REGION_CODE}:${licence.ID}:%`,
         chargeVersionRow.external_id
-      ]);
-    });
-  });
-});
+      ])
+    })
+  })
+})

--- a/test/modules/nald-import/services/extract-service.js
+++ b/test/modules/nald-import/services/extract-service.js
@@ -1,43 +1,43 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const sandbox = require('sinon').createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const sandbox = require('sinon').createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const extractService = require('../../../../src/modules/nald-import/services/extract-service');
-const s3Service = require('../../../../src/modules/nald-import/services/s3-service');
-const zipService = require('../../../../src/modules/nald-import/services/zip-service');
-const schemaService = require('../../../../src/modules/nald-import/services/schema-service');
-const loadCsvService = require('../../../../src/modules/nald-import/services/load-csv-service');
+const extractService = require('../../../../src/modules/nald-import/services/extract-service')
+const s3Service = require('../../../../src/modules/nald-import/services/s3-service')
+const zipService = require('../../../../src/modules/nald-import/services/zip-service')
+const schemaService = require('../../../../src/modules/nald-import/services/schema-service')
+const loadCsvService = require('../../../../src/modules/nald-import/services/load-csv-service')
 
-const processHelper = require('@envage/water-abstraction-helpers').process;
+const processHelper = require('@envage/water-abstraction-helpers').process
 
-const slack = require('../../../../src/lib/slack');
-const { logger } = require('../../../../src/logger');
+const slack = require('../../../../src/lib/slack')
+const { logger } = require('../../../../src/logger')
 
 experiment('modules/nald-import/services/extract-service', () => {
   beforeEach(async () => {
-    sandbox.stub(processHelper, 'execCommand');
-    sandbox.stub(slack, 'post');
-    sandbox.stub(logger, 'info');
-    sandbox.stub(s3Service, 'download');
-    sandbox.stub(zipService, 'extract');
-    sandbox.stub(schemaService, 'dropAndCreateSchema');
-    sandbox.stub(loadCsvService, 'importFiles');
-    sandbox.stub(schemaService, 'swapTemporarySchema');
-  });
+    sandbox.stub(processHelper, 'execCommand')
+    sandbox.stub(slack, 'post')
+    sandbox.stub(logger, 'info')
+    sandbox.stub(s3Service, 'download')
+    sandbox.stub(zipService, 'extract')
+    sandbox.stub(schemaService, 'dropAndCreateSchema')
+    sandbox.stub(loadCsvService, 'importFiles')
+    sandbox.stub(schemaService, 'swapTemporarySchema')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.downloadAndExtract', () => {
     beforeEach(async () => {
-      await extractService.downloadAndExtract();
-    });
+      await extractService.downloadAndExtract()
+    })
 
     test('the steps are called in the correct order', async () => {
       sandbox.assert.callOrder(
@@ -52,33 +52,33 @@ experiment('modules/nald-import/services/extract-service', () => {
         processHelper.execCommand,
         processHelper.execCommand,
         processHelper.execCommand
-      );
-    });
+      )
+    })
 
     const testMessage = (index, message) =>
       test(`${message} message is logged and posted to slack`, async () => {
-        expect(logger.info.getCall(index).args[0]).to.equal(message);
-        expect(slack.post.getCall(index).args[0]).to.equal(message);
-      });
+        expect(logger.info.getCall(index).args[0]).to.equal(message)
+        expect(slack.post.getCall(index).args[0]).to.equal(message)
+      })
 
-    testMessage(0, 'Import: preparing folders');
-    testMessage(1, 'Import: downloading from s3');
-    testMessage(2, 'Import: extracting files from zip');
-    testMessage(3, 'Import: create import_temp schema');
-    testMessage(4, 'Import: importing CSV files');
-    testMessage(5, 'Import: swapping schema from import_temp to import');
-    testMessage(6, 'Import: cleaning up local files');
+    testMessage(0, 'Import: preparing folders')
+    testMessage(1, 'Import: downloading from s3')
+    testMessage(2, 'Import: extracting files from zip')
+    testMessage(3, 'Import: create import_temp schema')
+    testMessage(4, 'Import: importing CSV files')
+    testMessage(5, 'Import: swapping schema from import_temp to import')
+    testMessage(6, 'Import: cleaning up local files')
 
     test('the correct schemas are used', async () => {
-      expect(schemaService.dropAndCreateSchema.calledWith('import_temp')).to.be.true();
-      expect(loadCsvService.importFiles.calledWith('import_temp')).to.be.true();
-    });
-  });
+      expect(schemaService.dropAndCreateSchema.calledWith('import_temp')).to.be.true()
+      expect(loadCsvService.importFiles.calledWith('import_temp')).to.be.true()
+    })
+  })
 
   experiment('.copyTestFiles', () => {
     beforeEach(async () => {
-      await extractService.copyTestFiles();
-    });
+      await extractService.copyTestFiles()
+    })
 
     test('the steps are called in the correct order', async () => {
       sandbox.assert.callOrder(
@@ -88,11 +88,11 @@ experiment('modules/nald-import/services/extract-service', () => {
         schemaService.dropAndCreateSchema,
         processHelper.execCommand,
         loadCsvService.importFiles
-      );
-    });
+      )
+    })
 
     test('the CSVs are copied from the correct location', async () => {
-      expect(processHelper.execCommand.getCall(3).args[0]).to.equal('cp ./test/dummy-csv/* temp/NALD');
-    });
-  });
-});
+      expect(processHelper.execCommand.getCall(3).args[0]).to.equal('cp ./test/dummy-csv/* temp/NALD')
+    })
+  })
+})

--- a/test/modules/nald-import/services/s3-service.js
+++ b/test/modules/nald-import/services/s3-service.js
@@ -1,51 +1,51 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const sandbox = require('sinon').createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const sandbox = require('sinon').createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const s3 = require('../../../../src/lib/services/s3');
-const s3Service = require('../../../../src/modules/nald-import/services/s3-service');
+const s3 = require('../../../../src/lib/services/s3')
+const s3Service = require('../../../../src/modules/nald-import/services/s3-service')
 
 experiment('modules/nald-import/services/s3', () => {
   beforeEach(async () => {
-    sandbox.stub(s3, 'download');
+    sandbox.stub(s3, 'download')
     sandbox.stub(s3, 'getHead').resolves({
       ETag: '"test-etag-here"'
-    });
-  });
+    })
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getEtag', () => {
-    let result;
+    let result
     beforeEach(async () => {
-      result = await s3Service.getEtag();
-    });
+      result = await s3Service.getEtag()
+    })
 
     test('the s3.getHead method is called', async () => {
-      expect(s3.getHead.calledWith('wal_nald_data_release/nald_enc.zip')).to.be.true();
-    });
+      expect(s3.getHead.calledWith('wal_nald_data_release/nald_enc.zip')).to.be.true()
+    })
 
     test('the etag is returned with quotes stripped', async () => {
-      expect(result).to.equal('test-etag-here');
-    });
-  });
+      expect(result).to.equal('test-etag-here')
+    })
+  })
 
   experiment('.download', () => {
     beforeEach(async () => {
-      await s3Service.download();
-    });
+      await s3Service.download()
+    })
 
     test('the s3.download method is called', async () => {
       expect(s3.download.calledWith(
         'wal_nald_data_release/nald_enc.zip', 'temp/nald_enc.zip'
-      )).to.be.true();
-    });
-  });
-});
+      )).to.be.true()
+    })
+  })
+})

--- a/test/modules/nald-import/services/schema-service.js
+++ b/test/modules/nald-import/services/schema-service.js
@@ -1,67 +1,67 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const constants = require('../../../../src/modules/nald-import/lib/constants');
-const schemaService = require('../../../../src/modules/nald-import/services/schema-service');
-const db = require('../../../../src/modules/nald-import/lib/db');
+const constants = require('../../../../src/modules/nald-import/lib/constants')
+const schemaService = require('../../../../src/modules/nald-import/services/schema-service')
+const db = require('../../../../src/modules/nald-import/lib/db')
 
 experiment('modules/nald-import/services/schema-service', () => {
   beforeEach(async () => {
-    sandbox.stub(constants, 'SCHEMA_IMPORT').value('test_schema');
-    sandbox.stub(constants, 'SCHEMA_TEMP').value('temp_schema');
+    sandbox.stub(constants, 'SCHEMA_IMPORT').value('test_schema')
+    sandbox.stub(constants, 'SCHEMA_TEMP').value('temp_schema')
 
-    sandbox.stub(db, 'dbQuery');
-  });
+    sandbox.stub(db, 'dbQuery')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.dropAndCreateSchema', () => {
     beforeEach(async () => {
-      await schemaService.dropAndCreateSchema();
-    });
+      await schemaService.dropAndCreateSchema()
+    })
 
     test('the schema is dropped', async () => {
-      const [query] = db.dbQuery.firstCall.args;
-      expect(query).to.equal('drop schema if exists test_schema cascade');
-    });
+      const [query] = db.dbQuery.firstCall.args
+      expect(query).to.equal('drop schema if exists test_schema cascade')
+    })
 
     test('the schema is re-created', async () => {
-      const [query] = db.dbQuery.secondCall.args;
-      expect(query).to.equal('create schema if not exists test_schema');
-    });
-  });
+      const [query] = db.dbQuery.secondCall.args
+      expect(query).to.equal('create schema if not exists test_schema')
+    })
+  })
 
   experiment('.swapTemporarySchema', () => {
     beforeEach(async () => {
-      await schemaService.swapTemporarySchema('test_schema');
-    });
+      await schemaService.swapTemporarySchema('test_schema')
+    })
 
     test('the schema is dropped', async () => {
-      const [query] = db.dbQuery.firstCall.args;
-      expect(query).to.equal('drop schema if exists test_schema cascade');
-    });
+      const [query] = db.dbQuery.firstCall.args
+      expect(query).to.equal('drop schema if exists test_schema cascade')
+    })
 
     test('the schema is re-created', async () => {
-      const [query] = db.dbQuery.secondCall.args;
-      expect(query).to.equal('alter schema temp_schema rename to test_schema;');
-    });
-  });
+      const [query] = db.dbQuery.secondCall.args
+      expect(query).to.equal('alter schema temp_schema rename to test_schema;')
+    })
+  })
 
   experiment('rename schema', () => {
     beforeEach(async () => {
-      await schemaService.renameSchema('schema_old', 'schema_new');
-    });
+      await schemaService.renameSchema('schema_old', 'schema_new')
+    })
 
     test('the schema is renamed', async () => {
-      const [query] = db.dbQuery.firstCall.args;
-      expect(query).to.equal('alter schema schema_old rename to schema_new;');
-    });
-  });
-});
+      const [query] = db.dbQuery.firstCall.args
+      expect(query).to.equal('alter schema schema_old rename to schema_new;')
+    })
+  })
+})

--- a/test/modules/nald-import/services/zip-service.js
+++ b/test/modules/nald-import/services/zip-service.js
@@ -1,64 +1,64 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const { logger } = require('../../../../src/logger');
-const processHelper = require('@envage/water-abstraction-helpers').process;
-const config = require('../../../../config');
+const { logger } = require('../../../../src/logger')
+const processHelper = require('@envage/water-abstraction-helpers').process
+const config = require('../../../../config')
 
-const zipService = require('../../../../src/modules/nald-import/services/zip-service');
+const zipService = require('../../../../src/modules/nald-import/services/zip-service')
 
 experiment('modules/nald-import/services/zip-service', () => {
   beforeEach(async () => {
-    sandbox.stub(processHelper, 'execCommand');
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
+    sandbox.stub(processHelper, 'execCommand')
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
 
-    sandbox.stub(config.import.nald, 'zipPassword').value('test-password');
-  });
+    sandbox.stub(config.import.nald, 'zipPassword').value('test-password')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.extract', () => {
     experiment('when the zip commands succeed', () => {
       beforeEach(async () => {
-        await zipService.extract();
-      });
+        await zipService.extract()
+      })
 
       test('logs an info message', async () => {
-        expect(logger.info.calledWith('Extracting data from NALD zip file')).to.be.true();
-      });
+        expect(logger.info.calledWith('Extracting data from NALD zip file')).to.be.true()
+      })
 
       test('the first call extracts the primary zip with password', async () => {
-        const [cmd] = processHelper.execCommand.firstCall.args;
-        expect(cmd).to.equal('7z x temp/nald_enc.zip -o./temp/ -ptest-password');
-      });
+        const [cmd] = processHelper.execCommand.firstCall.args
+        expect(cmd).to.equal('7z x temp/nald_enc.zip -o./temp/ -ptest-password')
+      })
 
       test('the second call extracts the secondary zip without password', async () => {
-        const [cmd] = processHelper.execCommand.secondCall.args;
-        expect(cmd).to.equal('7z x temp/NALD.zip -o./temp/');
-      });
-    });
+        const [cmd] = processHelper.execCommand.secondCall.args
+        expect(cmd).to.equal('7z x temp/NALD.zip -o./temp/')
+      })
+    })
 
     experiment('when the zip commands fail', () => {
-      const err = new Error('oops');
+      const err = new Error('oops')
 
       beforeEach(async () => {
-        processHelper.execCommand.rejects(err);
-      });
+        processHelper.execCommand.rejects(err)
+      })
 
       test('an error is logged and rethrown', async () => {
-        const func = () => zipService.extract();
-        const result = await expect(func()).to.reject();
-        expect(logger.error.calledWith('Could not extract NALD zip', err)).to.be.true();
-        expect(result).to.equal(err);
-      });
-    });
-  });
-});
+        const func = () => zipService.extract()
+        const result = await expect(func()).to.reject()
+        expect(logger.error.calledWith('Could not extract NALD zip', err)).to.be.true()
+        expect(result).to.equal(err)
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/transform-returns.js
+++ b/test/modules/nald-import/transform-returns.js
@@ -1,98 +1,98 @@
-'use strict';
+'use strict'
 
-const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const moment = require('moment');
-moment.locale('en-gb');
+const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const moment = require('moment')
+moment.locale('en-gb')
 
-const { buildReturnsPacket, getLicenceFormats } = require('../../../src/modules/nald-import/transform-returns');
-const queries = require('../../../src/modules/nald-import/lib/nald-queries/returns');
-const helpers = require('../../../src/modules/nald-import/lib/transform-returns-helpers.js');
-const dueDate = require('../../../src/modules/nald-import/lib/due-date');
+const { buildReturnsPacket, getLicenceFormats } = require('../../../src/modules/nald-import/transform-returns')
+const queries = require('../../../src/modules/nald-import/lib/nald-queries/returns')
+const helpers = require('../../../src/modules/nald-import/lib/transform-returns-helpers.js')
+const dueDate = require('../../../src/modules/nald-import/lib/due-date')
 
 experiment('modules/nald-import/transform-returns', () => {
   experiment('getLicenceFormats', () => {
     beforeEach(() => {
-      const formats = [{ name: 'format1' }];
+      const formats = [{ name: 'format1' }]
 
-      sandbox.stub(queries, 'getSplitDate').returns();
-      sandbox.stub(queries, 'getFormats').returns(formats);
-      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes');
-      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints');
-      sandbox.stub(helpers, 'getFormatCycles').returns('formatCycles');
-    });
+      sandbox.stub(queries, 'getSplitDate').returns()
+      sandbox.stub(queries, 'getFormats').returns(formats)
+      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes')
+      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints')
+      sandbox.stub(helpers, 'getFormatCycles').returns('formatCycles')
+    })
 
     afterEach(() => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     test('adds purposes, points and cycles to format object', async () => {
-      const licenceFormats = await getLicenceFormats('123/xyz');
-      expect(licenceFormats[0].purposes).to.equal('formatPurposes');
-      expect(licenceFormats[0].points).to.equal('formatPoints');
-      expect(licenceFormats[0].cycles).to.equal('formatCycles');
-    });
-  });
+      const licenceFormats = await getLicenceFormats('123/xyz')
+      expect(licenceFormats[0].purposes).to.equal('formatPurposes')
+      expect(licenceFormats[0].points).to.equal('formatPoints')
+      expect(licenceFormats[0].cycles).to.equal('formatCycles')
+    })
+  })
 
   experiment('buildReturnsPacket', () => {
-    const formats = [{}];
+    const formats = [{}]
     const logs = [
       { DATE_FROM: '01/04/2018', DATE_TO: '31/03/2019' }
-    ];
+    ]
 
     const cycle = [{
       startDate: '2018-04-01',
       endDate: '2019-03-31',
       isCurrent: true
-    }];
+    }]
 
     beforeEach(() => {
-      sandbox.stub(queries, 'getSplitDate').returns();
-      sandbox.stub(queries, 'getFormats').returns(formats);
-      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes');
-      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints');
-      sandbox.stub(helpers, 'getFormatCycles').returns(cycle);
-      sandbox.stub(queries, 'getLogs').returns(logs);
-      sandbox.stub(helpers, 'mapReceivedDate').returns();
-      sandbox.stub(helpers, 'getStatus').returns();
-      sandbox.stub(dueDate, 'getDueDate').returns('2019-04-28');
-      sandbox.stub(helpers, 'mapPeriod').returns('monthly');
-      sandbox.stub(helpers, 'formatReturnMetadata').returns({ version: 1 });
-      sandbox.stub(helpers, 'getFormatEndDate');
-    });
+      sandbox.stub(queries, 'getSplitDate').returns()
+      sandbox.stub(queries, 'getFormats').returns(formats)
+      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes')
+      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints')
+      sandbox.stub(helpers, 'getFormatCycles').returns(cycle)
+      sandbox.stub(queries, 'getLogs').returns(logs)
+      sandbox.stub(helpers, 'mapReceivedDate').returns()
+      sandbox.stub(helpers, 'getStatus').returns()
+      sandbox.stub(dueDate, 'getDueDate').returns('2019-04-28')
+      sandbox.stub(helpers, 'mapPeriod').returns('monthly')
+      sandbox.stub(helpers, 'formatReturnMetadata').returns({ version: 1 })
+      sandbox.stub(helpers, 'getFormatEndDate')
+    })
 
     afterEach(() => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     test('returns data as expected', async () => {
-      const { returns } = await buildReturnsPacket('123/xyz');
+      const { returns } = await buildReturnsPacket('123/xyz')
 
-      expect(returns[0].start_date).to.equal(cycle[0].startDate);
-      expect(returns[0].end_date).to.equal(cycle[0].endDate);
-      expect(returns[0].due_date).to.equal('2019-04-28');
-      expect(returns[0].returns_frequency).to.equal('monthly');
-      expect(returns[0].metadata).to.equal('{"version":1,"isCurrent":true,"isFinal":false}');
-    });
+      expect(returns[0].start_date).to.equal(cycle[0].startDate)
+      expect(returns[0].end_date).to.equal(cycle[0].endDate)
+      expect(returns[0].due_date).to.equal('2019-04-28')
+      expect(returns[0].returns_frequency).to.equal('monthly')
+      expect(returns[0].metadata).to.equal('{"version":1,"isCurrent":true,"isFinal":false}')
+    })
 
     test('isFinal flag returns true if endDate matches format end date', async () => {
-      helpers.getFormatEndDate.returns('2019-03-31');
-      const { returns } = await buildReturnsPacket('123/xyz');
+      helpers.getFormatEndDate.returns('2019-03-31')
+      const { returns } = await buildReturnsPacket('123/xyz')
 
-      expect(returns[0].metadata).to.include('"isFinal":true');
-    });
+      expect(returns[0].metadata).to.include('"isFinal":true')
+    })
 
     test('isFinal flag returns false if endDate does not match format end date', async () => {
-      helpers.getFormatEndDate.returns('2019-04-01');
-      const { returns } = await buildReturnsPacket('123/xyz');
+      helpers.getFormatEndDate.returns('2019-04-01')
+      const { returns } = await buildReturnsPacket('123/xyz')
 
-      expect(returns[0].metadata).to.include('"isFinal":false');
-    });
-  });
+      expect(returns[0].metadata).to.include('"isFinal":false')
+    })
+  })
 
   experiment('.getCycleLogs', () => {
 
-  });
-});
+  })
+})

--- a/test/modules/returns/controller.js
+++ b/test/modules/returns/controller.js
@@ -1,17 +1,17 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const { lines, returns, versions } = require('../../../src/lib/connectors/returns');
-const controller = require('../../../src/modules/returns/controller');
+const { lines, returns, versions } = require('../../../src/lib/connectors/returns')
+const controller = require('../../../src/modules/returns/controller')
 
 experiment('modules/returns/controller', () => {
   beforeEach(async () => {
@@ -26,60 +26,60 @@ experiment('modules/returns/controller', () => {
           }
         }
       ]
-    });
+    })
 
     sandbox.stub(versions, 'findMany').resolves({
       data: [
         { return_id: 'test-return-id', nil_return: false }
       ]
-    });
+    })
 
-    sandbox.stub(lines, 'findMany').resolves({ data: [] });
-  });
+    sandbox.stub(lines, 'findMany').resolves({ data: [] })
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getLinesForVersion', () => {
-    let request;
+    let request
 
     beforeEach(async () => {
       request = {
         params: {
           versionID: 'test-version-id'
         }
-      };
-    });
+      }
+    })
 
     test('throws a notFound if no version data returned', async () => {
-      versions.findMany.resolves({ data: [] });
-      const error = await expect(controller.getLinesForVersion(request)).to.reject();
+      versions.findMany.resolves({ data: [] })
+      const error = await expect(controller.getLinesForVersion(request)).to.reject()
 
-      expect(error.isBoom).to.equal(true);
-      expect(error.output.payload.statusCode).to.equal(404);
-      expect(error.output.payload.message).to.equal('Data not found for test-version-id');
-    });
+      expect(error.isBoom).to.equal(true)
+      expect(error.output.payload.statusCode).to.equal(404)
+      expect(error.output.payload.message).to.equal('Data not found for test-version-id')
+    })
 
     test('throws a notFound if no return data returned', async () => {
-      returns.findMany.resolves({ data: [] });
-      const error = await expect(controller.getLinesForVersion(request)).to.reject();
+      returns.findMany.resolves({ data: [] })
+      const error = await expect(controller.getLinesForVersion(request)).to.reject()
 
-      expect(error.isBoom).to.equal(true);
-      expect(error.output.payload.statusCode).to.equal(404);
-      expect(error.output.payload.message).to.equal('Data not found for test-return-id');
-    });
+      expect(error.isBoom).to.equal(true)
+      expect(error.output.payload.statusCode).to.equal(404)
+      expect(error.output.payload.message).to.equal('Data not found for test-return-id')
+    })
 
     test('returns the expected response when data is present', async () => {
-      const response = await controller.getLinesForVersion(request);
-      expect(response.error).to.equal(null);
-      expect(response.data.nil_return).to.equal(false);
-      expect(response.data.under_query).to.equal(false);
-      expect(response.data.under_query_comment).to.equal('');
-      expect(response.data.return.under_query_comment).to.equal('');
-      expect(response.data.return.regionCode).to.equal('1');
-      expect(response.data.return.formatId).to.equal(2);
-      expect(response.data.lines).to.equal([]);
-    });
-  });
-});
+      const response = await controller.getLinesForVersion(request)
+      expect(response.error).to.equal(null)
+      expect(response.data.nil_return).to.equal(false)
+      expect(response.data.under_query).to.equal(false)
+      expect(response.data.under_query_comment).to.equal('')
+      expect(response.data.return.under_query_comment).to.equal('')
+      expect(response.data.return.regionCode).to.equal('1')
+      expect(response.data.return.formatId).to.equal(2)
+      expect(response.data.lines).to.equal([])
+    })
+  })
+})

--- a/test/modules/returns/lib/api-helpers.js
+++ b/test/modules/returns/lib/api-helpers.js
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-const { experiment, it } = module.exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, it } = module.exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
 const {
   getVersionFilter,
   getEventFilter,
   getPagination
-} = require('../../../../src/modules/returns/lib/api-helpers');
+} = require('../../../../src/modules/returns/lib/api-helpers')
 
 experiment('getVersionFilter', () => {
   it('Should get version filter with no end date specified', async () => {
@@ -15,12 +15,12 @@ experiment('getVersionFilter', () => {
       query: {
         start: '2018-04-01'
       }
-    };
+    }
 
-    const data = getVersionFilter(request);
+    const data = getVersionFilter(request)
 
-    expect(data).to.equal({ current: true, created_at: { $gte: '2018-04-01' } });
-  });
+    expect(data).to.equal({ current: true, created_at: { $gte: '2018-04-01' } })
+  })
 
   it('Should get version filter with end date specified', async () => {
     const request = {
@@ -28,13 +28,13 @@ experiment('getVersionFilter', () => {
         start: '2018-04-01',
         end: '2018-05-12'
       }
-    };
+    }
 
-    const filter = getVersionFilter(request);
+    const filter = getVersionFilter(request)
 
-    expect(filter).to.equal({ current: true, created_at: { $gte: '2018-04-01', $lte: '2018-05-12' } });
-  });
-});
+    expect(filter).to.equal({ current: true, created_at: { $gte: '2018-04-01', $lte: '2018-05-12' } })
+  })
+})
 
 experiment('getEventFilter', () => {
   it('Should get event filter with no end date specified', async () => {
@@ -42,11 +42,11 @@ experiment('getEventFilter', () => {
       query: {
         start: '2018-04-01'
       }
-    };
+    }
 
-    const filter = getEventFilter(request);
-    expect(filter).to.equal({ created: { $gte: '2018-04-01' }, type: 'return.status' });
-  });
+    const filter = getEventFilter(request)
+    expect(filter).to.equal({ created: { $gte: '2018-04-01' }, type: 'return.status' })
+  })
 
   it('Should get event filter with end date specified', async () => {
     const request = {
@@ -54,12 +54,12 @@ experiment('getEventFilter', () => {
         start: '2018-04-01',
         end: '2018-06-01'
       }
-    };
+    }
 
-    const filter = getEventFilter(request);
-    expect(filter).to.equal({ created: { $gte: '2018-04-01', $lte: '2018-06-01' }, type: 'return.status' });
-  });
-});
+    const filter = getEventFilter(request)
+    expect(filter).to.equal({ created: { $gte: '2018-04-01', $lte: '2018-06-01' }, type: 'return.status' })
+  })
+})
 
 experiment('getPagination', () => {
   it('Should get default pagination', async () => {
@@ -67,43 +67,43 @@ experiment('getPagination', () => {
       query: {
         pagination: {}
       }
-    };
+    }
 
-    const pagination = getPagination(request);
+    const pagination = getPagination(request)
 
     expect(pagination).to.equal({
       page: 1,
       perPage: 2000
-    });
-  });
+    })
+  })
 
   it('Should be able to set page', async () => {
     const request = {
       query: {
         pagination: { page: 2 }
       }
-    };
+    }
 
-    const pagination = getPagination(request);
+    const pagination = getPagination(request)
 
     expect(pagination).to.equal({
       page: 2,
       perPage: 2000
-    });
-  });
+    })
+  })
 
   it('Should be able to set page and row count per page', async () => {
     const request = {
       query: {
         pagination: { page: 3, perPage: 200 }
       }
-    };
+    }
 
-    const pagination = getPagination(request);
+    const pagination = getPagination(request)
 
     expect(pagination).to.equal({
       page: 3,
       perPage: 200
-    });
-  });
-});
+    })
+  })
+})

--- a/test/modules/returns/lib/date-helpers.js
+++ b/test/modules/returns/lib/date-helpers.js
@@ -1,35 +1,35 @@
-'use strict';
+'use strict'
 
-const { experiment, it } = module.exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, it } = module.exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
 const {
   isDateWithinReturnCycle
-} = require('../../../../src/modules/returns/lib/date-helpers');
+} = require('../../../../src/modules/returns/lib/date-helpers')
 
 experiment('isDateWithinReturnCycle', () => {
   const cycle = {
     start_date: '2017-11-01',
     end_date: '2018-10-31'
-  };
+  }
 
   it('Should exclude dates before cycle', async () => {
-    expect(isDateWithinReturnCycle(cycle, '2017-10-31')).to.equal(false);
-  });
+    expect(isDateWithinReturnCycle(cycle, '2017-10-31')).to.equal(false)
+  })
 
   it('Should include start date of cycle', async () => {
-    expect(isDateWithinReturnCycle(cycle, '2017-11-01')).to.equal(true);
-  });
+    expect(isDateWithinReturnCycle(cycle, '2017-11-01')).to.equal(true)
+  })
 
   it('Should include dates within cycle', async () => {
-    expect(isDateWithinReturnCycle(cycle, '2018-02-01')).to.equal(true);
-  });
+    expect(isDateWithinReturnCycle(cycle, '2018-02-01')).to.equal(true)
+  })
 
   it('Should include end date of cycle', async () => {
-    expect(isDateWithinReturnCycle(cycle, '2018-10-31')).to.equal(true);
-  });
+    expect(isDateWithinReturnCycle(cycle, '2018-10-31')).to.equal(true)
+  })
 
   it('Should exclude dates outside cycle', async () => {
-    expect(isDateWithinReturnCycle(cycle, '2018-11-01')).to.equal(false);
-  });
-});
+    expect(isDateWithinReturnCycle(cycle, '2018-11-01')).to.equal(false)
+  })
+})

--- a/test/modules/returns/lib/generate-nil-lines.js
+++ b/test/modules/returns/lib/generate-nil-lines.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
-const moment = require('moment');
-moment.locale('en-gb');
+const moment = require('moment')
+moment.locale('en-gb')
 
-const { experiment, it } = module.exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const { uniq } = require('lodash');
+const { experiment, it } = module.exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const { uniq } = require('lodash')
 
 const {
   getDays,
@@ -15,69 +15,69 @@ const {
   isDateWithinAbstractionPeriod,
   getAbsPeriod,
   mapLine
-} = require('../../../../src/modules/returns/lib/generate-nil-lines');
+} = require('../../../../src/modules/returns/lib/generate-nil-lines')
 
 const sameYear = {
   periodStartDay: 5,
   periodStartMonth: 3,
   periodEndDay: 25,
   periodEndMonth: 12
-};
+}
 
 const differentYear = {
   periodStartDay: 1,
   periodStartMonth: 10,
   periodEndDay: 8,
   periodEndMonth: 6
-};
+}
 
 const allYear = {
   periodStartDay: 1,
   periodStartMonth: 1,
   periodEndDay: 31,
   periodEndMonth: 12
-};
+}
 
 experiment('getDays', () => {
   it('Should generate a line for each day', async () => {
-    const days = getDays('2018-01-01', '2018-12-31');
-    expect(days.length).to.equal(365);
-  });
+    const days = getDays('2018-01-01', '2018-12-31')
+    expect(days.length).to.equal(365)
+  })
 
   it('Should generate a line for each day on leap years', async () => {
-    const days = getDays('2020-01-01', '2020-12-31');
-    expect(days.length).to.equal(366);
-  });
+    const days = getDays('2020-01-01', '2020-12-31')
+    expect(days.length).to.equal(366)
+  })
 
   it('Should generate correct lines', async () => {
-    const days = getDays('2018-01-20', '2018-02-10');
-    expect(days[0].startDate).to.equal('2018-01-20');
-    expect(days[0].endDate).to.equal('2018-01-20');
-    expect(days[days.length - 1].startDate).to.equal('2018-02-10');
-    expect(days[days.length - 1].endDate).to.equal('2018-02-10');
-  });
+    const days = getDays('2018-01-20', '2018-02-10')
+    expect(days[0].startDate).to.equal('2018-01-20')
+    expect(days[0].endDate).to.equal('2018-01-20')
+    expect(days[days.length - 1].startDate).to.equal('2018-02-10')
+    expect(days[days.length - 1].endDate).to.equal('2018-02-10')
+  })
 
   it('Should output `day` as the period', async () => {
-    const days = getDays('2018-01-01', '2018-12-31');
-    const periods = uniq(days.map(day => day.timePeriod));
-    expect(periods).to.equal(['day']);
-  });
-});
+    const days = getDays('2018-01-01', '2018-12-31')
+    const periods = uniq(days.map(day => day.timePeriod))
+    expect(periods).to.equal(['day'])
+  })
+})
 
 experiment('getMonths', () => {
   it('Should generate a line for each month', async () => {
-    const months = getMonths('2018-01-01', '2018-12-31');
-    expect(months.length).to.equal(12);
-  });
+    const months = getMonths('2018-01-01', '2018-12-31')
+    expect(months.length).to.equal(12)
+  })
 
   it('Should output `month` as the period', async () => {
-    const days = getMonths('2018-01-01', '2018-12-31');
-    const periods = uniq(days.map(day => day.timePeriod));
-    expect(periods).to.equal(['month']);
-  });
+    const days = getMonths('2018-01-01', '2018-12-31')
+    const periods = uniq(days.map(day => day.timePeriod))
+    expect(periods).to.equal(['month'])
+  })
 
   it('Should generate correct months', async () => {
-    const months = getMonths('2018-01-01', '2018-12-31');
+    const months = getMonths('2018-01-01', '2018-12-31')
     expect(months).to.equal([
       {
         startDate: '2018-01-01',
@@ -138,21 +138,21 @@ experiment('getMonths', () => {
         startDate: '2018-12-01',
         endDate: '2018-12-31',
         timePeriod: 'month'
-      }]);
-  });
+      }])
+  })
 
   it('Should generate a month if the start date is anywhere within the month', async () => {
-    const months = getMonths('2018-03-15', '2018-03-16');
+    const months = getMonths('2018-03-15', '2018-03-16')
     expect(months).to.equal([
       {
         startDate: '2018-03-01',
         endDate: '2018-03-31',
         timePeriod: 'month'
-      }]);
-  });
+      }])
+  })
 
   it('Should generate a month if the end date is anywhere within the month', async () => {
-    const months = getMonths('2018-03-15', '2018-04-01');
+    const months = getMonths('2018-03-15', '2018-04-01')
     expect(months).to.equal([
       {
         startDate: '2018-03-01',
@@ -163,74 +163,74 @@ experiment('getMonths', () => {
         startDate: '2018-04-01',
         endDate: '2018-04-30',
         timePeriod: 'month'
-      }]);
-  });
-});
+      }])
+  })
+})
 
 experiment('getWeeks', () => {
   it('Should generate a line for each week running Sunday - Saturday', async () => {
-    const weeks = getWeeks('2018-01-01', '2018-12-31');
+    const weeks = getWeeks('2018-01-01', '2018-12-31')
 
-    expect(weeks[0].startDate).to.equal('2017-12-31');
-    expect(weeks[0].endDate).to.equal('2018-01-06');
+    expect(weeks[0].startDate).to.equal('2017-12-31')
+    expect(weeks[0].endDate).to.equal('2018-01-06')
 
-    expect(weeks[weeks.length - 1].startDate).to.equal('2018-12-23');
-    expect(weeks[weeks.length - 1].endDate).to.equal('2018-12-29');
-  });
+    expect(weeks[weeks.length - 1].startDate).to.equal('2018-12-23')
+    expect(weeks[weeks.length - 1].endDate).to.equal('2018-12-29')
+  })
 
   it('Should output `week` as the period', async () => {
-    const days = getWeeks('2018-01-01', '2018-12-31');
-    const periods = uniq(days.map(day => day.timePeriod));
-    expect(periods.length).to.equal(1);
-    expect(periods).to.equal(['week']);
-  });
-});
+    const days = getWeeks('2018-01-01', '2018-12-31')
+    const periods = uniq(days.map(day => day.timePeriod))
+    expect(periods.length).to.equal(1)
+    expect(periods).to.equal(['week'])
+  })
+})
 
 experiment('getRequiredLines', () => {
   it('Should generate daily lines', async () => {
-    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'day');
-    expect(lines[0].timePeriod).to.equal('day');
-  });
+    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'day')
+    expect(lines[0].timePeriod).to.equal('day')
+  })
   it('Should generate weekly lines', async () => {
-    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'week');
-    expect(lines[0].timePeriod).to.equal('week');
-  });
+    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'week')
+    expect(lines[0].timePeriod).to.equal('week')
+  })
   it('Should generate monthly lines', async () => {
-    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'month');
-    expect(lines[0].timePeriod).to.equal('month');
-  });
+    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'month')
+    expect(lines[0].timePeriod).to.equal('month')
+  })
   it('Should generate yearly lines', async () => {
-    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'year');
-    expect(lines[0].timePeriod).to.equal('year');
-  });
-});
+    const lines = getRequiredLines('2018-01-01', '2018-12-31', 'year')
+    expect(lines[0].timePeriod).to.equal('year')
+  })
+})
 
 experiment('Test isDateWithinAbstractionPeriod', () => {
   it('Period start/end in same year', async () => {
-    expect(isDateWithinAbstractionPeriod('2018-01-01', sameYear)).to.equal(false);
-    expect(isDateWithinAbstractionPeriod('2018-03-04', sameYear)).to.equal(false);
-    expect(isDateWithinAbstractionPeriod('2018-03-05', sameYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2018-12-25', sameYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2018-12-26', sameYear)).to.equal(false);
-    expect(isDateWithinAbstractionPeriod('2018-12-31', sameYear)).to.equal(false);
-  });
+    expect(isDateWithinAbstractionPeriod('2018-01-01', sameYear)).to.equal(false)
+    expect(isDateWithinAbstractionPeriod('2018-03-04', sameYear)).to.equal(false)
+    expect(isDateWithinAbstractionPeriod('2018-03-05', sameYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2018-12-25', sameYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2018-12-26', sameYear)).to.equal(false)
+    expect(isDateWithinAbstractionPeriod('2018-12-31', sameYear)).to.equal(false)
+  })
 
   it('Period start/end in different year', async () => {
-    expect(isDateWithinAbstractionPeriod('2018-09-30', differentYear)).to.equal(false);
-    expect(isDateWithinAbstractionPeriod('2018-10-01', differentYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2018-12-31', differentYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2019-01-01', differentYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2019-06-08', differentYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2019-06-09', differentYear)).to.equal(false);
-  });
+    expect(isDateWithinAbstractionPeriod('2018-09-30', differentYear)).to.equal(false)
+    expect(isDateWithinAbstractionPeriod('2018-10-01', differentYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2018-12-31', differentYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2019-01-01', differentYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2019-06-08', differentYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2019-06-09', differentYear)).to.equal(false)
+  })
 
   it('Period all year', async () => {
-    expect(isDateWithinAbstractionPeriod('2017-12-31', allYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2018-01-01', allYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2018-12-31', allYear)).to.equal(true);
-    expect(isDateWithinAbstractionPeriod('2019-01-01', allYear)).to.equal(true);
-  });
-});
+    expect(isDateWithinAbstractionPeriod('2017-12-31', allYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2018-01-01', allYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2018-12-31', allYear)).to.equal(true)
+    expect(isDateWithinAbstractionPeriod('2019-01-01', allYear)).to.equal(true)
+  })
+})
 
 experiment('Test getAbsPeriod', () => {
   const returnData = {
@@ -242,18 +242,18 @@ experiment('Test getAbsPeriod', () => {
         periodEndMonth: '11'
       }
     }
-  };
+  }
 
   it('Should extract abstraction period start/end dates as integers', async () => {
-    const dates = getAbsPeriod(returnData);
+    const dates = getAbsPeriod(returnData)
     expect(dates).to.equal({
       periodStartDay: 2,
       periodStartMonth: 4,
       periodEndDay: 5,
       periodEndMonth: 11
-    });
-  });
-});
+    })
+  })
+})
 
 experiment('Test mapLine', () => {
   const absPeriod = {
@@ -261,11 +261,11 @@ experiment('Test mapLine', () => {
     periodStartMonth: 4,
     periodEndDay: 5,
     periodEndMonth: 11
-  };
+  }
 
   it('Should return 0 quantity within abstraction period ', async () => {
-    const line = { startDate: '2018-05-01', endDate: '2018-05-30', timePeriod: 'month' };
-    const mapped = mapLine(line, absPeriod, 'month');
+    const line = { startDate: '2018-05-01', endDate: '2018-05-30', timePeriod: 'month' }
+    const mapped = mapLine(line, absPeriod, 'month')
     expect(mapped).to.equal({
       start_date: '2018-05-01',
       end_date: '2018-05-30',
@@ -274,12 +274,12 @@ experiment('Test mapLine', () => {
       user_unit: 'm³',
       reading_type: 'measured',
       time_period: 'month'
-    });
-  });
+    })
+  })
 
   it('Should return null quantity before abstraction period starts', async () => {
-    const line = { startDate: '2018-03-11', endDate: '2018-03-17', timePeriod: 'week' };
-    const mapped = mapLine(line, absPeriod, 'week');
+    const line = { startDate: '2018-03-11', endDate: '2018-03-17', timePeriod: 'week' }
+    const mapped = mapLine(line, absPeriod, 'week')
     expect(mapped).to.equal({
       start_date: '2018-03-11',
       end_date: '2018-03-17',
@@ -288,12 +288,12 @@ experiment('Test mapLine', () => {
       user_unit: 'm³',
       reading_type: 'measured',
       time_period: 'week'
-    });
-  });
+    })
+  })
 
   it('Should return null quantity after abstraction period ends', async () => {
-    const line = { startDate: '2018-11-11', endDate: '2018-11-11', timePeriod: 'day' };
-    const mapped = mapLine(line, absPeriod, 'week');
+    const line = { startDate: '2018-11-11', endDate: '2018-11-11', timePeriod: 'day' }
+    const mapped = mapLine(line, absPeriod, 'week')
     expect(mapped).to.equal({
       start_date: '2018-11-11',
       end_date: '2018-11-11',
@@ -302,6 +302,6 @@ experiment('Test mapLine', () => {
       user_unit: 'm³',
       reading_type: 'measured',
       time_period: 'day'
-    });
-  });
-});
+    })
+  })
+})

--- a/test/modules/returns/lib/transformers.js
+++ b/test/modules/returns/lib/transformers.js
@@ -1,57 +1,57 @@
-'use strict';
+'use strict'
 
-const { beforeEach, experiment, it } = module.exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const { difference, cloneDeep, set } = require('lodash');
+const { beforeEach, experiment, it } = module.exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const { difference, cloneDeep, set } = require('lodash')
 
-const transformers = require('../../../../src/modules/returns/lib/transformers');
+const transformers = require('../../../../src/modules/returns/lib/transformers')
 
-const returnResponse = require('../responses/return');
-const monthlyLineResponse = require('../responses/lineMonthly');
-const weeklyLineResponse = require('../responses/lineWeekly');
+const returnResponse = require('../responses/return')
+const monthlyLineResponse = require('../responses/lineMonthly')
+const weeklyLineResponse = require('../responses/lineWeekly')
 
 experiment('transformReturn', () => {
-  let transformed;
+  let transformed
 
   beforeEach(async () => {
-    transformed = transformers.transformReturn(returnResponse);
-  });
+    transformed = transformers.transformReturn(returnResponse)
+  })
 
   it('includes the returns_frequency', async () => {
-    expect(transformed.returns_frequency).to.equal(returnResponse.returns_frequency);
-  });
+    expect(transformed.returns_frequency).to.equal(returnResponse.returns_frequency)
+  })
 
   it('includes the licence_ref', async () => {
-    expect(transformed.licence_ref).to.equal(returnResponse.licence_ref);
-  });
+    expect(transformed.licence_ref).to.equal(returnResponse.licence_ref)
+  })
 
   it('includes the start_date', async () => {
-    expect(transformed.start_date).to.equal(returnResponse.start_date);
-  });
+    expect(transformed.start_date).to.equal(returnResponse.start_date)
+  })
 
   it('includes the end_date', async () => {
-    expect(transformed.end_date).to.equal(returnResponse.end_date);
-  });
+    expect(transformed.end_date).to.equal(returnResponse.end_date)
+  })
 
   it('includes a nald_ret_lines style date_from value: the first of the month containing the return start date', async () => {
-    expect(transformed.nald_date_from).to.equal('20171101000000');
-  });
+    expect(transformed.nald_date_from).to.equal('20171101000000')
+  })
 
   it('includes the regionCode', async () => {
-    expect(transformed.regionCode).to.equal(returnResponse.metadata.nald.regionCode);
-  });
+    expect(transformed.regionCode).to.equal(returnResponse.metadata.nald.regionCode)
+  })
 
   it('includes the formatId', async () => {
-    expect(transformed.formatId).to.equal(returnResponse.metadata.nald.formatId);
-  });
+    expect(transformed.formatId).to.equal(returnResponse.metadata.nald.formatId)
+  })
 
   it('includes the received_date', async () => {
-    expect(transformed.received_date).to.equal(returnResponse.received_date);
-  });
+    expect(transformed.received_date).to.equal(returnResponse.received_date)
+  })
 
   it('includes a nald_ret_lines style ret_date  value', async () => {
-    expect(transformed.nald_ret_date).to.equal('20180913000000');
-  });
+    expect(transformed.nald_ret_date).to.equal('20180913000000')
+  })
 
   it('does not include any other keys', async () => {
     const allowed = [
@@ -68,70 +68,70 @@ experiment('transformReturn', () => {
       'under_query',
       'under_query_comment',
       'return_cycle_start'
-    ];
+    ]
 
-    expect(difference(Object.keys(transformed), allowed)).to.have.length(0);
-  });
+    expect(difference(Object.keys(transformed), allowed)).to.have.length(0)
+  })
 
   it('under_query_comment is transformed to empty string if null', async () => {
-    expect(transformed.under_query_comment).to.equal('');
-  });
+    expect(transformed.under_query_comment).to.equal('')
+  })
 
   it('Should return a date for return_cycle_start if the isSummer flag is set in the metadata', async () => {
-    expect(transformed.return_cycle_start).to.equal('2017-11-01');
-  });
-});
+    expect(transformed.return_cycle_start).to.equal('2017-11-01')
+  })
+})
 
 experiment('transformLine', () => {
-  let transformed;
+  let transformed
 
   beforeEach(async () => {
-    transformed = transformers.transformLine(monthlyLineResponse);
-  });
+    transformed = transformers.transformLine(monthlyLineResponse)
+  })
 
   it('returns an integer if the quantity is an integer', async () => {
-    const line = Object.assign({}, monthlyLineResponse, { quantity: 123 });
-    const transformedLine = transformers.transformLine(line);
-    expect(transformedLine.quantity).to.equal('123');
-  });
+    const line = Object.assign({}, monthlyLineResponse, { quantity: 123 })
+    const transformedLine = transformers.transformLine(line)
+    expect(transformedLine.quantity).to.equal('123')
+  })
 
   it('rounds to three decimal places when the quantity has decimal places', async () => {
-    const line = Object.assign({}, monthlyLineResponse, { quantity: 123.456789 });
-    const transformedLine = transformers.transformLine(line);
-    expect(transformedLine.quantity).to.equal('123.457');
-  });
+    const line = Object.assign({}, monthlyLineResponse, { quantity: 123.456789 })
+    const transformedLine = transformers.transformLine(line)
+    expect(transformedLine.quantity).to.equal('123.457')
+  })
 
   it('includes the start_date', async () => {
-    expect(transformed.start_date).to.equal(monthlyLineResponse.start_date);
-  });
+    expect(transformed.start_date).to.equal(monthlyLineResponse.start_date)
+  })
 
   it('includes the end_date', async () => {
-    expect(transformed.end_date).to.equal(monthlyLineResponse.end_date);
-  });
+    expect(transformed.end_date).to.equal(monthlyLineResponse.end_date)
+  })
 
   it('includes the time_period', async () => {
-    expect(transformed.time_period).to.equal(monthlyLineResponse.time_period);
-  });
+    expect(transformed.time_period).to.equal(monthlyLineResponse.time_period)
+  })
 
   it('includes the reading_type', async () => {
-    expect(transformed.reading_type).to.equal(monthlyLineResponse.reading_type);
-  });
+    expect(transformed.reading_type).to.equal(monthlyLineResponse.reading_type)
+  })
 
   it('includes the unit', async () => {
-    expect(transformed.unit).to.equal(monthlyLineResponse.unit);
-  });
+    expect(transformed.unit).to.equal(monthlyLineResponse.unit)
+  })
 
   it('includes the user unit', async () => {
-    expect(transformed.user_unit).to.equal(monthlyLineResponse.user_unit);
-  });
+    expect(transformed.user_unit).to.equal(monthlyLineResponse.user_unit)
+  })
 
   it('includes a nald style time_period', async () => {
-    expect(transformed.nald_time_period).to.equal('M');
-  });
+    expect(transformed.nald_time_period).to.equal('M')
+  })
 
   it('includes a nald style reading_type', async () => {
-    expect(transformed.nald_reading_type).to.equal('M');
-  });
+    expect(transformed.nald_reading_type).to.equal('M')
+  })
 
   it('does not include any other keys', async () => {
     const allowed = [
@@ -145,75 +145,75 @@ experiment('transformLine', () => {
       'nald_reading_type',
       'nald_time_period',
       'nald_units'
-    ];
+    ]
 
-    expect(difference(Object.keys(transformed), allowed)).to.have.length(0);
-  });
+    expect(difference(Object.keys(transformed), allowed)).to.have.length(0)
+  })
 
   it('throws if passed a weekly line', async () => {
-    expect(() => transformers.transformLine(weeklyLineResponse)).to.throw();
-  });
-});
+    expect(() => transformers.transformLine(weeklyLineResponse)).to.throw()
+  })
+})
 
 experiment('transformWeeklyLine', () => {
-  let transformed;
+  let transformed
 
   beforeEach(async () => {
-    transformed = transformers.transformWeeklyLine(weeklyLineResponse);
-  });
+    transformed = transformers.transformWeeklyLine(weeklyLineResponse)
+  })
 
   // the test response is a week in the range:
   // "start_date": "2017-10-29",
   // "end_date": "2017-11-04",
   it('returns an array of days of the week', async () => {
-    expect(transformed).to.have.length(7);
-    expect(transformed[0].start_date).to.equal('2017-10-29');
-    expect(transformed[0].end_date).to.equal('2017-10-29');
-    expect(transformed[1].start_date).to.equal('2017-10-30');
-    expect(transformed[1].end_date).to.equal('2017-10-30');
-    expect(transformed[2].start_date).to.equal('2017-10-31');
-    expect(transformed[2].end_date).to.equal('2017-10-31');
-    expect(transformed[3].start_date).to.equal('2017-11-01');
-    expect(transformed[3].end_date).to.equal('2017-11-01');
-    expect(transformed[4].start_date).to.equal('2017-11-02');
-    expect(transformed[4].end_date).to.equal('2017-11-02');
-    expect(transformed[5].start_date).to.equal('2017-11-03');
-    expect(transformed[5].end_date).to.equal('2017-11-03');
-    expect(transformed[6].start_date).to.equal('2017-11-04');
-    expect(transformed[6].end_date).to.equal('2017-11-04');
-  });
+    expect(transformed).to.have.length(7)
+    expect(transformed[0].start_date).to.equal('2017-10-29')
+    expect(transformed[0].end_date).to.equal('2017-10-29')
+    expect(transformed[1].start_date).to.equal('2017-10-30')
+    expect(transformed[1].end_date).to.equal('2017-10-30')
+    expect(transformed[2].start_date).to.equal('2017-10-31')
+    expect(transformed[2].end_date).to.equal('2017-10-31')
+    expect(transformed[3].start_date).to.equal('2017-11-01')
+    expect(transformed[3].end_date).to.equal('2017-11-01')
+    expect(transformed[4].start_date).to.equal('2017-11-02')
+    expect(transformed[4].end_date).to.equal('2017-11-02')
+    expect(transformed[5].start_date).to.equal('2017-11-03')
+    expect(transformed[5].end_date).to.equal('2017-11-03')
+    expect(transformed[6].start_date).to.equal('2017-11-04')
+    expect(transformed[6].end_date).to.equal('2017-11-04')
+  })
 
   it('the first 6 days have a value of null', async () => {
-    const firstSix = transformed.slice(0, 6);
-    const allZero = firstSix.every(line => line.quantity === null);
-    expect(allZero).to.be.true();
-  });
+    const firstSix = transformed.slice(0, 6)
+    const allZero = firstSix.every(line => line.quantity === null)
+    expect(allZero).to.be.true()
+  })
 
   it('includes the quantity value in the last day', async () => {
-    expect(transformed[6].quantity).to.equal(weeklyLineResponse.quantity);
-  });
+    expect(transformed[6].quantity).to.equal(weeklyLineResponse.quantity)
+  })
 
   it('sets the time_period to day', async () => {
-    expect(transformed.every(line => line.time_period === 'day')).to.be.true();
-  });
+    expect(transformed.every(line => line.time_period === 'day')).to.be.true()
+  })
 
   it('includes the reading_type', async () => {
     expect(transformed.every(line => {
-      return line.reading_type === weeklyLineResponse.reading_type;
-    })).to.be.true();
-  });
+      return line.reading_type === weeklyLineResponse.reading_type
+    })).to.be.true()
+  })
 
   it('includes the unit', async () => {
     expect(transformed.every(line => {
-      return line.unit === weeklyLineResponse.unit;
-    })).to.be.true();
-  });
+      return line.unit === weeklyLineResponse.unit
+    })).to.be.true()
+  })
 
   it('includes the user unit', async () => {
     expect(transformed.every(line => {
-      return line.user_unit === weeklyLineResponse.user_unit;
-    })).to.be.true();
-  });
+      return line.user_unit === weeklyLineResponse.user_unit
+    })).to.be.true()
+  })
 
   it('does not include any other keys', async () => {
     const allowed = [
@@ -227,110 +227,110 @@ experiment('transformWeeklyLine', () => {
       'nald_reading_type',
       'nald_time_period',
       'nald_units'
-    ];
+    ]
 
-    expect(difference(Object.keys(transformed[0]), allowed)).to.have.length(0);
-  });
+    expect(difference(Object.keys(transformed[0]), allowed)).to.have.length(0)
+  })
 
   it('throws if the time_period is not week', async () => {
-    expect(() => transformers.transformWeeklyLineLine(monthlyLineResponse)).to.throw();
-  });
-});
+    expect(() => transformers.transformWeeklyLineLine(monthlyLineResponse)).to.throw()
+  })
+})
 
 experiment('transformQuantity', () => {
   it('returns a string representation on an integer for an integer input', async () => {
-    const val = transformers.transformQuantity(123);
-    expect(val).to.equal('123');
-  });
+    const val = transformers.transformQuantity(123)
+    expect(val).to.equal('123')
+  })
 
   it('returns a string representation on an integer for a string representation of an integer input', async () => {
-    const val = transformers.transformQuantity('123');
-    expect(val).to.equal('123');
-  });
+    const val = transformers.transformQuantity('123')
+    expect(val).to.equal('123')
+  })
 
   it('returns a string representation on a float for a float input', async () => {
-    const val = transformers.transformQuantity(123);
-    expect(val).to.equal('123');
-  });
+    const val = transformers.transformQuantity(123)
+    expect(val).to.equal('123')
+  })
 
   it('returns a string representation on a float for a string representation of a float input', async () => {
-    const val = transformers.transformQuantity('123');
-    expect(val).to.equal('123');
-  });
+    const val = transformers.transformQuantity('123')
+    expect(val).to.equal('123')
+  })
 
   it('floats are rounded to three decimal places', async () => {
-    expect(transformers.transformQuantity(123.123456)).to.equal('123.123');
-    expect(transformers.transformQuantity(123.129999)).to.equal('123.130');
-  });
+    expect(transformers.transformQuantity(123.123456)).to.equal('123.123')
+    expect(transformers.transformQuantity(123.129999)).to.equal('123.130')
+  })
 
   it('returns null if the quantity is null', async () => {
-    const val = transformers.transformQuantity(null);
-    expect(val).to.equal(null);
-  });
+    const val = transformers.transformQuantity(null)
+    expect(val).to.equal(null)
+  })
 
   it('returns null if the quantity is a string representation of null', async () => {
-    expect(transformers.transformQuantity('null')).to.be.null();
-    expect(transformers.transformQuantity('NULL')).to.be.null();
-    expect(transformers.transformQuantity('Null')).to.be.null();
-  });
-});
+    expect(transformers.transformQuantity('null')).to.be.null()
+    expect(transformers.transformQuantity('NULL')).to.be.null()
+    expect(transformers.transformQuantity('Null')).to.be.null()
+  })
+})
 
 experiment('transformUnits', () => {
   it('Transforms gallons to I (imperial)', async () => {
-    expect(transformers.transformUnits('gal')).to.equal('I');
-  });
+    expect(transformers.transformUnits('gal')).to.equal('I')
+  })
 
   it('Transforms cubic metres to M (metric)', async () => {
-    expect(transformers.transformUnits('m³')).to.equal('M');
-  });
+    expect(transformers.transformUnits('m³')).to.equal('M')
+  })
 
   it('Transforms litres to M (metric)', async () => {
-    expect(transformers.transformUnits('l')).to.equal('M');
-  });
+    expect(transformers.transformUnits('l')).to.equal('M')
+  })
 
   it('Transforms megalitres to M (metric)', async () => {
-    expect(transformers.transformUnits('Ml')).to.equal('M');
-  });
-});
+    expect(transformers.transformUnits('Ml')).to.equal('M')
+  })
+})
 
 experiment('filterLines', () => {
   it('Should filter daily return lines outside return cycle for weekly return', async () => {
-    const lines = transformers.transformWeeklyLine(weeklyLineResponse);
-    const filtered = transformers.filterLines(returnResponse, lines);
-    const dates = filtered.map(row => row.start_date);
-    expect(dates[0]).to.equal(returnResponse.start_date);
-  });
+    const lines = transformers.transformWeeklyLine(weeklyLineResponse)
+    const filtered = transformers.filterLines(returnResponse, lines)
+    const dates = filtered.map(row => row.start_date)
+    expect(dates[0]).to.equal(returnResponse.start_date)
+  })
 
   it('Should pass lines unchanged for non-weekly', async () => {
     const ret = {
       ...returnResponse,
       returns_frequency: 'day'
-    };
-    const lines = transformers.transformWeeklyLine(weeklyLineResponse);
-    const filtered = transformers.filterLines(ret, lines);
+    }
+    const lines = transformers.transformWeeklyLine(weeklyLineResponse)
+    const filtered = transformers.filterLines(ret, lines)
 
-    expect(filtered).to.equal(lines);
-  });
-});
+    expect(filtered).to.equal(lines)
+  })
+})
 
 experiment('getReturnCycleStart', () => {
   it('Should return undefined if the isSummer flag is missing in the metadata', async () => {
-    const data = cloneDeep(returnResponse);
-    delete data.metadata.isSummer;
-    const cycleStart = transformers.getReturnCycleStart(data);
-    expect(cycleStart).to.equal(undefined);
-  });
+    const data = cloneDeep(returnResponse)
+    delete data.metadata.isSummer
+    const cycleStart = transformers.getReturnCycleStart(data)
+    expect(cycleStart).to.equal(undefined)
+  })
 
   it('Should return a summer cycle if the isSummer flag is true', async () => {
-    const data = cloneDeep(returnResponse);
-    const cycleStart = transformers.getReturnCycleStart(data);
-    expect(cycleStart).to.equal('2017-11-01');
-  });
+    const data = cloneDeep(returnResponse)
+    const cycleStart = transformers.getReturnCycleStart(data)
+    expect(cycleStart).to.equal('2017-11-01')
+  })
 
   it('Should return a winter cycle if the isSummer flag is false', async () => {
-    const data = cloneDeep(returnResponse);
-    set(data, 'metadata.isSummer', false);
-    const cycleStart = transformers.getReturnCycleStart(data);
-    expect(cycleStart).to.equal('2017-04-01');
-  });
-});
+    const data = cloneDeep(returnResponse)
+    set(data, 'metadata.isSummer', false)
+    const cycleStart = transformers.getReturnCycleStart(data)
+    expect(cycleStart).to.equal('2017-04-01')
+  })
+})

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const { cloneDeep } = require('lodash');
-const Hapi = require('@hapi/hapi');
+const { cloneDeep } = require('lodash')
+const Hapi = require('@hapi/hapi')
 
 /**
  * Creates a HAPI server to allow a single route to be
@@ -12,15 +12,15 @@ const Hapi = require('@hapi/hapi');
  * @param {Object} route The HAPI route definition
  */
 const createServerForRoute = route => {
-  const server = Hapi.server();
-  const testRoute = cloneDeep(route);
-  testRoute.handler = async () => 'ok';
+  const server = Hapi.server()
+  const testRoute = cloneDeep(route)
+  testRoute.handler = async () => 'ok'
 
-  server.route(testRoute);
+  server.route(testRoute)
 
-  return server;
-};
+  return server
+}
 
 module.exports = {
   createServerForRoute
-};
+}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/9

Defra's JavaScript standard is to use StandardJS for linting. We currently use ESLint, configured to Semi-Standard (ie. StandardJS with semicolons). For consistency, we should change this to the regular Standard rules, and replace ESLint with StandardJS while we're at it.