### PR TITLE
Alter fix for charge versions import

### DIFF
--- a/src/modules/charging-import/jobs/charge-versions.js
+++ b/src/modules/charging-import/jobs/charge-versions.js
@@ -1,7 +1,20 @@
 'use strict'
 
 /**
- * @note: this can be removed following go live and migration to service
+ * Creates new PRESROC `water.charge_versions` records or updates existing ones based on `import.NALD_CHG_VERSIONS`
+ * @module ChargeVersionsJob
+ *
+ * The job was written as a one-off to create the charge version records WRLS billing needed when it first went live.
+ * It was written at a time there was only the PRESROC scheme.
+ *
+ * Now we have SROC and this process (creating the `water_import.charge_versions_metadata` source data and then
+ * updating `water.charge_versions` using it) has no knowledge of it. Nor does NALD for that matter. A completely
+ * different one-off mechanism (the charge version upload in water-abstraction-service) was built to handle creating
+ * the SROC charge versions needed to support SROC billing.
+ *
+ * When devs and testers build or rebuild a local environment you still need to manually trigger this redundant import
+ * job to create your base PRESROC charge versions. But it only deals with PRESROC. Any licences with a start date
+ * after 2022-04-01 will need you to manually create their charge versions.
  */
 
 const job = require('../lib/job')

--- a/src/modules/charging-import/lib/queries/charging.js
+++ b/src/modules/charging-import/lib/queries/charging.js
@@ -108,14 +108,14 @@ WHERE charge_element_id IN (
     and bv.billing_volume_id is null
 );`
 
+// This query is part of the one-off charge versions import job which was used to create the initial PRESROC charge
+// versions as part of billing going live in WRLS. It only has knowledge of PRESROC hence `alcs` is hardcoded as the
+// scheme. For more context check out the notes in src/modules/charging-import/jobs/charge-versions.js.
 const importChargeVersions = `INSERT INTO water.charge_versions (licence_ref, scheme, external_id, version_number, start_date, status, apportionment,
 error, end_date, billed_upto_date, region_code, date_created, date_updated, source, invoice_account_id, company_id, licence_id, change_reason_id)
 SELECT
   l."LIC_NO" AS licence_ref,
-CASE
-  WHEN cvm.start_date >= '2022-04-01'::date THEN 'sroc'
-  ELSE 'alcs'
-END AS scheme,
+  'alcs' AS scheme,
   cvm.external_id as external_id,
   cvm.version_number,
   cvm.start_date AS start_date,

--- a/src/modules/charging-import/lib/queries/charging.js
+++ b/src/modules/charging-import/lib/queries/charging.js
@@ -152,6 +152,7 @@ LEFT JOIN (
 JOIN import."NALD_ABS_LICENCES" l ON split_part(cvm.external_id, ':', 1)=l."FGAC_REGION_CODE" and split_part(cvm.external_id, ':', 2)=l."ID"
 JOIN water.licences wl on wl.licence_ref = l."LIC_NO"
 JOIN water.change_reasons cr on cr.description='NALD gap'
+WHERE cvm.start_date < '2022-04-01'::date
 ON CONFLICT (external_id) DO UPDATE SET licence_ref=EXCLUDED.licence_ref,
 scheme=EXCLUDED.scheme,
 version_number=EXCLUDED.version_number, start_date=EXCLUDED.start_date,

--- a/src/modules/nald-import/lib/nald-queries/charge-versions.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions.js
@@ -33,7 +33,7 @@ JOIN water.licences wl ON l."LIC_NO"=wl.licence_ref
 WHERE v."FGAC_REGION_CODE"=$1
 and v."AABL_ID"=$2
 and v."STATUS"<>'DRAFT'
-and to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') < '2022-04-01'
+and to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') < '2022-04-01'::date
 ORDER BY
   to_date(v."EFF_ST_DATE", 'DD/MM/YYYY'),
   v."VERS_NO"::integer;

--- a/src/modules/nald-import/lib/nald-queries/charge-versions.js
+++ b/src/modules/nald-import/lib/nald-queries/charge-versions.js
@@ -1,12 +1,13 @@
 'use strict'
 
+// This query is used to populate the `water_import.charge_versions_metadata` table. The
+// src/modules/charging-import/jobs/charge-versions.js job then creates or updates charge versions based on it.
+//
+// Check out the module for more notes about the context for this query.
 const getNonDraftChargeVersionsForLicence = `SELECT
   l."LIC_NO" AS licence_ref,
   wl.licence_id,
-(CASE
-  WHEN to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') >= '2022-04-01'::date THEN 'sroc'
-  ELSE 'alcs'
-END) AS scheme,
+  ('alcs') AS scheme,
   concat_ws(':', v."FGAC_REGION_CODE", v."AABL_ID", v."VERS_NO") as external_id,
   v."VERS_NO"::integer AS version_number,
   to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') AS start_date,
@@ -29,7 +30,10 @@ JOIN crm_v2.invoice_accounts ia ON ia.invoice_account_number=v."AIIA_IAS_CUST_RE
 JOIN import."NALD_LH_ACCS" lha ON v."AIIA_ALHA_ACC_NO"=lha."ACC_NO" AND v."FGAC_REGION_CODE"=lha."FGAC_REGION_CODE"
 JOIN crm_v2.companies c ON c.external_id=concat_ws(':', lha."FGAC_REGION_CODE", lha."ACON_APAR_ID")
 JOIN water.licences wl ON l."LIC_NO"=wl.licence_ref
-WHERE v."FGAC_REGION_CODE"=$1 and v."AABL_ID"=$2 and v."STATUS"<>'DRAFT'
+WHERE v."FGAC_REGION_CODE"=$1
+and v."AABL_ID"=$2
+and v."STATUS"<>'DRAFT'
+and to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') < '2022-04-01'
 ORDER BY
   to_date(v."EFF_ST_DATE", 'DD/MM/YYYY'),
   v."VERS_NO"::integer;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4024

We implemented [Fix charging-import charge versions job](https://github.com/DEFRA/water-abstraction-import/pull/658) because we had spotted that an existing import job (charge versions) did not have knowledge of SROC so was hard coding everything as `alcs`.

Having merged all pleased with ourselves, we then spotted the charge version import is followed by a charge element import. The same problem exists there, the data it is setting up and the child records it is creating are all for the PRESROC scheme. It would need a complete rewrite to cater for the SROC scheme! 😱😩

So, a better fix would be to alter the charge version import to _only_ do it for PRESROC licences. Anything with a start date of 2022-04-01 or greater will be ignored and folks setting up a new environment will just have to create SROC charge versions manually (until we have a proper dev/test data seeding solution).