### PR TITLE
Remove pm2 watch config from ecosystem file

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -2,16 +2,8 @@
   "apps": [
     {
       "name": "import",
-      "ignore_watch": [
-        "node_modules",
-        "temp"
-      ],
       "script": "index.js",
-      "env": {
-        "watch": true
-      },
       "env_production": {
-        "watch": false,
         "instances" : "1"
       }
     }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/10

Here we have removed the watch config for pm2. This is due to using nodemon instead. Having both in the application is causing too many files to be registered, making it problematic to watch.