### PR TITLE
Fix error logging and notifications

### DIFF
--- a/src/lib/notifiers/base-notifier.lib.js
+++ b/src/lib/notifiers/base-notifier.lib.js
@@ -75,12 +75,12 @@ class BaseNotifierLib {
    * ```
    *
    * @param {string} message Message to add to the log (ERROR)
-   * @param {Object} [data={}] An object containing any values to be logged and sent in the notification to Errbit, for
-   *  example, a bill run ID. Defaults to an empty object
    * @param {Error} [error=null] An instance of the error to be logged and sent to Errbit. If no error is provided one
    *  will be created using `message` as the error message
+   * @param {Object} [data={}] An object containing any values to be logged and sent in the notification to Errbit, for
+   *  example, a bill run ID. Defaults to an empty object
    */
-  omfg (message, data = {}, error = null) {
+  omfg (message, error = null, data = {}) {
     // This deals with anyone calling omfg() with `omfg('It broke', null, error)` which would cause things to break
     if (!data) {
       data = {}

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -61,7 +61,7 @@ async function handler (job) {
       global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { numberOfJobs: job.data.numberOfJobs })
     }
   } catch (error) {
-    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, job.data, error)
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error, job.data)
     throw error
   }
 }

--- a/test/lib/notifiers/base-notifier.lib.test.js
+++ b/test/lib/notifiers/base-notifier.lib.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const BaseNotifierLib = require('../../../src/lib/notifiers/base-notifier.lib.js')
 
-experiment.only('BaseNotifierLib class', () => {
+experiment('BaseNotifierLib class', () => {
   const id = '1234567890'
   const message = 'say what test'
 

--- a/test/lib/notifiers/base-notifier.lib.test.js
+++ b/test/lib/notifiers/base-notifier.lib.test.js
@@ -11,7 +11,7 @@ const { expect } = Code
 // Thing under test
 const BaseNotifierLib = require('../../../src/lib/notifiers/base-notifier.lib.js')
 
-experiment('BaseNotifierLib class', () => {
+experiment.only('BaseNotifierLib class', () => {
   const id = '1234567890'
   const message = 'say what test'
 
@@ -103,7 +103,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message and some data is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, { id })
+          testNotifier.omfg(message, null, { id })
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -115,7 +115,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, { id })
+          testNotifier.omfg(message, null, { id })
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 
@@ -128,7 +128,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message, some data and an error is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, { id }, testError)
+          testNotifier.omfg(message, testError, { id })
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -140,7 +140,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, { id }, testError)
+          testNotifier.omfg(message, testError, { id })
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 
@@ -153,7 +153,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message, no data but an error is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, null, testError)
+          testNotifier.omfg(message, testError, null)
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -164,7 +164,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, null, testError)
+          testNotifier.omfg(message, testError, null)
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 

--- a/test/modules/nald-import/jobs/import-licence.test.js
+++ b/test/modules/nald-import/jobs/import-licence.test.js
@@ -145,8 +145,8 @@ experiment('NALD Import: Import Licence job', () => {
 
         expect(notifierStub.omfg.calledWith(
           'nald-import.import-licence: errored',
-          job.data,
-          err
+          err,
+          job.data
         )).to.be.true()
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4039

In [Replace old logging](https://github.com/DEFRA/water-abstraction-import/pull/654), we migrated from the app's prior logging method to the [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) approach.

Or so we thought! If an error occurs, we receive a log message and a notification to Errbit. However, we have not been receiving the correct stack trace.

Digging deeper, we discovered that the order of args in the base notifier does not match how the remainder of the code calls '.omfg()'. Doh! 🤦

So, the base notifier has been encapsulating the error in another error, causing muddled stack traces! This changes the base notifier to align with the calls, allowing us to receive cleaner, more informative stack traces again!
