### PR TITLE
Update log and errbit notifiers

### DIFF
--- a/src/lib/notifiers/global-notifier.lib.js
+++ b/src/lib/notifiers/global-notifier.lib.js
@@ -23,20 +23,6 @@ class GlobalNotifierLib extends BaseNotifierLib {
 
     super(logger, notifier)
   }
-
-  _formatLogPacket (message, data) {
-    return {
-      message,
-      ...data
-    }
-  }
-
-  _formatNotifyPacket (message, data) {
-    return {
-      message,
-      session: data
-    }
-  }
 }
 
 module.exports = GlobalNotifierLib

--- a/test/lib/notifiers/global-notifier.lib.test.js
+++ b/test/lib/notifiers/global-notifier.lib.test.js
@@ -43,38 +43,4 @@ experiment('GlobalNotifierLib class', () => {
       })
     })
   })
-
-  experiment('when a log entry is made', () => {
-    const id = '1234567890'
-    const message = 'say what test'
-
-    test('formats it as expected', () => {
-      const expectedArgs = {
-        message,
-        id
-      }
-      const testNotifier = new GlobalNotifierLib(pinoFake, airbrakeFake)
-      testNotifier.omg(message, { id })
-
-      expect(pinoFake.info.calledOnceWith(expectedArgs)).to.be.true()
-    })
-  })
-
-  experiment('when an airbrake notification is sent', () => {
-    const message = 'hell no test'
-    const data = { offTheChart: true }
-
-    test('formats it as expected', () => {
-      const expectedArgs = {
-        message,
-        session: {
-          ...data
-        }
-      }
-      const testNotifier = new GlobalNotifierLib(pinoFake, airbrakeFake)
-      testNotifier.omfg(message, data)
-
-      expect(airbrakeFake.notify.calledOnceWith(expectedArgs)).to.be.true()
-    })
-  })
 })


### PR DESCRIPTION
When working on [Move ChargeVersionsMetadataImport out of NALD](https://github.com/DEFRA/water-abstraction-import/pull/661) we encountered an error. That was expected; we were mid-implementation. What we didn't expect was

- the lack of detail in the log
- that attempting to view the error in Errbit caused an error

Suffice it to say, we realised our notifier implementation was wrong. We were passing things incorrectly to both [pino](https://github.com/pinojs/pino) and [errbit](https://github.com/errbit/errbit). [Better handle errors in Notifiers](https://github.com/DEFRA/water-abstraction-system/pull/273) goes into more detail about the issue and what we did to resolve it.

That is our main repo and the place we copied the current implementation of `GlobalNotifier` and `BaseNotifier`. So, we did the original fixes there. This change updates the copies of those notifiers in this repo to include the fixes.