### PR TITLE
Replicate NALD returns when import triggered

### DIFF
--- a/config.js
+++ b/config.js
@@ -83,7 +83,6 @@ module.exports = {
     nald: {
       zipPassword: process.env.NALD_ZIP_PASSWORD,
       path: process.env.S3_NALD_IMPORT_PATH || 'wal_nald_data_release',
-      overwriteReturns: false, // Set to false as this is highly disruptive
       schedule: process.env.WRLS_CRON_NALD || '0 1 * * *'
     },
     licences: {

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -116,7 +116,7 @@ const postImportLicence = async (request, h) => {
  * is always present in the queue. So, our manual trigger wouldn't work without first removing what's already there.
  */
 const postImportLicences = async (request, h) => {
-  const message = s3DownloadJob.createMessage(false)
+  const message = s3DownloadJob.createMessage(false, true)
 
   try {
     await request.server.messageQueue.deleteQueue(s3DownloadJob.name)

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -32,7 +32,7 @@ async function handler () {
 async function onComplete (messageQueue, job) {
   // Publish a new job to populate pending import table but only if delete removed documents was successful
   if (!job.failed) {
-    await messageQueue.publish(QueueLicencesJob.createMessage())
+    await messageQueue.publish(QueueLicencesJob.createMessage(job.data.replicateReturns))
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -32,7 +32,9 @@ async function handler () {
 async function onComplete (messageQueue, job) {
   // Publish a new job to populate pending import table but only if delete removed documents was successful
   if (!job.failed) {
-    await messageQueue.publish(QueueLicencesJob.createMessage(job.data.replicateReturns))
+    const { replicateReturns } = job.data.request.data
+
+    await messageQueue.publish(QueueLicencesJob.createMessage(replicateReturns))
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -5,12 +5,15 @@ const QueueLicencesJob = require('./queue-licences')
 
 const JOB_NAME = 'nald-import.delete-removed-documents'
 
-function createMessage () {
+function createMessage (replicateReturns) {
   return {
     name: JOB_NAME,
     options: {
       expireIn: '1 hours',
       singletonKey: JOB_NAME
+    },
+    data: {
+      replicateReturns
     }
   }
 }

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -55,7 +55,7 @@ async function handler (job) {
     }
 
     // Import the licence
-    await licenceLoader.load(job.data.licenceNumber)
+    await licenceLoader.load(job.data.licenceNumber, job.data.replicateReturns)
 
     if (job.data.jobNumber === job.data.numberOfJobs) {
       global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { numberOfJobs: job.data.numberOfJobs })

--- a/src/modules/nald-import/jobs/queue-licences.js
+++ b/src/modules/nald-import/jobs/queue-licences.js
@@ -44,7 +44,8 @@ async function onComplete (messageQueue, job) {
       const data = {
         licenceNumber,
         jobNumber: index + 1,
-        numberOfJobs
+        numberOfJobs,
+        replicateReturns: job.data.replicateReturns
       }
       await messageQueue.publish(ImportLicenceJob.createMessage(data))
     }

--- a/src/modules/nald-import/jobs/queue-licences.js
+++ b/src/modules/nald-import/jobs/queue-licences.js
@@ -6,12 +6,15 @@ const importService = require('../../../lib/services/import')
 
 const JOB_NAME = 'nald-import.queue-licences'
 
-function createMessage () {
+function createMessage (replicateReturns) {
   return {
     name: JOB_NAME,
     options: {
       expireIn: '1 hours',
       singletonKey: JOB_NAME
+    },
+    data: {
+      replicateReturns
     }
   }
 }

--- a/src/modules/nald-import/jobs/queue-licences.js
+++ b/src/modules/nald-import/jobs/queue-licences.js
@@ -35,6 +35,7 @@ async function handler () {
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
+    const { replicateReturns } = job.data.request.data
     const { licenceNumbers } = job.data.response
     const numberOfJobs = licenceNumbers.length
 
@@ -45,7 +46,7 @@ async function onComplete (messageQueue, job) {
         licenceNumber,
         jobNumber: index + 1,
         numberOfJobs,
-        replicateReturns: job.data.replicateReturns
+        replicateReturns
       }
       await messageQueue.publish(ImportLicenceJob.createMessage(data))
     }

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -45,6 +45,7 @@ async function handler (job) {
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
     const { isRequired } = job.data.response
+    const { replicateReturns } = job.data.request.data
 
     if (isRequired) {
       // Delete existing PG boss import queues
@@ -55,7 +56,7 @@ async function onComplete (messageQueue, job) {
       ])
 
       // Publish a new job to delete any removed documents
-      await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(job.data.replicateReturns))
+      await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(replicateReturns))
     }
   }
 

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -9,7 +9,7 @@ const s3Service = require('../services/s3-service.js')
 
 const JOB_NAME = 'nald-import.s3-download'
 
-function createMessage (checkEtag = true) {
+function createMessage (checkEtag = true, replicateReturns = false) {
   return {
     name: JOB_NAME,
     options: {
@@ -17,7 +17,8 @@ function createMessage (checkEtag = true) {
       singletonKey: JOB_NAME
     },
     data: {
-      checkEtag
+      checkEtag,
+      replicateReturns
     }
   }
 }

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -55,7 +55,7 @@ async function onComplete (messageQueue, job) {
       ])
 
       // Publish a new job to delete any removed documents
-      await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage())
+      await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(job.data.replicateReturns))
     }
   }
 

--- a/src/modules/nald-import/lib/persist-returns.js
+++ b/src/modules/nald-import/lib/persist-returns.js
@@ -45,7 +45,7 @@ const getUpdateRow = (row) => {
  * @param {Object} row
  * @return {Promise} resolves when row is created/updated
  */
-const createOrUpdateReturn = async row => {
+const createOrUpdateReturn = async (row, replicateReturns) => {
   const { return_id: returnId } = row
 
   const exists = await returnExists(returnId)
@@ -58,7 +58,7 @@ const createOrUpdateReturn = async row => {
     const thisReturn = await returns.create(row)
 
     /* For non-production environments, we allow the system to import the returns data so we can test billing */
-    if (!config.isProduction && config.import.nald.overwriteReturns) {
+    if (!config.isProduction && replicateReturns) {
       await replicateReturnsDataFromNaldForNonProductionEnvironments(row)
     }
     return thisReturn
@@ -68,14 +68,15 @@ const createOrUpdateReturn = async row => {
 /**
  * Persists list of returns to API
  * @param {Array} returns
+ * @param {Boolean} replicateReturns
  * @return {Promise} resolves when all processed
  */
-const persistReturns = async (returns) => {
+const persistReturns = async (returns, replicateReturns) => {
   for (const ret of returns) {
-    if (!config.isProduction && config.import.nald.overwriteReturns) {
+    if (!config.isProduction && replicateReturns) {
       await returnsApi.deleteAllReturnsData(ret.return_id)
     }
-    await createOrUpdateReturn(ret)
+    await createOrUpdateReturn(ret, replicateReturns)
   }
 }
 

--- a/src/modules/nald-import/load.js
+++ b/src/modules/nald-import/load.js
@@ -31,12 +31,12 @@ const loadPermitAndDocumentHeader = async (licenceNumber, licenceData) => {
  * Calculates and imports a list of return cycles for the given licence
  * based on NALD formats and form logs
  * @param {String} licenceNumber
- * @param {Object} licenceData - extracted from NALD import tables
+ * @param {Boolean} replicateReturns
  * @return {Promise} resolves when returns imported
  */
-const loadReturns = async (licenceNumber) => {
+const loadReturns = async (licenceNumber, replicateReturns) => {
   const { returns } = await buildReturnsPacket(licenceNumber)
-  await persistReturns(returns)
+  await persistReturns(returns, replicateReturns)
 
   // Clean up invalid cycles
   const returnIds = returns.map(row => row.return_id)
@@ -46,14 +46,15 @@ const loadReturns = async (licenceNumber) => {
 /**
  * Imports the whole licence
  * @param {String} licenceNumber
+ * @param {Boolean} replicateReturns
  * @return {Promise} resolves when complete
  */
-const load = async (licenceNumber) => {
+const load = async (licenceNumber, replicateReturns) => {
   const licenceData = await getLicenceJson(licenceNumber)
 
   if (licenceData.data.versions.length > 0) {
     await loadPermitAndDocumentHeader(licenceNumber, licenceData)
-    await loadReturns(licenceNumber)
+    await loadReturns(licenceNumber, replicateReturns)
   }
 }
 

--- a/test/modules/nald-import/jobs/delete-removed-documents.test.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.test.js
@@ -15,6 +15,8 @@ const importService = require('../../../../src/lib/services/import')
 const DeleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents')
 
 experiment('NALD Import: Delete Removed Documents job', () => {
+  const replicateReturns = false
+
   let notifierStub
 
   beforeEach(async () => {
@@ -34,13 +36,16 @@ experiment('NALD Import: Delete Removed Documents job', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = DeleteRemovedDocumentsJob.createMessage()
+      const message = DeleteRemovedDocumentsJob.createMessage(replicateReturns)
 
       expect(message).to.equal({
         name: 'nald-import.delete-removed-documents',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.delete-removed-documents'
+        },
+        data: {
+          replicateReturns: false
         }
       })
     })
@@ -98,7 +103,10 @@ experiment('NALD Import: Delete Removed Documents job', () => {
 
     experiment('when the job succeeds', () => {
       beforeEach(async () => {
-        job = { failed: false }
+        job = {
+          failed: false,
+          data: { request: { data: { replicateReturns: false } } }
+        }
       })
 
       test('a message is logged', async () => {

--- a/test/modules/nald-import/jobs/queue-licences.test.js
+++ b/test/modules/nald-import/jobs/queue-licences.test.js
@@ -16,6 +16,8 @@ const assertImportTablesExist = require('../../../../src/modules/nald-import/lib
 const QueueLicencesJob = require('../../../../src/modules/nald-import/jobs/queue-licences.js')
 
 experiment('NALD Import: Queue Licences job', () => {
+  const replicateReturns = false
+
   let notifierStub
 
   beforeEach(async () => {
@@ -39,13 +41,16 @@ experiment('NALD Import: Queue Licences job', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = QueueLicencesJob.createMessage()
+      const message = QueueLicencesJob.createMessage(replicateReturns)
 
       expect(message).to.equal({
         name: 'nald-import.queue-licences',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.queue-licences'
+        },
+        data: {
+          replicateReturns: false
         }
       })
     })
@@ -122,6 +127,7 @@ experiment('NALD Import: Queue Licences job', () => {
         job = {
           failed: false,
           data: {
+            request: { data: { replicateReturns: false } },
             response: {
               licenceNumbers: [
                 'licence-1',
@@ -144,7 +150,9 @@ experiment('NALD Import: Queue Licences job', () => {
 
         const jobMessage = messageQueue.publish.firstCall.args[0]
 
-        expect(jobMessage.data).to.equal({ licenceNumber: 'licence-1', jobNumber: 1, numberOfJobs: 2 })
+        expect(jobMessage.data).to.equal({
+          licenceNumber: 'licence-1', jobNumber: 1, numberOfJobs: 2, replicateReturns: false
+        })
       })
 
       test('the import licence job is published to the queue for the second licence', async () => {
@@ -152,7 +160,9 @@ experiment('NALD Import: Queue Licences job', () => {
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.data).to.equal({ licenceNumber: 'licence-2', jobNumber: 2, numberOfJobs: 2 })
+        expect(jobMessage.data).to.equal({
+          licenceNumber: 'licence-2', jobNumber: 2, numberOfJobs: 2, replicateReturns: false
+        })
       })
 
       experiment('but an error is thrown', () => {

--- a/test/modules/nald-import/jobs/s3-download.test.js
+++ b/test/modules/nald-import/jobs/s3-download.test.js
@@ -48,7 +48,8 @@ experiment('NALD Import: S3 Download job', () => {
           singletonKey: 'nald-import.s3-download'
         },
         data: {
-          checkEtag: true
+          checkEtag: true,
+          replicateReturns: false
         }
       })
     })
@@ -308,9 +309,8 @@ experiment('NALD Import: S3 Download job', () => {
           job = {
             failed: false,
             data: {
-              response: {
-                isRequired: true
-              }
+              request: { data: { replicateReturns: false } },
+              response: { isRequired: true }
             }
           }
         })
@@ -359,9 +359,8 @@ experiment('NALD Import: S3 Download job', () => {
           job = {
             failed: false,
             data: {
-              response: {
-                isRequired: false
-              }
+              request: { data: { replicateReturns: false } },
+              response: { isRequired: false }
             }
           }
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4270

We've been working on building a better understanding of the jobs within the import service. We've even documented [details on the background jobs](https://github.com/DEFRA/water-abstraction-team/pull/39).

One of the things we'd like to be able to do is rebuild a DB locally from scratch. This will be especially useful for those new to the team when setting up their environment (and the rest of us when we break it!)

Something we noticed when trialling how to do this was that there was no return submission data. This would be useful to have and should be available in NALD for importing. Well, it turns out it is but it's hidden behind a hard-coded 'config' value (🤦🤡)

When we manually changed the value and ran the job our local DB was suddenly populated with lots of return information which makes testing much easier and the local experience more realistic.

Reviewing the commit history and the existing comment (`// Set to false as this is highly disruptive`) we understand this is not something you want to happen every time the job is run (which is at least once a day). But we can make a fair assumption it is something we do want to happen when we manually trigger the NALD import. Our only reason for doing so is when rebuilding the DB.

This change makes the necessary amendments to allow us to automatically replicate returns data when manually triggering the NALD import.