### PR TITLE
Better ETag config and override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,14 +41,6 @@ WATER_SERVICE_MAILBOX=
 # run in production that we often need to re-run in local and non-production environments
 IMPORT_LICENCE_AGREEMENTS=false
 
-# For development only! See https://eaflood.atlassian.net/browse/WATER-2923
-# https://github.com/DEFRA/water-abstraction-import/pull/232 added a new check of the etag of the NALD zip file to be
-# downloaded and imported. Along with that a flag to override the check was added (force the import to go ahead even
-# if the etag on the file is not different).
-# When implemented it was basic; always disable the check if NODE_ENV is test else enable the check. As part of
-# https://github.com/DEFRA/water-abstraction-team/issues/43 we added a new env var to control the check directly.
-ENABLE_NALD_ETAG_CHECK=false
-
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug
 

--- a/config.js
+++ b/config.js
@@ -81,7 +81,6 @@ module.exports = {
 
   import: {
     nald: {
-      isEtagCheckEnabled: (process.env.ENABLE_NALD_ETAG_CHECK === 'true') || true,
       zipPassword: process.env.NALD_ZIP_PASSWORD,
       path: process.env.S3_NALD_IMPORT_PATH || 'wal_nald_data_release',
       overwriteReturns: false, // Set to false as this is highly disruptive

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -111,7 +111,7 @@ const postImportLicence = async (request, h) => {
  * is always present in the queue. So, our manual trigger wouldn't work without first removing what's already there.
  */
 const postImportLicences = async (request, h) => {
-  const message = s3DownloadJob.createMessage()
+  const message = s3DownloadJob.createMessage(false)
 
   try {
     await request.server.messageQueue.deleteQueue(s3DownloadJob.jobName)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4024
https://eaflood.atlassian.net/browse/WATER-4039

We made changes to the import service to [Replace the legacy logging](https://github.com/DEFRA/water-abstraction-import/pull/654) and [Move ChargeVersionsMetadataImport out of NALD](https://github.com/DEFRA/water-abstraction-import/pull/661).

There were a few other tweaks along the way. One of them though appears to have stopped the NALD import process from completing.

So, we want to trigger the NALD import process to see what is going on. We can do that by hitting `http://localhost:8007/import/1.0/nald/licences` but there is a problem. It keeps looking at the [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) of the zip file in the AWS S3 bucket and comparing it to the ETag we record on the last completed run. If they are the same it quits the process.

Ok, again there appears to be a mechanism for overriding this. Set the env var `ENABLE_NALD_ETAG_CHECK` to false and it should ignore doing the check. Or it would if the code was correct.

The problem is we have this logic in the `config.js` file.

```javascript
import: {
    nald: {
      isEtagCheckEnabled: (process.env.ENABLE_NALD_ETAG_CHECK === 'true') || true
      // ...
    }
}
```

It is always returning `true` irrespective of what the env var holds. So, we cannot override it. Here is a demo of what is happening, plus what to do to fix it

```javascript
console.log('false' === 'true' || true) // true
console.log('true' === 'true' || true) // true
console.log('foo' === 'true' || true) // true

console.log('false' === 'true' && true) // false
console.log('true' === 'true' && true) // true
console.log('foo' === 'true' && true) // false
```

But we're not going to do that. This is the first time we have messed with the env var and we're only doing it to investigate an issue. We're then immediately hitting the `http://localhost:8007/import/1.0/nald/licences` endpoint to try and trigger it.

When the job runs according to its schedule it makes perfect sense to compare the ETags to see if there is any point in running. But when we are hitting the endpoint it's only because we _want_ the blasted thing to run now!

So, this change removes the config value. Instead, when the plugin publishes the job we'll tell it to compare the ETags. When we hit our endpoint, the job it publishes will disable the ETag check.

No more messing with env vars or broken override config!