### PR TITLE
Make cron background job timings configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ WATER_SERVICE_MAILBOX=
 # Enables import of licence agreements during the licence import process. This was a one time import
 # run in production that we often need to re-run in local and non-production environments
 IMPORT_LICENCE_AGREEMENTS=false
+
+# Use Cron type syntax to set timings for these background processes
+WRLS_CRON_LICENCES='0 16 * * 1,2,3,4,5'
+WRLS_CRON_CHARGING='0 14 * * 1,2,3,4,5'

--- a/config.js
+++ b/config.js
@@ -78,7 +78,7 @@ module.exports = {
       overwriteReturns: false // Set to false as this is highly disruptive
     },
     licences: {
-      schedule: isProduction ? '0 4 * * 1,2,3,4,5' : '0 16 * * 1,2,3,4,5',
+      schedule: process.env.WRLS_CRON_LICENCES || '0 4 * * 1,2,3,4,5',
       // Note: these 2 flags need to be set to false for charging go-live
       // to suspend the import of invoice accounts and licence agreements
       // Update: I've changed those values to false ahead of the v2.0 charging
@@ -95,7 +95,7 @@ module.exports = {
       isBillingDocumentRoleImportEnabled: false
     },
     charging: {
-      schedule: isProduction ? '0 1 * * 1,2,3,4,5' : '0 14 * * 1,2,3,4,5'
+      schedule: process.env.WRLS_CRON_CHARGING || '0 1 * * 1,2,3,4,5'
     },
     monitoring: {
       schedule: '* * * * *'

--- a/test/modules/charging-import/plugin.js
+++ b/test/modules/charging-import/plugin.js
@@ -1,8 +1,12 @@
 'use strict'
 
+require('dotenv').config()
+
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
 const sandbox = require('sinon').createSandbox()
 const cron = require('node-cron')
+
+const config = require('../../../config')
 
 const { plugin } = require('../../../src/modules/charging-import/plugin')
 
@@ -40,8 +44,9 @@ experiment('modules/charging-import/plugin.js', () => {
     experiment('on target environments', () => {
       beforeEach(async () => {
         sandbox.stub(process, 'env').value({
-          NODE_ENV: 'test'
+          NODE_ENV: 'dev'
         })
+        sandbox.stub(config.import.charging, 'schedule').value('0 14 * * 1,2,3,4,5')
         await plugin.register(server)
       })
 

--- a/test/modules/charging-import/plugin.js
+++ b/test/modules/charging-import/plugin.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
 const sandbox = require('sinon').createSandbox()
 const cron = require('node-cron')

--- a/test/modules/licence-import/plugin.js
+++ b/test/modules/licence-import/plugin.js
@@ -2,6 +2,7 @@
 
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
 const sandbox = require('sinon').createSandbox()
+const config = require('../../../config')
 const cron = require('node-cron')
 const { plugin } = require('../../../src/modules/licence-import/plugin')
 const jobs = require('../../../src/modules/licence-import/jobs')
@@ -43,6 +44,7 @@ experiment('modules/licence-import/plugin.js', () => {
         sandbox.stub(process, 'env').value({
           NODE_ENV: 'test'
         })
+        sandbox.stub(config.import.licences, 'schedule').value('0 16 * * 1,2,3,4,5')
         await plugin.register(server)
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

The context for this change is actually to give as much 'oomph' to our pre-prod environment to run some other testing. By making the background cron jobs in this service configurable we can ensure they run outside the time testing is taking place.

However, we would expect them to be configurable anyway to give us this kind of flexibility. So, this change amends the cron config in `config.js`. Now what is set for `production` will become the default if an env var with the timing is not set.