### PR TITLE
Apply consistent CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,70 +1,106 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - '**'
-      - '!dependabot/**'
+on: push
 
 jobs:
-  base-node-pipeline:
-    uses: DEFRA/water-abstraction-orchestration/.github/workflows/base-node-pipeline.yml@develop
-    with:
-      serviceName: DEFRA_water-abstraction-import
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  docker-build-and-push-image:
-    uses: DEFRA/water-abstraction-orchestration/.github/workflows/docker.yml@develop
-  test:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 14.x ]
-    name: Test  - Node.js ${{ matrix.node-version }}
     env:
+      DATABASE_URL: postgres://water_user:password@localhost:5432/wabs_test
+      JWT_SECRET: ItsNoSecretBecauseYouToldEverybody
+      JWT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwibmFtZSI6InRlc3QiLCJpYXQiOjE1MDMzMTg0NDV9.eWghqjYlPrb8ZjWacYzTCTh1PBtr2BeSv-_ZIwrtmwE
       # These need to be duplicated in services section for postgres. Unfortunately, there is not a way to reuse them
       PGUSER: water_user
-      PGHOST: localhost
       PGPASSWORD: password
+      PGDATABASE: wabs_test
+      PGHOST: localhost
       PGPORT: 5432
-      PGDATABASE: permits
-      ENVIRONMENT: dev
-      DATABASE_URL: postgres://water_user:password@localhost:5432/permits
-      JWT_SECRET: secret
-      JWT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIzNH0.MOREC6-Kszb9bDFw0O1UKywpnkcP-c5cPjASMpjk8Po
-      NOTIFY_KEY: somerealnotifykey-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
+
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:10-alpine
+        image: postgres:12-alpine
         # Provide the password for postgres
         env:
           POSTGRES_USER: water_user
-          POSTGRES_DB: permits
           POSTGRES_PASSWORD: password
+          POSTGRES_DB: wabs_test
         # Maps tcp port 5432 on service container to the host
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
         # postgres is up and running before proceeding
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - name: Install node modules
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # Before we do anything, check we haven't accidentally left any `experiment.only()` or `test.only(` statements in
+      # the tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
         run: |
-          npm ci
-      - name: Create database
+          ! grep -R 'experiment.only(\|test.only(' test
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
         run: |
-          PGPASSWORD=password psql -U water_user -tc "SELECT 'CREATE DATABASE water' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'water_user')"
-      - name: Run database migrations
+          npm run lint
+
+      - name: Database migrations
         run: |
           npm run migrate
-      - name: Test
-        run:
-          npm run test:ci
+
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage/lcov.info
+
+      - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,7 +1,16 @@
+'use strict'
 // default settings for lab test runs.
 //
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
+  verbose: true,
+  coverage: true,
+  // Means when we use *.only() in our tests we just get the output for what we've flagged rather than all output but
+  // greyed out to show it was skipped
+  'silent-skips': true,
+  // lcov reporter required for SonarCloud
+  reporter: ['console', 'html', 'lcov'],
+  output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],
   globals: [
     '__classPrivateFieldGet',
     '__extends',
@@ -34,12 +43,5 @@ module.exports = {
     '__coverage__',
     '__createBinding',
     '__spreadArray'
-  ].join(','),
-  verbose: true,
-
-  'coverage-exclude': [
-    'migrations',
-    'node_modules',
-    'test'
-  ]
+  ].join(',')
 };

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Water Abstraction Import
 
