### PR TITLE
add abstraction quantities to licence purpose

### DIFF
--- a/src/modules/licence-import/load/connectors/index.js
+++ b/src/modules/licence-import/load/connectors/index.js
@@ -108,6 +108,9 @@ const createLicenceVersionPurpose = async (purpose, licenceVersionId) => {
     purpose.timeLimitedStartDate,
     purpose.timeLimitedEndDate,
     purpose.notes,
+    purpose.instantQuantity,
+    purpose.hourlyQuantity,
+    purpose.dailyQuantity,
     purpose.annualQuantity,
     purpose.externalId
   ]

--- a/src/modules/licence-import/transform/mappers/licence-purpose.js
+++ b/src/modules/licence-import/transform/mappers/licence-purpose.js
@@ -17,6 +17,15 @@ const mapLicencePurpose = data => {
     timeLimitedStartDate: dateMapper.mapNaldDate(data.TIMELTD_ST_DATE),
     timeLimitedEndDate: dateMapper.mapNaldDate(data.TIMELTD_END_DATE),
     notes: nald.stringNullToNull(data.NOTES),
+    instantQuantity: nald.stringNullToNull(data.INST_QTY) === null
+      ? null
+      : +data.INST_QTY,
+    hourlyQuantity: nald.stringNullToNull(data.HOURLY_QTY) === null
+      ? null
+      : +data.HOURLY_QTY,
+    dailyQuantity: nald.stringNullToNull(data.DAILY_QTY) === null
+      ? null
+      : +data.DAILY_QTY,
     annualQuantity: nald.stringNullToNull(data.ANNUAL_QTY) === null
       ? null
       : +data.ANNUAL_QTY,

--- a/test/modules/licence-import/load/connectors/index.test.js
+++ b/test/modules/licence-import/load/connectors/index.test.js
@@ -473,6 +473,9 @@ experiment('modules/licence-import/load/connectors', () => {
         timeLimitedStartDate: null,
         timeLimitedEndDate: null,
         notes: 'notes',
+        instantQuantity: 10,
+        hourlyQuantity: 10,
+        dailyQuantity: 100,
         annualQuantity: 1000,
         externalId: '1:111222'
       }
@@ -500,6 +503,9 @@ experiment('modules/licence-import/load/connectors', () => {
         purpose.timeLimitedStartDate,
         purpose.timeLimitedEndDate,
         purpose.notes,
+        purpose.instantQuantity,
+        purpose.hourlyQuantity,
+        purpose.dailyQuantity,
         purpose.annualQuantity,
         purpose.externalId
       ])

--- a/test/modules/licence-import/load/licence.test.js
+++ b/test/modules/licence-import/load/licence.test.js
@@ -33,6 +33,9 @@ const createLicence = (expiryDate = null) => ({
       timeLimitedStartDate: null,
       timeLimitedEndDate: null,
       notes: 'testing',
+      instantQuantity: 1,
+      hourlyQuantity: 10,
+      dailyQuantity: 20,
       annualQuantity: 100,
       conditions: [{
         code: 'AGG',
@@ -62,6 +65,9 @@ const createLicence = (expiryDate = null) => ({
       timeLimitedStartDate: null,
       timeLimitedEndDate: null,
       notes: 'testing',
+      instantQuantity: 1,
+      hourlyQuantity: 10,
+      dailyQuantity: 20,
       annualQuantity: 100,
       conditions: []
     }]
@@ -219,6 +225,9 @@ experiment('modules/licence-import/load/licence', () => {
       expect(purpose.timeLimitedStartDate).to.equal(null)
       expect(purpose.timeLimitedEndDate).to.equal(null)
       expect(purpose.notes).to.equal('testing')
+      expect(purpose.instantQuantity).to.equal(1)
+      expect(purpose.hourlyQuantity).to.equal(10)
+      expect(purpose.dailyQuantity).to.equal(20)
       expect(purpose.annualQuantity).to.equal(100)
     })
 

--- a/test/modules/licence-import/transform/mappers/licence-purpose.test.js
+++ b/test/modules/licence-import/transform/mappers/licence-purpose.test.js
@@ -36,6 +36,9 @@ experiment('modules/licence-import/transform/mappers/licence-purpose', () => {
         PERIOD_ST_MONTH: '10',
         PERIOD_END_DAY: '21',
         PERIOD_END_MONTH: '11',
+        INST_QTY: '1',
+        HOURLY_QTY: '10',
+        DAILY_QTY: '100',
         ANNUAL_QTY: '1000',
         TIMELTD_ST_DATE: 'null',
         TIMELTD_END_DATE: 'null',
@@ -112,11 +115,41 @@ experiment('modules/licence-import/transform/mappers/licence-purpose', () => {
       expect(mapped.notes).to.equal(null)
     })
 
+    test('maps the instant quantity', async () => {
+      expect(mapped.instantQuantity).to.equal(1)
+    })
+
+    test('maps the instant quantity to null when string null', async () => {
+      purpose.INST_QTY = 'null'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.instantQuantity).to.equal(null)
+    })
+
+    test('maps the hourly quantity', async () => {
+      expect(mapped.hourlyQuantity).to.equal(10)
+    })
+
+    test('maps the hourly quantity to null when string null', async () => {
+      purpose.HOURLY_QTY = 'null'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.hourlyQuantity).to.equal(null)
+    })
+
+    test('maps the annual quantity', async () => {
+      expect(mapped.dailyQuantity).to.equal(100)
+    })
+
+    test('maps the annual quantity to null when string null', async () => {
+      purpose.DAILY_QTY = 'null'
+      mapped = mapLicencePurpose(purpose)
+      expect(mapped.dailyQuantity).to.equal(null)
+    })
+
     test('maps the annual quantity', async () => {
       expect(mapped.annualQuantity).to.equal(1000)
     })
 
-    test('maps the notes to null when string null', async () => {
+    test('maps the annual quantity to null when string null', async () => {
       purpose.ANNUAL_QTY = 'null'
       mapped = mapLicencePurpose(purpose)
       expect(mapped.annualQuantity).to.equal(null)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4442

As part of the work to enable return requirements in the service we want to be able to have the different frequencies of abstraction time frames included with the licence purpose version. 

This PR adds the instant, hourly and daily columns to the import job so the information is added during the job.