### PR TITLE
Stop passing err to logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,12 +67,12 @@ const start = async function () {
       server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error(err)
+    logger.error(err.stack)
   }
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -28,7 +28,7 @@ function post (message) {
 
   return rp(options)
     .catch((err) => {
-      logger.error('Slack error', err)
+      logger.error('Slack error', err.stack)
     })
 }
 

--- a/src/modules/charging-import/lib/import-charge-version-metadata.js
+++ b/src/modules/charging-import/lib/import-charge-version-metadata.js
@@ -16,7 +16,7 @@ const importChargeVersionMetadata = async () => {
 
     logger.info('Charge version metadata import complete')
   } catch (err) {
-    logger.error(err)
+    logger.error(err.stack)
     throw err
   }
 }

--- a/src/modules/core/jobs/import-tracker.js
+++ b/src/modules/core/jobs/import-tracker.js
@@ -41,7 +41,7 @@ const handler = async job => {
       slack.post(content)
     }
   } catch (err) {
-    logger.error(`Error handling job ${job.name}`, err)
+    logger.error(`Error handling job ${job.name}`, err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/delete-documents.js
+++ b/src/modules/licence-import/handlers/delete-documents.js
@@ -6,7 +6,7 @@ module.exports = async job => {
     logger.info('Deleting removed documents')
     return documentsConnector.deleteRemovedDocuments()
   } catch (err) {
-    logger.error('Failed to delete removed documents', err)
+    logger.error('Failed to delete removed documents', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/import-companies.js
+++ b/src/modules/licence-import/handlers/import-companies.js
@@ -13,7 +13,7 @@ module.exports = async job => {
     const data = await importCompanies.initialise()
     return data.map(mapRow)
   } catch (err) {
-    logger.error('Import companies error', err)
+    logger.error('Import companies error', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/import-company.js
+++ b/src/modules/licence-import/handlers/import-company.js
@@ -22,7 +22,7 @@ module.exports = async job => {
 
     await importCompanies.setImportedStatus(regionCode, partyId)
   } catch (err) {
-    logger.error('Import company error', err)
+    logger.error('Import company error', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/import-licence.js
+++ b/src/modules/licence-import/handlers/import-licence.js
@@ -16,7 +16,7 @@ module.exports = async job => {
     // Load licence to DB
     await load.licence.loadLicence(mapped)
   } catch (err) {
-    logger.error('Import licence error', err)
+    logger.error('Import licence error', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/import-licences.js
+++ b/src/modules/licence-import/handlers/import-licences.js
@@ -7,7 +7,7 @@ module.exports = async job => {
     const rows = await extract.getAllLicenceNumbers()
     return rows
   } catch (err) {
-    logger.error('Import licences error', err)
+    logger.error('Import licences error', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/import-purpose-condition-types.js
+++ b/src/modules/licence-import/handlers/import-purpose-condition-types.js
@@ -9,7 +9,7 @@ module.exports = async () => {
     // Load to data in to database
     return purposeConditionsConnector.createPurposeConditionTypes()
   } catch (err) {
-    logger.error('Import purpose condition types error', err)
+    logger.error('Import purpose condition types error', err.stack)
     throw err
   }
 }

--- a/src/modules/licence-import/handlers/on-complete-import-licences.js
+++ b/src/modules/licence-import/handlers/on-complete-import-licences.js
@@ -10,7 +10,7 @@ module.exports = async (messageQueue, job) => {
       await messageQueue.publish(jobs.importLicence(row.LIC_NO))
     }
   } catch (err) {
-    logger.error(`Error handling onComplete ${job.data.request.name}`, err)
+    logger.error(`Error handling onComplete ${job.data.request.name}`, err.stack)
     throw err
   }
 }

--- a/src/modules/nald-import/jobs/lib/logger.js
+++ b/src/modules/nald-import/jobs/lib/logger.js
@@ -4,7 +4,7 @@ const logHandlingJob = job =>
   logger.info(`Handling job: ${job.name}`, job.data)
 
 const logJobError = (job, err) =>
-  logger.error(`Error handling job ${job.name}`, err, job.data)
+  logger.error(`Error handling job ${job.name}`, err.stack, job.data)
 
 const logFailedJob = job =>
   logger.error(`Job: ${job.data.request.name} failed, aborting`, job.data.request.data)
@@ -13,7 +13,7 @@ const logHandlingOnCompleteJob = job =>
   logger.info(`Handling onComplete job: ${job.data.request.name}`, job.data.request.data)
 
 const logHandlingOnCompleteError = (job, err) =>
-  logger.error(`Error handling onComplete job: ${job.data.request.name}`, err, job.data.request.data)
+  logger.error(`Error handling onComplete job: ${job.data.request.name}`, err.stack, job.data.request.data)
 
 const logAbortingOnComplete = job =>
   logger.info(`Aborting onComplete job: ${job.data.request.name}`, job.data)

--- a/src/modules/nald-import/lib/db.js
+++ b/src/modules/nald-import/lib/db.js
@@ -16,7 +16,7 @@ const dbQuery = async (query, params = []) => {
     }
     return rows
   } catch (error) {
-    logger.error('dbQuery error', error)
+    logger.error('dbQuery error', error.stack)
     throw error
   }
 }

--- a/src/modules/nald-import/services/charge-version-metadata-import.js
+++ b/src/modules/nald-import/services/charge-version-metadata-import.js
@@ -76,7 +76,7 @@ const importChargeVersionMetadataForLicence = async licence => {
     await persistChargeVersionMetadata(wrlsChargeVersions)
     await cleanup(licence, wrlsChargeVersions)
   } catch (err) {
-    logger.error(`Error importing charge versions for licence ${licence.LIC_NO}`, err)
+    logger.error(`Error importing charge versions for licence ${licence.LIC_NO}`, err.stack)
   }
 }
 

--- a/src/modules/nald-import/services/zip-service.js
+++ b/src/modules/nald-import/services/zip-service.js
@@ -36,7 +36,7 @@ const extract = async () => {
     await extractArchive(primaryPath, constants.LOCAL_TEMP_PATH, zipPassword)
     await extractArchive(secondaryPath, constants.LOCAL_TEMP_PATH)
   } catch (err) {
-    logger.error('Could not extract NALD zip', err)
+    logger.error('Could not extract NALD zip', err.stack)
     throw err
   }
 }

--- a/src/modules/nald-import/transform-crm.js
+++ b/src/modules/nald-import/transform-crm.js
@@ -121,7 +121,7 @@ function buildCRMPacket (licenceData, licenceRef, licenceId) {
     metadata.contacts = contactsFormatter(findCurrent(licenceData.data.versions), licenceData.data.roles)
     crmData.metadata = JSON.stringify(metadata)
   } catch (error) {
-    logger.error('Cannot build CRM packet', error, crmData)
+    logger.error('Cannot build CRM packet', error.stack, crmData)
   }
   return crmData
 }

--- a/src/modules/nald-import/transform-permit.js
+++ b/src/modules/nald-import/transform-permit.js
@@ -132,7 +132,7 @@ const getLicenceJson = async (licenceNumber) => {
 
     return licenceRow
   } catch (error) {
-    logger.error('Error getting licence JSON', error, { licenceNumber })
+    logger.error('Error getting licence JSON', error.stack, { licenceNumber })
   }
 }
 

--- a/src/modules/returns/controller.js
+++ b/src/modules/returns/controller.js
@@ -27,7 +27,7 @@ const getVersions = async (request, h) => {
     const pagination = getPagination(request)
     return versions.findMany(filter, {}, pagination, ['version_id', 'return_id', 'nil_return'])
   } catch (err) {
-    logger.error('getVersions error', err)
+    logger.error('getVersions error', err.stack)
     throw err
   }
 }
@@ -95,7 +95,7 @@ const getLinesForVersion = async (request, h) => {
       }
     }
   } catch (err) {
-    logger.error('getLinesForVersion error', err)
+    logger.error('getLinesForVersion error', err.stack)
     throw err
   }
 }