-|               |              |  
-|---------------|--------------|
-| Build         |  ![CI](https://github.com/DEFRA/water-abstraction-import/workflows/CI/badge.svg) |
-| Test coverage | [![Test Coverage](https://api.codeclimate.com/v1/badges/36785e4052ddbae42719/test_coverage)](https://codeclimate.com/github/DEFRA/water-abstraction-import/test_coverage)  |
-| Quality check |  [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-import&metric=alert_status)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-import) |
+![Build Status](https://github.com/DEFRA/water-abstraction-import/workflows/CI/badge.svg?branch=develop)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-import&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-import)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-import&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-import)
+[![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/water-abstraction-import/badge.svg)](https://snyk.io/test/github/DEFRA/water-abstraction-import)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 ## Development Team
 
@@ -37,4 +37,3 @@ The following attribution statement MUST be cited in your products and applicati
 The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.
-

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "DATABASE_URL=postgres://water_user:password@localhost:5432/permits lab",
+    "test": "DATABASE_URL=postgres://water_user:password@localhost:5432/wabs_test lab",
     "test:bail": "DATABASE_URL=postgres://water_user:password@localhost:5432/permits lab --bail",
-    "test:ci": "lab -t 55 -m 0 -r lcov -o coverage/lcov.info -r console -o stdout",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "codecov": "codecov",
@@ -14,7 +13,7 @@
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --",
-    "migrate:local-test": "DATABASE_URL=postgres://water_user:password@localhost:5432/permits node scripts/create-schema && DATABASE_URL=postgres://water_user:password@localhost:5432/permits db-migrate up --verbose"
+    "migrate:local-test": "DATABASE_URL=postgres://water_user:password@localhost:5432/wabs_test node scripts/create-schema && DATABASE_URL=postgres://water_user:password@localhost:5432/wabs_test db-migrate up --verbose"
   },
   "repository": {
     "type": "git",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,34 @@
+# Reference for all available properties
+# https://sonarcloud.io/documentation/analysis/analysis-parameters/
+# Reference for how to glob files
+# https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/
+
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_water-abstraction-import
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=water-abstraction-import
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/water-abstraction-import
+sonar.links.ci=https://github.com/DEFRA/water-abstraction-import/actions
+sonar.links.scm=https://github.com/DEFRA/water-abstraction-import
+sonar.links.issue=https://github.com/DEFRA/water-abstraction-team/issues
+
+# Path is relative to the sonar-project.properties file.
+# SonarCloud seems to have little intelligence when it comes to code coverage. Quite simply if it sees a code file, it
+# checks it against our coverage report and if not found flags it as uncovered. This also effects the overall coverage
+# score. In our case this means SonarCloud could flag everything under test/ as lacking code coverage!
+# We have found this combinations of `sources`, `tests` and `tests.inclusions` means SonarCloud properly understands
+# what is code and what is a test file. Note the use of ./ in `sources`. This is the only way we found to include root
+# level files and ensure they are correctly resolved when SonarCloud scans the lcov coverage data.
+sonar.sources=src,./config.js,./index.js,./server.js
+sonar.tests=test
+sonar.test.inclusions=test/**/*.js
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+# Ensure SonarCloud knows where to pick up test coverage stats
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/4

As a team, we are currently maintaining 11 repos and that's not including documentation, support and deployment-related stuff! What we inherited was not consistent; different CI tools were used for the same purpose and different CI steps were implemented.

An effort was made to get this under control with [water-abstraction-orchestration](https://github.com/DEFRA/water-abstraction-orchestration). But to get a handle on it in such a way as the current team can manage, we're simplifying still further.

This change updates `.github/workflows/ci.yml` to use a template we're applying across all the repos, amended to the requirements of the project. In the future, we hope to return to the lessons **water-abstraction-orchestration** taught us, if only to remove the duplication across the projects. But for now, the template hopefully simplifies and makes consistent our build process.

**Notes**

- Apply ci.yml template

This is very much based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.github/workflows/ci.yml

There is now one process, which means you'll just see the one item listed in the checks on GitHub. The steps are ordered in an effort to fail fast and/or where needed, for example, DB migrations before running tests and SonarCloud analysis after code coverage data has been generated.

- Update .labrc

This is based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.labrc.js. We use the config file to ensure we generate the coverage output in a format needed by SonarCloud.

- Add SonarCloud properties file

Previously, the CI specified the values SonarCloud needs in its steps plus there were some in the web UI. But there are a bunch of other things we can tell SonarCloud about which makes managing SonarCloud much easier.

So, we use `sonar-project.properties` files to set what the SonarCloud analysis step needs and what's useful in its UI.

- Update README with new badges

Also displays the badges we want in a layout that is consistent with most open source repos.