### PR TITLE
Set log level using new env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ WATER_SERVICE_MAILBOX=
 # run in production that we often need to re-run in local and non-production environments
 IMPORT_LICENCE_AGREEMENTS=false
 
+# Set log level for app. Default is 'info'
+WRLS_LOG_LEVEL=debug
+
 # Use Cron type syntax to set timings for these background processes
 WRLS_CRON_LICENCES='0 16 * * 1,2,3,4,5'
 WRLS_CRON_CHARGING='0 14 * * 1,2,3,4,5'

--- a/config.js
+++ b/config.js
@@ -10,7 +10,6 @@ const ENV_PREPROD = 'preprod'
 const ENV_PRODUCTION = 'production'
 
 const isAcceptanceTestTarget = [ENV_LOCAL, ENV_DEV, ENV_TEST, ENV_QA, ENV_PREPROD].includes(process.env.NODE_ENV)
-const testMode = parseInt(process.env.TEST_MODE) === 1
 const isProduction = process.env.NODE_ENV === ENV_PRODUCTION
 const isLocal = process.env.NODE_ENV === ENV_LOCAL
 const isTest = process.env.NODE_ENV === ENV_TEST
@@ -27,7 +26,7 @@ module.exports = {
   },
 
   logger: {
-    level: testMode ? 'info' : 'error',
+    level: process.env.WRLS_LOG_LEVEL || 'info',
     airbrakeKey: process.env.ERRBIT_KEY,
     airbrakeHost: process.env.ERRBIT_SERVER,
     airbrakeLevel: 'error'


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/41

We're currently unable to set the log level used within the app. Instead, it's determined by looking at the env var `TEST_MODE`. If 'truthy' it sets the log level to `info`, else the default is `error`.

But we'd actually like to run with `debug` locally and `info` in **production**. And if that works out too noisy perhaps try `warn`. The key thing is we would expect to be able to explicitly set the log level for an app in an environment and currently we can't.

So, this change removes the reliance on `TEST_MODE` for setting the log level and instead will read it directly from an env var (if set).