### PR TITLE
Tidy up inconsistences in Licence & NALD imports

### DIFF
--- a/src/modules/licence-import/controller.js
+++ b/src/modules/licence-import/controller.js
@@ -1,16 +1,16 @@
 'use strict'
 
-const DeleteDocumentsJob = require('./jobs/delete-documents.js')
+const DeleteRemovedDocumentsJob = require('./jobs/delete-removed-documents.js')
 const ImportCompanyJob = require('./jobs/import-company.js')
 const ImportLicenceJob = require('./jobs/import-licence.js')
 
 const Boom = require('@hapi/boom')
 
 const postImport = async (request, h) => {
-  const message = DeleteDocumentsJob.createMessage()
+  const message = DeleteRemovedDocumentsJob.createMessage()
 
   try {
-    await request.server.messageQueue.deleteQueue(DeleteDocumentsJob.name)
+    await request.server.messageQueue.deleteQueue(DeleteRemovedDocumentsJob.name)
     await request.server.messageQueue.publish(message)
 
     return h.response().code(202)

--- a/src/modules/licence-import/jobs/delete-removed-documents.js
+++ b/src/modules/licence-import/jobs/delete-removed-documents.js
@@ -3,7 +3,7 @@
 const documentsConnector = require('../connectors/documents')
 const ImportPurposeConditionTypesJob = require('./import-purpose-condition-types.js')
 
-const JOB_NAME = 'import.delete-documents'
+const JOB_NAME = 'licence-import.delete-removed-documents'
 
 function createMessage () {
   return {
@@ -17,11 +17,11 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('import.delete-documents: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     return documentsConnector.deleteRemovedDocuments()
   } catch (error) {
-    global.GlobalNotifier.omfg('import.delete-documents: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -31,7 +31,7 @@ async function onComplete (messageQueue, job) {
     await messageQueue.publish(ImportPurposeConditionTypesJob.createMessage())
   }
 
-  global.GlobalNotifier.omg('import.delete-documents: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/licence-import/jobs/import-company.js
+++ b/src/modules/licence-import/jobs/import-company.js
@@ -2,11 +2,11 @@
 
 const extract = require('../extract')
 const importCompanies = require('../connectors/import-companies')
-const ImportLicencesJob = require('./import-licences.js')
+const QueueLicencesJob = require('./queue-licences.js')
 const load = require('../load')
 const transform = require('../transform')
 
-const JOB_NAME = 'import.company'
+const JOB_NAME = 'licence-import.import-company'
 
 const options = {
   teamSize: 75,
@@ -50,7 +50,7 @@ async function handler (job) {
 
     await importCompanies.setImportedStatus(regionCode, partyId)
   } catch (error) {
-    global.GlobalNotifier.omfg('import.company: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -59,10 +59,10 @@ async function onComplete (messageQueue) {
   const count = await importCompanies.getPendingCount()
 
   if (count === 0) {
-    await messageQueue.deleteQueue('__state__completed__import.company')
-    await messageQueue.publish(ImportLicencesJob.createMessage())
+    await messageQueue.deleteQueue('__state__completed__licence-import.import-company')
+    await messageQueue.publish(QueueLicencesJob.createMessage())
 
-    global.GlobalNotifier.omg('import.company: finished')
+    global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
   }
 }
 

--- a/src/modules/licence-import/jobs/import-licence.js
+++ b/src/modules/licence-import/jobs/import-licence.js
@@ -4,7 +4,7 @@ const extract = require('../extract')
 const load = require('../load')
 const transform = require('../transform')
 
-const JOB_NAME = 'import.licence'
+const JOB_NAME = 'licence-import.import-licence'
 
 const options = {
   teamSize: 75,
@@ -34,7 +34,7 @@ async function handler (job) {
     // Load licence to DB
     await load.licence.loadLicence(mapped)
   } catch (error) {
-    global.GlobalNotifier.omfg('import.licence: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }

--- a/src/modules/licence-import/jobs/import-purpose-condition-types.js
+++ b/src/modules/licence-import/jobs/import-purpose-condition-types.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const ImportCompaniesJob = require('./import-companies.js')
+const QueueCompaniesJob = require('./queue-companies.js')
 const purposeConditionsConnector = require('../connectors/purpose-conditions-types')
 
-const JOB_NAME = 'import.purpose-condition-types'
+const JOB_NAME = 'licence-import.import-purpose-condition-types'
 
 function createMessage () {
   return {
@@ -17,21 +17,21 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('import.purpose-condition-types: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     return purposeConditionsConnector.createPurposeConditionTypes()
   } catch (error) {
-    global.GlobalNotifier.omfg('import.purpose-condition-types: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
-    await messageQueue.publish(ImportCompaniesJob.createMessage())
+    await messageQueue.publish(QueueCompaniesJob.createMessage())
   }
 
-  global.GlobalNotifier.omg('import.purpose-condition-types: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/licence-import/jobs/queue-companies.js
+++ b/src/modules/licence-import/jobs/queue-companies.js
@@ -3,7 +3,7 @@
 const importCompanies = require('../connectors/import-companies')
 const ImportCompanyJob = require('./import-company.js')
 
-const JOB_NAME = 'import.companies'
+const JOB_NAME = 'licence-import.queue-companies'
 
 function createMessage () {
   return {
@@ -17,7 +17,7 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('import.companies: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     await importCompanies.clear()
     const data = await importCompanies.initialise()
@@ -29,7 +29,7 @@ async function handler () {
       }
     })
   } catch (error) {
-    global.GlobalNotifier.omfg('import.companies: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -43,7 +43,7 @@ async function onComplete (messageQueue, job) {
     }
   }
 
-  global.GlobalNotifier.omg('import.companies: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/licence-import/jobs/queue-licences.js
+++ b/src/modules/licence-import/jobs/queue-licences.js
@@ -3,7 +3,7 @@
 const extract = require('../extract')
 const ImportLicenceJob = require('./import-licence.js')
 
-const JOB_NAME = 'import.licences'
+const JOB_NAME = 'licence-import.queue-licences'
 
 function createMessage () {
   return {
@@ -17,13 +17,13 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('import.licences: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     const rows = await extract.getAllLicenceNumbers()
 
     return rows
   } catch (error) {
-    global.GlobalNotifier.omfg('import.licences: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -37,7 +37,7 @@ async function onComplete (messageQueue, job) {
     }
   }
 
-  global.GlobalNotifier.omg('import.licences: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/licence-import/plugin.js
+++ b/src/modules/licence-import/plugin.js
@@ -2,20 +2,20 @@
 
 const cron = require('node-cron')
 
-const DeleteDocumentsJob = require('./jobs/delete-documents.js')
-const ImportCompaniesJob = require('./jobs/import-companies.js')
+const DeleteRemovedDocumentsJob = require('./jobs/delete-removed-documents.js')
 const ImportCompanyJob = require('./jobs/import-company.js')
-const ImportLicencesJob = require('./jobs/import-licences.js')
 const ImportLicenceJob = require('./jobs/import-licence.js')
 const ImportPurposeConditionTypesJob = require('./jobs/import-purpose-condition-types.js')
+const QueueCompaniesJob = require('./jobs/queue-companies.js')
+const QueueLicencesJob = require('./jobs/queue-licences.js')
 
 const config = require('../../../config')
 
 async function register (server, _options) {
   // First step is to remove any documents that no longer exist in NALD
-  await server.messageQueue.subscribe(DeleteDocumentsJob.name, DeleteDocumentsJob.handler)
-  await server.messageQueue.onComplete(DeleteDocumentsJob.name, (executedJob) => {
-    return DeleteDocumentsJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(DeleteRemovedDocumentsJob.name, DeleteRemovedDocumentsJob.handler)
+  await server.messageQueue.onComplete(DeleteRemovedDocumentsJob.name, (executedJob) => {
+    return DeleteRemovedDocumentsJob.onComplete(server.messageQueue, executedJob)
   })
 
   // When the documents have been marked as deleted import a list of all companies into the
@@ -26,9 +26,9 @@ async function register (server, _options) {
   })
 
   // When the water_import.company_import table is ready, jobs are scheduled to import each company
-  await server.messageQueue.subscribe(ImportCompaniesJob.name, ImportCompaniesJob.handler)
-  await server.messageQueue.onComplete(ImportCompaniesJob.name, (executedJob) => {
-    return ImportCompaniesJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(QueueCompaniesJob.name, QueueCompaniesJob.handler)
+  await server.messageQueue.onComplete(QueueCompaniesJob.name, (executedJob) => {
+    return QueueCompaniesJob.onComplete(server.messageQueue, executedJob)
   })
 
   await server.messageQueue.subscribe(ImportCompanyJob.name, ImportCompanyJob.options, ImportCompanyJob.handler)
@@ -36,15 +36,15 @@ async function register (server, _options) {
     return ImportCompanyJob.onComplete(server.messageQueue)
   })
 
-  await server.messageQueue.subscribe(ImportLicencesJob.name, ImportLicencesJob.handler)
-  await server.messageQueue.onComplete(ImportLicencesJob.name, (executedJob) => {
-    return ImportLicencesJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(QueueLicencesJob.name, QueueLicencesJob.handler)
+  await server.messageQueue.onComplete(QueueLicencesJob.name, (executedJob) => {
+    return QueueLicencesJob.onComplete(server.messageQueue, executedJob)
   })
 
   await server.messageQueue.subscribe(ImportLicenceJob.name, ImportLicenceJob.options, ImportLicenceJob.handler)
 
   cron.schedule(config.import.licences.schedule, async () => {
-    await server.messageQueue.publish(DeleteDocumentsJob.createMessage())
+    await server.messageQueue.publish(DeleteRemovedDocumentsJob.createMessage())
   })
 }
 

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const importService = require('../../../lib/services/import')
-const populatePendingImportJob = require('./populate-pending-import')
+const QueueLicencesJob = require('./queue-licences')
 
 const JOB_NAME = 'nald-import.delete-removed-documents'
 
@@ -17,11 +17,11 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('nald-import.delete-removed-documents: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     return importService.deleteRemovedDocuments()
   } catch (error) {
-    global.GlobalNotifier.omfg('nald-import.delete-removed-documents: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -29,10 +29,10 @@ async function handler () {
 async function onComplete (messageQueue, job) {
   // Publish a new job to populate pending import table but only if delete removed documents was successful
   if (!job.failed) {
-    await messageQueue.publish(populatePendingImportJob.createMessage())
+    await messageQueue.publish(QueueLicencesJob.createMessage())
   }
 
-  global.GlobalNotifier.omg('nald-import.delete-removed-documents: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -58,17 +58,17 @@ async function handler (job) {
     // likewise the finished message a few before the end. But it's good enough to give an indication that the 'jobs'
     // did start and finish.
     if (job.data.jobNumber === 1) {
-      global.GlobalNotifier.omg('nald-import.import-licence: started', { numberOfLicences: job.data.numberOfLicences })
+      global.GlobalNotifier.omg(`${JOB_NAME}: started`, { numberOfLicences: job.data.numberOfLicences })
     }
 
     // Import the licence
     await licenceLoader.load(job.data.licenceNumber)
 
     if (job.data.jobNumber === job.data.numberOfLicences) {
-      global.GlobalNotifier.omg('nald-import.import-licence: finished', { numberOfLicences: job.data.numberOfLicences })
+      global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { numberOfLicences: job.data.numberOfLicences })
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('nald-import.import-licence: errored', job.data, error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, job.data, error)
     throw error
   }
 }

--- a/src/modules/nald-import/jobs/queue-licences.js
+++ b/src/modules/nald-import/jobs/queue-licences.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const assertImportTablesExist = require('../lib/assert-import-tables-exist')
-const importLicenceJob = require('./import-licence')
+const ImportLicenceJob = require('./import-licence')
 const importService = require('../../../lib/services/import')
 
-const JOB_NAME = 'nald-import.populate-pending-import'
+const JOB_NAME = 'nald-import.queue-licences'
 
 function createMessage () {
   return {
@@ -18,14 +18,14 @@ function createMessage () {
 
 async function handler () {
   try {
-    global.GlobalNotifier.omg('nald-import.populate-pending-import: started')
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     await assertImportTablesExist.assertImportTablesExist()
     const licenceNumbers = await importService.getLicenceNumbers()
 
     return { licenceNumbers }
   } catch (error) {
-    global.GlobalNotifier.omfg('nald-import.populate-pending-import: errored', error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
 }
@@ -43,11 +43,11 @@ async function onComplete (messageQueue, job) {
         jobNumber: index + 1,
         numberOfLicences
       }
-      await messageQueue.publish(importLicenceJob.createMessage(data))
+      await messageQueue.publish(ImportLicenceJob.createMessage(data))
     }
   }
 
-  global.GlobalNotifier.omg('nald-import.populate-pending-import: finished')
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 
 module.exports = {

--- a/src/modules/nald-import/plugin.js
+++ b/src/modules/nald-import/plugin.js
@@ -2,52 +2,47 @@
 
 const cron = require('node-cron')
 
-const deleteRemovedDocumentsJob = require('./jobs/delete-removed-documents.js')
-const importLicenceJob = require('./jobs/import-licence.js')
-const populatePendingImportJob = require('./jobs/populate-pending-import.js')
-const s3DownloadJob = require('./jobs/s3-download.js')
+const DeleteRemovedDocumentsJob = require('./jobs/delete-removed-documents.js')
+const ImportLicenceJob = require('./jobs/import-licence.js')
+const QueueLicencesJob = require('./jobs/queue-licences.js')
+const S3DownloadJob = require('./jobs/s3-download.js')
 
 const config = require('../../../config')
 
-const registerSubscribers = async (server) => {
+async function register (server) {
   // These are the steps in the import process. This is creating the 'queues' and where relevant, setting the
   // a handler to be called when a job in that queue completes
 
   // First step is to download the nald_enc.zip from S3, extract it, and push the data into 'import'
-  await server.messageQueue.subscribe(s3DownloadJob.name, s3DownloadJob.handler)
-  await server.messageQueue.onComplete(s3DownloadJob.name, (executedJob) => {
-    return s3DownloadJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(S3DownloadJob.name, S3DownloadJob.handler)
+  await server.messageQueue.onComplete(S3DownloadJob.name, (executedJob) => {
+    return S3DownloadJob.onComplete(server.messageQueue, executedJob)
   })
 
   // Next step is to delete documents that have been removed from NALD
-  await server.messageQueue.subscribe(deleteRemovedDocumentsJob.name, deleteRemovedDocumentsJob.handler)
-  await server.messageQueue.onComplete(deleteRemovedDocumentsJob.name, (executedJob) => {
-    return deleteRemovedDocumentsJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(DeleteRemovedDocumentsJob.name, DeleteRemovedDocumentsJob.handler)
+  await server.messageQueue.onComplete(DeleteRemovedDocumentsJob.name, (executedJob) => {
+    return DeleteRemovedDocumentsJob.onComplete(server.messageQueue, executedJob)
   })
 
   // Then we get the licences to import and publish a job for each one
-  await server.messageQueue.subscribe(populatePendingImportJob.name, populatePendingImportJob.handler)
-  await server.messageQueue.onComplete(populatePendingImportJob.name, (executedJob) => {
-    return populatePendingImportJob.onComplete(server.messageQueue, executedJob)
+  await server.messageQueue.subscribe(QueueLicencesJob.name, QueueLicencesJob.handler)
+  await server.messageQueue.onComplete(QueueLicencesJob.name, (executedJob) => {
+    return QueueLicencesJob.onComplete(server.messageQueue, executedJob)
   })
 
   // Then we import each licence
-  await server.messageQueue.subscribe(importLicenceJob.name, importLicenceJob.options, importLicenceJob.handler)
+  await server.messageQueue.subscribe(ImportLicenceJob.name, ImportLicenceJob.options, ImportLicenceJob.handler)
 
-  // If we're not running the unit tests, setup the schedule for the first job in the chain
-  if (process.env.NODE_ENV !== 'test') {
-    cron.schedule(config.import.nald.schedule, async () => {
-      await server.messageQueue.publish(s3DownloadJob.createMessage())
-    })
-  }
-}
-
-const plugin = {
-  name: 'importNaldData',
-  dependencies: ['pgBoss'],
-  register: registerSubscribers
+  cron.schedule(config.import.nald.schedule, async () => {
+    await server.messageQueue.publish(S3DownloadJob.createMessage())
+  })
 }
 
 module.exports = {
-  plugin
+  plugin: {
+    name: 'importNaldData',
+    dependencies: ['pgBoss'],
+    register
+  }
 }

--- a/test/modules/licence-import/controller.test.js
+++ b/test/modules/licence-import/controller.test.js
@@ -46,7 +46,7 @@ experiment('modules/licence-import/controller.js', () => {
 
         const [jobName] = request.server.messageQueue.deleteQueue.firstCall.args
 
-        expect(jobName).to.equal('import.delete-documents')
+        expect(jobName).to.equal('licence-import.delete-removed-documents')
       })
 
       test('the Delete Documents job is published', async () => {
@@ -55,8 +55,8 @@ experiment('modules/licence-import/controller.js', () => {
         const [message] = request.server.messageQueue.publish.firstCall.args
 
         expect(message).to.equal({
-          name: 'import.delete-documents',
-          options: { singletonKey: 'import.delete-documents', expireIn: '1 hours' }
+          name: 'licence-import.delete-removed-documents',
+          options: { singletonKey: 'licence-import.delete-removed-documents', expireIn: '1 hours' }
         })
       })
 
@@ -93,7 +93,7 @@ experiment('modules/licence-import/controller.js', () => {
 
         const [jobName] = request.server.messageQueue.deleteQueue.firstCall.args
 
-        expect(jobName).to.equal('import.company')
+        expect(jobName).to.equal('licence-import.import-company')
       })
 
       test('the Import Company job is published', async () => {
@@ -102,9 +102,9 @@ experiment('modules/licence-import/controller.js', () => {
         const [message] = request.server.messageQueue.publish.firstCall.args
 
         expect(message).to.equal({
-          name: 'import.company',
+          name: 'licence-import.import-company',
           data: { regionCode: 1, partyId: 37760 },
-          options: { singletonKey: 'import.company.1.37760', expireIn: '1 hours' }
+          options: { singletonKey: 'licence-import.import-company.1.37760', expireIn: '1 hours' }
         })
       })
 
@@ -129,7 +129,7 @@ experiment('modules/licence-import/controller.js', () => {
 
         const [jobName] = request.server.messageQueue.deleteQueue.firstCall.args
 
-        expect(jobName).to.equal('import.licence')
+        expect(jobName).to.equal('licence-import.import-licence')
       })
 
       test('the Import Licence job is published', async () => {
@@ -138,9 +138,9 @@ experiment('modules/licence-import/controller.js', () => {
         const [message] = request.server.messageQueue.publish.firstCall.args
 
         expect(message).to.equal({
-          name: 'import.licence',
+          name: 'licence-import.import-licence',
           data: { licenceNumber: '01/123' },
-          options: { singletonKey: 'import.licence.01/123' }
+          options: { singletonKey: 'licence-import.import-licence.01/123' }
         })
       })
 

--- a/test/modules/licence-import/jobs/delete-removed-documents.test.js
+++ b/test/modules/licence-import/jobs/delete-removed-documents.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const documentsConnector = require('../../../../src/modules/licence-import/connectors/documents.js')
 
 // Thing under test
-const DeleteDocumentsJob = require('../../../../src/modules/licence-import/jobs/delete-documents.js')
+const DeleteRemovedDocumentsJob = require('../../../../src/modules/licence-import/jobs/delete-removed-documents.js')
 
-experiment('modules/licence-import/jobs/delete-removed-documents', () => {
+experiment('Licence Import: Delete Removed Documents', () => {
   let notifierStub
 
   beforeEach(async () => {
@@ -34,12 +34,12 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = DeleteDocumentsJob.createMessage()
+      const message = DeleteRemovedDocumentsJob.createMessage()
 
       expect(message).to.equal({
-        name: 'import.delete-documents',
+        name: 'licence-import.delete-removed-documents',
         options: {
-          singletonKey: 'import.delete-documents',
+          singletonKey: 'licence-import.delete-removed-documents',
           expireIn: '1 hours'
         }
       })
@@ -49,15 +49,15 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
   experiment('.handler', () => {
     experiment('when the job is successful', () => {
       test('a message is logged', async () => {
-        await DeleteDocumentsJob.handler()
+        await DeleteRemovedDocumentsJob.handler()
 
         const [message] = notifierStub.omg.lastCall.args
 
-        expect(message).to.equal('import.delete-documents: started')
+        expect(message).to.equal('licence-import.delete-removed-documents: started')
       })
 
       test('deletes the removed documents', async () => {
-        await DeleteDocumentsJob.handler()
+        await DeleteRemovedDocumentsJob.handler()
 
         expect(documentsConnector.deleteRemovedDocuments.called).to.equal(true)
       })
@@ -71,15 +71,15 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
       })
 
       test('logs an error message', async () => {
-        await expect(DeleteDocumentsJob.handler()).to.reject()
+        await expect(DeleteRemovedDocumentsJob.handler()).to.reject()
 
         expect(notifierStub.omfg.calledWith(
-          'import.delete-documents: errored', err
+          'licence-import.delete-removed-documents: errored', err
         )).to.equal(true)
       })
 
       test('rethrows the error', async () => {
-        const err = await expect(DeleteDocumentsJob.handler()).to.reject()
+        const err = await expect(DeleteRemovedDocumentsJob.handler()).to.reject()
 
         expect(err.message).to.equal('Oops!')
       })
@@ -102,19 +102,19 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
       })
 
       test('a message is logged', async () => {
-        await DeleteDocumentsJob.onComplete(messageQueue, job)
+        await DeleteRemovedDocumentsJob.onComplete(messageQueue, job)
 
         const [message] = notifierStub.omg.lastCall.args
 
-        expect(message).to.equal('import.delete-documents: finished')
+        expect(message).to.equal('licence-import.delete-removed-documents: finished')
       })
 
       test('the import purpose condition types job is published to the queue', async () => {
-        await DeleteDocumentsJob.onComplete(messageQueue, job)
+        await DeleteRemovedDocumentsJob.onComplete(messageQueue, job)
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('import.purpose-condition-types')
+        expect(jobMessage.name).to.equal('licence-import.import-purpose-condition-types')
       })
 
       experiment('but an error is thrown', () => {
@@ -125,7 +125,7 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
         })
 
         test('rethrows the error', async () => {
-          const error = await expect(DeleteDocumentsJob.onComplete(messageQueue, job)).to.reject()
+          const error = await expect(DeleteRemovedDocumentsJob.onComplete(messageQueue, job)).to.reject()
 
           expect(error).to.equal(error)
         })
@@ -138,7 +138,7 @@ experiment('modules/licence-import/jobs/delete-removed-documents', () => {
       })
 
       test('no further jobs are published', async () => {
-        await DeleteDocumentsJob.onComplete(messageQueue, job)
+        await DeleteRemovedDocumentsJob.onComplete(messageQueue, job)
 
         expect(messageQueue.publish.called).to.be.false()
       })

--- a/test/modules/licence-import/jobs/import-company.test.js
+++ b/test/modules/licence-import/jobs/import-company.test.js
@@ -17,7 +17,7 @@ const transform = require('../../../../src/modules/licence-import/transform/inde
 // Thing under test
 const ImportCompanyJob = require('../../../../src/modules/licence-import/jobs/import-company.js')
 
-experiment('modules/licence-import/jobs/import-company', () => {
+experiment('Licence Import: Import Company job', () => {
   const regionCode = 1
   const partyId = 37760
 
@@ -46,13 +46,13 @@ experiment('modules/licence-import/jobs/import-company', () => {
       const message = ImportCompanyJob.createMessage(regionCode, partyId)
 
       expect(message).to.equal({
-        name: 'import.company',
+        name: 'licence-import.import-company',
         data: {
           regionCode: 1,
           partyId: 37760
         },
         options: {
-          singletonKey: 'import.company.1.37760',
+          singletonKey: 'licence-import.import-company.1.37760',
           expireIn: '1 hours'
         }
       })
@@ -99,7 +99,7 @@ experiment('modules/licence-import/jobs/import-company', () => {
         await expect(ImportCompanyJob.handler(job)).to.reject()
 
         expect(notifierStub.omfg.calledWith(
-          'import.company: errored', err
+          'licence-import.import-company: errored', err
         )).to.equal(true)
       })
 
@@ -131,7 +131,7 @@ experiment('modules/licence-import/jobs/import-company', () => {
 
         const [message] = notifierStub.omg.lastCall.args
 
-        expect(message).to.equal('import.company: finished')
+        expect(message).to.equal('licence-import.import-company: finished')
       })
 
       test("the import 'state completed' queue is deleted", async () => {
@@ -139,7 +139,7 @@ experiment('modules/licence-import/jobs/import-company', () => {
 
         const queueName = messageQueue.deleteQueue.lastCall.args[0]
 
-        expect(queueName).to.equal('__state__completed__import.company')
+        expect(queueName).to.equal('__state__completed__licence-import.import-company')
       })
 
       test('the import licences job is published to the queue', async () => {
@@ -147,7 +147,7 @@ experiment('modules/licence-import/jobs/import-company', () => {
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('import.licences')
+        expect(jobMessage.name).to.equal('licence-import.queue-licences')
       })
     })
 

--- a/test/modules/licence-import/jobs/import-licence.test.js
+++ b/test/modules/licence-import/jobs/import-licence.test.js
@@ -16,7 +16,7 @@ const transform = require('../../../../src/modules/licence-import/transform/inde
 // Thing under test
 const ImportLicenceJob = require('../../../../src/modules/licence-import/jobs/import-licence.js')
 
-experiment('modules/licence-import/jobs/import-licence', () => {
+experiment('Licence Import: Import Licence job', () => {
   const licenceNumber = '01/123'
 
   let notifierStub
@@ -43,12 +43,12 @@ experiment('modules/licence-import/jobs/import-licence', () => {
       const message = ImportLicenceJob.createMessage(licenceNumber)
 
       expect(message).to.equal({
-        name: 'import.licence',
+        name: 'licence-import.import-licence',
         data: {
           licenceNumber: '01/123'
         },
         options: {
-          singletonKey: 'import.licence.01/123'
+          singletonKey: 'licence-import.import-licence.01/123'
         }
       })
     })
@@ -88,7 +88,7 @@ experiment('modules/licence-import/jobs/import-licence', () => {
         await expect(ImportLicenceJob.handler(job)).to.reject()
 
         expect(notifierStub.omfg.calledWith(
-          'import.licence: errored', err
+          'licence-import.import-licence: errored', err
         )).to.equal(true)
       })
 

--- a/test/modules/licence-import/jobs/import-purpose-condition-types.test.js
+++ b/test/modules/licence-import/jobs/import-purpose-condition-types.test.js
@@ -14,7 +14,7 @@ const purposeConditionsConnector = require('../../../../src/modules/licence-impo
 // Thing under test
 const ImportPurposeConditionTypesJob = require('../../../../src/modules/licence-import/jobs/import-purpose-condition-types.js')
 
-experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
+experiment('Licence Import: Import Purpose Condition Types job', () => {
   let notifierStub
 
   beforeEach(async () => {
@@ -37,9 +37,9 @@ experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
       const message = ImportPurposeConditionTypesJob.createMessage()
 
       expect(message).to.equal({
-        name: 'import.purpose-condition-types',
+        name: 'licence-import.import-purpose-condition-types',
         options: {
-          singletonKey: 'import.purpose-condition-types',
+          singletonKey: 'licence-import.import-purpose-condition-types',
           expireIn: '1 hours'
         }
       })
@@ -53,7 +53,7 @@ experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
 
         const [message] = notifierStub.omg.lastCall.args
 
-        expect(message).to.equal('import.purpose-condition-types: started')
+        expect(message).to.equal('licence-import.import-purpose-condition-types: started')
       })
 
       test('creates the purpose condition types', async () => {
@@ -74,7 +74,7 @@ experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
         await expect(ImportPurposeConditionTypesJob.handler()).to.reject()
 
         expect(notifierStub.omfg.calledWith(
-          'import.purpose-condition-types: errored', err
+          'licence-import.import-purpose-condition-types: errored', err
         )).to.equal(true)
       })
 
@@ -106,7 +106,7 @@ experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
 
         const [message] = notifierStub.omg.lastCall.args
 
-        expect(message).to.equal('import.purpose-condition-types: finished')
+        expect(message).to.equal('licence-import.import-purpose-condition-types: finished')
       })
 
       test('the import companies job is published to the queue', async () => {
@@ -114,7 +114,7 @@ experiment('modules/licence-import/jobs/import-purpose-condition-types', () => {
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('import.companies')
+        expect(jobMessage.name).to.equal('licence-import.queue-companies')
       })
 
       experiment('but an error is thrown', () => {

--- a/test/modules/licence-import/plugin.test.js
+++ b/test/modules/licence-import/plugin.test.js
@@ -10,12 +10,12 @@ const { expect } = Code
 
 // Test helpers
 const config = require('../../../config.js')
-const DeleteDocumentsJob = require('../../../src/modules/licence-import/jobs/delete-documents.js')
-const ImportCompaniesJob = require('../../../src/modules/licence-import/jobs/import-companies.js')
+const DeleteRemovedDocumentsJob = require('../../../src/modules/licence-import/jobs/delete-removed-documents.js')
 const ImportCompanyJob = require('../../../src/modules/licence-import/jobs/import-company.js')
-const ImportLicencesJob = require('../../../src/modules/licence-import/jobs/import-licences.js')
 const ImportLicenceJob = require('../../../src/modules/licence-import/jobs/import-licence.js')
 const ImportPurposeConditionTypesJob = require('../../../src/modules/licence-import/jobs/import-purpose-condition-types.js')
+const QueueCompaniesJob = require('../../../src/modules/licence-import/jobs/queue-companies.js')
+const QueueLicencesJob = require('../../../src/modules/licence-import/jobs/queue-licences.js')
 
 // Things we need to stub
 const cron = require('node-cron')
@@ -50,14 +50,14 @@ experiment('modules/licence-import/plugin.js', () => {
   })
 
   experiment('register', () => {
-    experiment('for Delete Documents', () => {
+    experiment('for Delete Removed Documents', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
         const subscribeArgs = server.messageQueue.subscribe.getCall(0).args
 
-        expect(subscribeArgs[0]).to.equal(DeleteDocumentsJob.name)
-        expect(subscribeArgs[1]).to.equal(DeleteDocumentsJob.handler)
+        expect(subscribeArgs[0]).to.equal(DeleteRemovedDocumentsJob.name)
+        expect(subscribeArgs[1]).to.equal(DeleteRemovedDocumentsJob.handler)
       })
 
       test('registers its onComplete for the job', async () => {
@@ -65,7 +65,7 @@ experiment('modules/licence-import/plugin.js', () => {
 
         const onCompleteArgs = server.messageQueue.onComplete.getCall(0).args
 
-        expect(onCompleteArgs[0]).to.equal(DeleteDocumentsJob.name)
+        expect(onCompleteArgs[0]).to.equal(DeleteRemovedDocumentsJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
       })
 
@@ -96,14 +96,14 @@ experiment('modules/licence-import/plugin.js', () => {
       })
     })
 
-    experiment('for Import Companies', () => {
+    experiment('for Queue Companies', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
         const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
 
-        expect(subscribeArgs[0]).to.equal(ImportCompaniesJob.name)
-        expect(subscribeArgs[1]).to.equal(ImportCompaniesJob.handler)
+        expect(subscribeArgs[0]).to.equal(QueueCompaniesJob.name)
+        expect(subscribeArgs[1]).to.equal(QueueCompaniesJob.handler)
       })
 
       test('registers its onComplete for the job', async () => {
@@ -111,7 +111,7 @@ experiment('modules/licence-import/plugin.js', () => {
 
         const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
 
-        expect(onCompleteArgs[0]).to.equal(ImportCompaniesJob.name)
+        expect(onCompleteArgs[0]).to.equal(QueueCompaniesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
       })
     })
@@ -137,14 +137,14 @@ experiment('modules/licence-import/plugin.js', () => {
       })
     })
 
-    experiment('for Import Licences', () => {
+    experiment('for Queue Licences', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
         const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
 
-        expect(subscribeArgs[0]).to.equal(ImportLicencesJob.name)
-        expect(subscribeArgs[1]).to.equal(ImportLicencesJob.handler)
+        expect(subscribeArgs[0]).to.equal(QueueLicencesJob.name)
+        expect(subscribeArgs[1]).to.equal(QueueLicencesJob.handler)
       })
 
       test('registers its onComplete for the job', async () => {
@@ -152,7 +152,7 @@ experiment('modules/licence-import/plugin.js', () => {
 
         const onCompleteArgs = server.messageQueue.onComplete.getCall(4).args
 
-        expect(onCompleteArgs[0]).to.equal(ImportLicencesJob.name)
+        expect(onCompleteArgs[0]).to.equal(QueueLicencesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
       })
     })

--- a/test/modules/nald-import/jobs/delete-removed-documents.test.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.test.js
@@ -14,7 +14,7 @@ const importService = require('../../../../src/lib/services/import')
 // Thing under test
 const DeleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents')
 
-experiment('modules/nald-import/jobs/delete-removed-documents', () => {
+experiment('NALD Import: Delete Removed Documents job', () => {
   let notifierStub
 
   beforeEach(async () => {
@@ -71,8 +71,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents', () => {
       })
 
       test('logs an error message', async () => {
-        const func = () => DeleteRemovedDocumentsJob.handler()
-        await expect(func()).to.reject()
+        await expect(DeleteRemovedDocumentsJob.handler()).to.reject()
 
         expect(notifierStub.omfg.calledWith(
           'nald-import.delete-removed-documents: errored', err
@@ -80,8 +79,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents', () => {
       })
 
       test('rethrows the error', async () => {
-        const func = () => DeleteRemovedDocumentsJob.handler()
-        const err = await expect(func()).to.reject()
+        const err = await expect(DeleteRemovedDocumentsJob.handler()).to.reject()
 
         expect(err.message).to.equal('Oops!')
       })
@@ -116,7 +114,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents', () => {
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('nald-import.populate-pending-import')
+        expect(jobMessage.name).to.equal('nald-import.queue-licences')
       })
 
       experiment('but an error is thrown', () => {
@@ -127,8 +125,7 @@ experiment('modules/nald-import/jobs/delete-removed-documents', () => {
         })
 
         test('rethrows the error', async () => {
-          const func = () => DeleteRemovedDocumentsJob.onComplete(messageQueue, job)
-          const error = await expect(func()).to.reject()
+          const error = await expect(DeleteRemovedDocumentsJob.onComplete(messageQueue, job)).to.reject()
 
           expect(error).to.equal(error)
         })

--- a/test/modules/nald-import/jobs/import-licence.test.js
+++ b/test/modules/nald-import/jobs/import-licence.test.js
@@ -12,9 +12,9 @@ const { expect } = Code
 const licenceLoader = require('../../../../src/modules/nald-import/load')
 
 // Thing under test
-const importLicence = require('../../../../src/modules/nald-import/jobs/import-licence')
+const ImportLicenceJob = require('../../../../src/modules/nald-import/jobs/import-licence')
 
-experiment('modules/nald-import/jobs/import-licence', () => {
+experiment('NALD Import: Import Licence job', () => {
   let notifierStub
 
   beforeEach(async () => {
@@ -34,18 +34,18 @@ experiment('modules/nald-import/jobs/import-licence', () => {
 
   experiment('.options', () => {
     test('has teamSize set to 75', async () => {
-      expect(importLicence.options.teamSize).to.equal(75)
+      expect(ImportLicenceJob.options.teamSize).to.equal(75)
     })
 
     test('has teamConcurrency set to 1', async () => {
-      expect(importLicence.options.teamConcurrency).to.equal(1)
+      expect(ImportLicenceJob.options.teamConcurrency).to.equal(1)
     })
   })
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
       const data = { licenceNumber: 'test-licence-number', jobNumber: 1, numberOfLicences: 1 }
-      const job = importLicence.createMessage(data)
+      const job = ImportLicenceJob.createMessage(data)
 
       expect(job).to.equal({
         data: {
@@ -69,16 +69,16 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         })
 
         test("a 'started' message is logged", async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           const [message] = notifierStub.omg.lastCall.args
-          expect(message).to.equal('nald-import.import-licence: started')
 
+          expect(message).to.equal('nald-import.import-licence: started')
           expect(notifierStub.omg.called).to.be.true()
         })
 
         test('loads the requested licence', async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           expect(licenceLoader.load.calledWith('test-licence-number')).to.be.true()
         })
@@ -92,13 +92,13 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         })
 
         test('a message is NOT logged', async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           expect(notifierStub.omg.called).to.be.false()
         })
 
         test('loads the requested licence', async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           expect(licenceLoader.load.calledWith('test-licence-number')).to.be.true()
         })
@@ -112,7 +112,7 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         })
 
         test("a 'finished' message is logged", async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           const [message] = notifierStub.omg.lastCall.args
           expect(message).to.equal('nald-import.import-licence: finished')
@@ -121,7 +121,7 @@ experiment('modules/nald-import/jobs/import-licence', () => {
         })
 
         test('loads the requested licence', async () => {
-          await importLicence.handler(job)
+          await ImportLicenceJob.handler(job)
 
           expect(licenceLoader.load.calledWith('test-licence-number')).to.be.true()
         })
@@ -141,8 +141,8 @@ experiment('modules/nald-import/jobs/import-licence', () => {
       })
 
       test('logs an error message', async () => {
-        const func = () => importLicence.handler(job)
-        await expect(func()).to.reject()
+        await expect(ImportLicenceJob.handler(job)).to.reject()
+
         expect(notifierStub.omfg.calledWith(
           'nald-import.import-licence: errored',
           job.data,
@@ -151,8 +151,7 @@ experiment('modules/nald-import/jobs/import-licence', () => {
       })
 
       test('rethrows the error', async () => {
-        const func = () => importLicence.handler(job)
-        const err = await expect(func()).to.reject()
+        const err = await expect(ImportLicenceJob.handler(job)).to.reject()
         expect(err.message).to.equal('Oops!')
       })
     })

--- a/test/modules/nald-import/jobs/s3-download.test.js
+++ b/test/modules/nald-import/jobs/s3-download.test.js
@@ -16,7 +16,7 @@ const s3Service = require('../../../../src/modules/nald-import/services/s3-servi
 // Thing under test
 const S3DownloadJob = require('../../../../src/modules/nald-import/jobs/s3-download')
 
-experiment('modules/nald-import/jobs/s3-download', () => {
+experiment('NALD Import: S3 Download job', () => {
   let notifierStub
 
   beforeEach(async () => {
@@ -259,16 +259,14 @@ experiment('modules/nald-import/jobs/s3-download', () => {
       })
 
       test('logs an error message', async () => {
-        const func = () => S3DownloadJob.handler(job)
-        await expect(func()).to.reject()
+        await expect(S3DownloadJob.handler(job)).to.reject()
         expect(notifierStub.omfg.calledWith(
           'nald-import.s3-download: errored', err
         )).to.be.true()
       })
 
       test('rethrows the error', async () => {
-        const func = () => S3DownloadJob.handler(job)
-        const err = await expect(func()).to.reject()
+        const err = await expect(S3DownloadJob.handler(job)).to.reject()
         expect(err.message).to.equal('Oops!')
       })
     })
@@ -328,7 +326,7 @@ experiment('modules/nald-import/jobs/s3-download', () => {
           await S3DownloadJob.onComplete(messageQueue, job)
 
           expect(messageQueue.deleteQueue.calledWith('nald-import.import-licence')).to.be.true()
-          expect(messageQueue.deleteQueue.calledWith('nald-import.populate-pending-import')).to.be.true()
+          expect(messageQueue.deleteQueue.calledWith('nald-import.queue-licences')).to.be.true()
           expect(messageQueue.deleteQueue.calledWith('nald-import.delete-removed-documents')).to.be.true()
         })
 


### PR DESCRIPTION
Whilst working on [Consolidate NALD Import jobs](https://github.com/DEFRA/water-abstraction-import/pull/679) and [Consolidate Licence Import jobs](https://github.com/DEFRA/water-abstraction-import/pull/682) we noticed some inconsistencies between them. Also, as we get to understand what they are doing some of the naming didn't make sense.

As the 2 primary imports in the service, we took the time to iron out some of the inconsistencies and try and improve the naming of some of the jobs.