### PR TITLE
Fix issue with migrations

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "schema": "water_import"
+  }
+}


### PR DESCRIPTION
We have spotted that migrations are not working as expected. They failed when we deployed them to our AWS environment. When we investigated we found that a new `migrations` table had been created in the `public` schema and as such, it was then trying to run all migrations.

The first 4 are fine because they either initiate commands where the current state of the DB doesn't matter, or they have conditions in place, for example, `CREATE TABLE IF NOT EXISTS`. But the 5th uses a simple `CREATE TABLE water_import.charge_versions_metadata` which fails because the table already exists.

The root cause is our mistaken assumption that by specifying the `DATABASE_URL` [db-migrate](https://db-migrate.readthedocs.io/) doesn't use `database.json`. In fact, that was the only place it is able to read what schema to use.

So, this change adds the file back in but just specifies the schema to use.