### PR TITLE
Remove assert tables exist in NALD import job

### DIFF
--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assertImportTablesExist = require('../lib/assert-import-tables-exist')
 const licenceLoader = require('../load')
 
 const JOB_NAME = 'nald-import.import-licence'
@@ -58,8 +57,6 @@ const handler = async (job) => {
     if (job.data.jobNumber === 1) {
       global.GlobalNotifier.omg('nald-import.import-licence: started', { numberOfLicences: job.data.numberOfLicences })
     }
-
-    await assertImportTablesExist.assertImportTablesExist()
 
     // Import the licence
     await licenceLoader.load(job.data.licenceNumber)

--- a/test/modules/nald-import/jobs/import-licence.test.js
+++ b/test/modules/nald-import/jobs/import-licence.test.js
@@ -10,7 +10,6 @@ const { expect } = Code
 
 // Things we need to stub
 const licenceLoader = require('../../../../src/modules/nald-import/load')
-const assertImportTablesExist = require('../../../../src/modules/nald-import/lib/assert-import-tables-exist')
 
 // Thing under test
 const importLicence = require('../../../../src/modules/nald-import/jobs/import-licence')
@@ -20,7 +19,6 @@ experiment('modules/nald-import/jobs/import-licence', () => {
 
   beforeEach(async () => {
     Sinon.stub(licenceLoader, 'load')
-    Sinon.stub(assertImportTablesExist, 'assertImportTablesExist')
 
     // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
     // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
@@ -79,12 +77,6 @@ experiment('modules/nald-import/jobs/import-licence', () => {
           expect(notifierStub.omg.called).to.be.true()
         })
 
-        test('asserts that the import tables exist', async () => {
-          await importLicence.handler(job)
-
-          expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true()
-        })
-
         test('loads the requested licence', async () => {
           await importLicence.handler(job)
 
@@ -103,12 +95,6 @@ experiment('modules/nald-import/jobs/import-licence', () => {
           await importLicence.handler(job)
 
           expect(notifierStub.omg.called).to.be.false()
-        })
-
-        test('asserts that the import tables exist', async () => {
-          await importLicence.handler(job)
-
-          expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true()
         })
 
         test('loads the requested licence', async () => {
@@ -134,12 +120,6 @@ experiment('modules/nald-import/jobs/import-licence', () => {
           expect(notifierStub.omg.called).to.be.true()
         })
 
-        test('asserts that the import tables exist', async () => {
-          await importLicence.handler(job)
-
-          expect(assertImportTablesExist.assertImportTablesExist.called).to.be.true()
-        })
-
         test('loads the requested licence', async () => {
           await importLicence.handler(job)
 
@@ -157,7 +137,8 @@ experiment('modules/nald-import/jobs/import-licence', () => {
       }
 
       beforeEach(async () => {
-        assertImportTablesExist.assertImportTablesExist.throws(err)
+        licenceLoader.load.throws(err)
+        // assertImportTablesExist.assertImportTablesExist.throws(err)
       })
 
       test('logs an error message', async () => {

--- a/test/modules/nald-import/jobs/import-licence.test.js
+++ b/test/modules/nald-import/jobs/import-licence.test.js
@@ -138,7 +138,6 @@ experiment('modules/nald-import/jobs/import-licence', () => {
 
       beforeEach(async () => {
         licenceLoader.load.throws(err)
-        // assertImportTablesExist.assertImportTablesExist.throws(err)
       })
 
       test('logs an error message', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4024
https://eaflood.atlassian.net/browse/WATER-4039

When looking at the [logging in](https://github.com/DEFRA/water-abstraction-import/pull/677) `src/modules/nald-import/jobs/import-licence.js` we spotted that it runs a check to confirm the import tables exist.

The issue is this job isn't a one-off. We create a job for every licence to be imported which is normally 71K of them! That means we're doing the same check 71 thousand times. The current process takes approximately 3 to 4 hours to complete. So, every saving we can make will help.

It doesn't help that the `src/modules/nald-import/jobs/populate-pending-import.js` which is responsible for determining which licences will be imported already does the check 🤦.

So, we're dropping it from `src/modules/nald-import/jobs/import-licence.js` to see if we can speed things up a little bit.