### PR TITLE
Move db-migrate packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "aws-sdk": "^2.674.0",
         "blipp": "^4.0.1",
         "csv-stringify": "^5.5.0",
-        "db-migrate": "^0.11.11",
+        "db-migrate": "^0.11.13",
+        "db-migrate-pg": "^1.2.2",
         "deep-map": "^2.0.0",
         "dotenv": "^8.2.0",
         "es6-weak-map": "^2.0.3",
@@ -46,7 +47,6 @@
         "@hapi/lab": "^22.0.4",
         "auto-changelog": "^1.16.4",
         "codecov": "^3.7.1",
-        "db-migrate-pg": "^1.2.2",
         "sinon": "^9.0.2",
         "standard": "^17.0.0"
       }
@@ -3051,7 +3051,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-2.3.1.tgz",
       "integrity": "sha512-HewYQ3HPmy7NOWmhhMLg9TzN1StEtSqGL3w8IbBRCxEsJ+oM3bDUQ/z5fqpYKfIUK07mMXieCmZYwFpwWkSHDw==",
-      "dev": true,
       "dependencies": {
         "bluebird": "^3.1.1"
       }
@@ -3060,7 +3059,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-1.2.2.tgz",
       "integrity": "sha512-+rgrhGNWC2SzcfweopyZqOQ1Igz1RVFMUZwUs6SviHpOUzFwb0NZWkG0pw1GaO+JxTxS7VJjckUWkOwZbVYVag==",
-      "dev": true,
       "dependencies": {
         "bluebird": "^3.1.1",
         "db-migrate-base": "^2.3.0",
@@ -3072,7 +3070,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -12163,7 +12160,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-2.3.1.tgz",
       "integrity": "sha512-HewYQ3HPmy7NOWmhhMLg9TzN1StEtSqGL3w8IbBRCxEsJ+oM3bDUQ/z5fqpYKfIUK07mMXieCmZYwFpwWkSHDw==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
       }
@@ -12172,7 +12168,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-1.2.2.tgz",
       "integrity": "sha512-+rgrhGNWC2SzcfweopyZqOQ1Igz1RVFMUZwUs6SviHpOUzFwb0NZWkG0pw1GaO+JxTxS7VJjckUWkOwZbVYVag==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.1.1",
         "db-migrate-base": "^2.3.0",
@@ -12183,8 +12178,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "aws-sdk": "^2.674.0",
     "blipp": "^4.0.1",
     "csv-stringify": "^5.5.0",
-    "db-migrate": "^0.11.11",
+    "db-migrate": "^0.11.13",
+    "db-migrate-pg": "^1.2.2",
     "deep-map": "^2.0.0",
     "dotenv": "^8.2.0",
     "es6-weak-map": "^2.0.3",
@@ -56,7 +57,6 @@
     "@hapi/lab": "^22.0.4",
     "auto-changelog": "^1.16.4",
     "codecov": "^3.7.1",
-    "db-migrate-pg": "^1.2.2",
     "sinon": "^9.0.2",
     "standard": "^17.0.0"
   }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/36

Whilst we were trying to bring some sanity to the deployment process we found that the db-migrate package had been installed as a dev dependency. This dependency is required as part of the deployment process which has meant currently ALL dependencies have to be installed upon deployment, the devDependencies cannot be ignored.