### PR TITLE
Add logging to NALD import licence jobs

### DIFF
--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -10,11 +10,30 @@ const options = {
   teamConcurrency: 1
 }
 
-const createMessage = (licenceNumber) => ({
+/**
+ * Data needed by the import licence handler to process the job
+ *
+ * This is a convention with PGBoss. A number of the jobs/handlers implement a `createMessage()` function which returns
+ * a data object that will be used to queue the job. When it then gets processed the data object is passed to the
+ * handler.
+ *
+ * It may also contain non-default config to be used by PGBoss when adding the job, for example, the use of
+ * `singletonKey` in this job.
+ *
+ * @param {Object} data information needed for the handler to complete the job
+ * @param {Object.string} data.licenceNumber reference of the licence to import
+ * @param {Object.number} data.jobNumber index position of all licence numbers when this job was added to the queue
+ * @param {Object.number} data.numberOfLicences total number of licences to be imported
+ *
+ * @returns {Object} the message object used by the handler to process the job
+ */
+const createMessage = (data) => ({
   name: JOB_NAME,
-  data: { licenceNumber },
+  data,
   options: {
-    singletonKey: licenceNumber
+    // Using the licence number as the singleton ensures PGBoss only adds one import licence job for this licence to the
+    // queue. If anything else tries to add a job with the same licence number PGBoss will ignore it
+    singletonKey: data.licenceNumber
   }
 })
 
@@ -25,12 +44,31 @@ const createMessage = (licenceNumber) => ({
  */
 const handler = async (job) => {
   try {
+    // Most 'jobs' are single operation things in the NALD import process, for example, deal with the NALD zip file or
+    // delete any removed documents. However, there are typically 71K instances of this job queued up as part of the
+    // process! Previously, we logged every instance hence this was a primary offender in adding noise to the logs. We
+    // removed that logging but that leaves us with no way of confirming the job is running. So, instead we get
+    // src/modules/nald-import/jobs/populate-pending-import-complete.js to include details on how many licences there
+    // are to import and when each one was added to the queue. We then use this information to log when the first is
+    // picked up and the last.
+    //
+    // N.B. It's not entirely accurate. If you log all you might see the start message appear after a few jobs and
+    // likewise the finished message a few before the end. But it's good enough to give an indication that the 'jobs'
+    // did start and finish.
+    if (job.data.jobNumber === 1) {
+      global.GlobalNotifier.omg('nald-import.import-licence: started', { numberOfLicences: job.data.numberOfLicences })
+    }
+
     await assertImportTablesExist.assertImportTablesExist()
 
     // Import the licence
     await licenceLoader.load(job.data.licenceNumber)
+
+    if (job.data.jobNumber === job.data.numberOfLicences) {
+      global.GlobalNotifier.omg('nald-import.import-licence: finished', { numberOfLicences: job.data.numberOfLicences })
+    }
   } catch (error) {
-    global.GlobalNotifier.omfg('nald-import.import-licence: errored', error)
+    global.GlobalNotifier.omfg('nald-import.import-licence: errored', job.data, error)
     throw error
   }
 }

--- a/src/modules/nald-import/jobs/populate-pending-import-complete.js
+++ b/src/modules/nald-import/jobs/populate-pending-import-complete.js
@@ -5,9 +5,17 @@ const importLicenceJob = require('./import-licence')
 async function handler (messageQueue, job) {
   if (!job.failed) {
     const { licenceNumbers } = job.data.response
+    const numberOfLicences = licenceNumbers.length
 
-    for (const licenceNumber of licenceNumbers) {
-      await messageQueue.publish(importLicenceJob.createMessage(licenceNumber))
+    for (const [index, licenceNumber] of licenceNumbers.entries()) {
+      // This information is to help us log when the import licence jobs start and finish. See
+      // src/modules/nald-import/jobs/import-licence.js for more details
+      const data = {
+        licenceNumber,
+        jobNumber: index + 1,
+        numberOfLicences
+      }
+      await messageQueue.publish(importLicenceJob.createMessage(data))
     }
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4024
https://eaflood.atlassian.net/browse/WATER-4039

As part of our efforts to [clean up the logs](https://github.com/DEFRA/water-abstraction-import/pull/654) for the import service we removed the logging that was happening in `src/modules/nald-import/jobs/import-licence.js`.

One job gets added for every licence to import which is normally 71K! Since then we've been looking at the output to confirm we can see what is going on.

We found there was a big unknown when it came to the NALD import licence job. With the logging removed, there was no way to confirm the jobs were running. We didn't want to put the logging back in. But also, we were limited with what we could do. Later versions of PGBoss allow you to query the queue and jobs remaining but our version is too old and out of scope for being updated.

So, the solution we have come up with is to add data on how many invoices there are to import, along with the index position of each one to the job's data. We can then use this information to decide whether to output a start and finish log message that confirms to us this process is happening.

For reference, the import can take _up to 3 hours!_ So, when you are checking the logs be patient waiting for the 'finished' entry 😬