@@ -122,7 +122,7 @@ const getReturns = async (request, h) => {
     response.data = await Promise.all(tasks)
     return response
   } catch (err) {
-    logger.error('getReturns error', err)
+    logger.error('getReturns error', err.stack)
     throw err
   }
 }

--- a/test/modules/nald-import/jobs/delete-removed-documents-complete.test.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents-complete.test.js
@@ -83,7 +83,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents-complete', () => {
 
           const [message, error] = logger.error.lastCall.args
           expect(message).to.equal('Error handling onComplete job: nald-import.delete-removed-documents')
-          expect(error).to.equal(err)
+          expect(error).to.equal(err.stack)
         })
       })
     })

--- a/test/modules/nald-import/jobs/delete-removed-documents.test.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.test.js
@@ -68,7 +68,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents', () => {
         const func = () => deleteRemovedDocumentsJob.handler(job)
         await expect(func()).to.reject()
         expect(logger.error.calledWith(
-          'Error handling job nald-import.delete-removed-documents', err
+          'Error handling job nald-import.delete-removed-documents', err.stack
         )).to.equal(true)
       })
 

--- a/test/modules/nald-import/jobs/import-licence.test.js
+++ b/test/modules/nald-import/jobs/import-licence.test.js
@@ -101,7 +101,7 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         await expect(func()).to.reject()
         expect(logger.error.calledWith(
           'Error handling job nald-import.import-licence',
-          err,
+          err.stack,
           { licenceNumber: 'test-licence-number' }
         )).to.be.true()
       })

