### PR TITLE
Fix Migration issue

### DIFF
--- a/migrations/sqls/20201120135927-create-charge-versions-metadata-table-up.sql
+++ b/migrations/sqls/20201120135927-create-charge-versions-metadata-table-up.sql
@@ -1,6 +1,6 @@
 CREATE TYPE charge_version_metadata_status AS ENUM('current', 'superseded');
 
-CREATE TABLE water_import.charge_versions_metadata
+CREATE TABLE IF NOT EXISTS water_import.charge_versions_metadata
 (
 	external_id varchar not null,
 	version_number integer not null,


### PR DESCRIPTION
When running the migrations in our Docker test environment I noticed we were getting the following error: `[ERROR] AssertionError [ERR_ASSERTION]: ifError got unwanted exception: relation "charge_versions_metadata" already exists`.

I've identified that this issue is being caused by the migration script trying to create the table even if it already exists. Altering the migration to only create the table if it doesn't already exist will resolve the issue.