### PR TITLE
Remove verbose from db migrate commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "lab",
     "lint": "standard",
     "migrate": "node scripts/create-schema && node scripts/migrate",
-    "migrate:down": "db-migrate down --verbose",
+    "migrate:down": "db-migrate down",
     "migrate:create": "db-migrate create --sql-file --",
     "migrate:test": "export NODE_ENV=test && node scripts/create-schema && node scripts/migrate",
     "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -10,7 +10,7 @@ async function run () {
   const databaseUrl = process.env.NODE_ENV !== 'test' ? process.env.DATABASE_URL : process.env.TEST_DATABASE_URL
 
   try {
-    const { stdout, stderr } = await exec(`export DATABASE_URL=${databaseUrl} && db-migrate up --verbose`)
+    const { stdout, stderr } = await exec(`export DATABASE_URL=${databaseUrl} && db-migrate up`)
 
     const output = stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
     console.log(output)


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/65

We needed to add a large data migration to fix an issue. The fix worked but it broke CI. GitHub actions started erroring when the migrations ran with `##[error]stderr maxBuffer length exceeded`.

Unlike locally, where only the latest migrations are run, in CI all migrations are run all the time and our 2.5k SQL script (😳 😁 ) was obviously the straw that broke the camel's back.

We realised that so much was outputting because all our migration scripts have the `--verbose` flag set. When we removed it in this case, the problem was solved.

We don't need to see it, and it might avoid the same problem from happening to other repos. So, this issue is about going through the repos and removing `--verbose` from any migrate commands.