--- a/test/modules/nald-import/jobs/populate-pending-import-complete.test.js
+++ b/test/modules/nald-import/jobs/populate-pending-import-complete.test.js
@@ -92,7 +92,7 @@ experiment('modules/nald-import/jobs/populate-pending-import-complete', () => {
 
         const [message, error] = logger.error.lastCall.args
         expect(message).to.equal('Error handling onComplete job: nald-import.populate-pending-import')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
       })
     })
   })

--- a/test/modules/nald-import/jobs/populate-pending-import.test.js
+++ b/test/modules/nald-import/jobs/populate-pending-import.test.js
@@ -87,7 +87,7 @@ experiment('modules/nald-import/jobs/populate-pending-import', () => {
         const func = () => populatePendingImport.handler(job)
         await expect(func()).to.reject()
         expect(logger.error.calledWith(
-          'Error handling job nald-import.populate-pending-import', err
+          'Error handling job nald-import.populate-pending-import', err.stack
         )).to.be.true()
       })
 

--- a/test/modules/nald-import/jobs/s3-download-complete.test.js
+++ b/test/modules/nald-import/jobs/s3-download-complete.test.js
@@ -119,7 +119,7 @@ experiment('modules/nald-import/jobs/s3-download-import-complete', () => {
 
           const [message, error] = logger.error.lastCall.args
           expect(message).to.equal('Error handling onComplete job: nald-import.s3-download')
-          expect(error).to.equal(err)
+          expect(error).to.equal(err.stack)
         })
       })
     })

--- a/test/modules/nald-import/jobs/s3-download.test.js
+++ b/test/modules/nald-import/jobs/s3-download.test.js
@@ -183,7 +183,7 @@ experiment('modules/nald-import/jobs/s3-download', () => {
         const func = () => s3Download.handler(job)
         await expect(func()).to.reject()
         expect(logger.error.calledWith(
-          'Error handling job nald-import.s3-download', err
+          'Error handling job nald-import.s3-download', err.stack
         )).to.be.true()
       })
 

--- a/test/modules/nald-import/services/zip-service.test.js
+++ b/test/modules/nald-import/services/zip-service.test.js
@@ -56,7 +56,7 @@ experiment('modules/nald-import/services/zip-service', () => {
       test('an error is logged and rethrown', async () => {
         const func = () => zipService.extract()
         const result = await expect(func()).to.reject()
-        expect(logger.error.calledWith('Could not extract NALD zip', err)).to.be.true()
+        expect(logger.error.calledWith('Could not extract NALD zip', err.stack)).to.be.true()
         expect(result).to.equal(err)
       })
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.