### PR TITLE
Fix licence version purpose import failing

### DIFF
--- a/src/modules/licence-import/load/connectors/queries.js
+++ b/src/modules/licence-import/load/connectors/queries.js
@@ -170,6 +170,9 @@ const createLicenceVersionPurpose = `insert into water.licence_version_purposes 
     time_limited_start_date,
     time_limited_end_date,
     notes,
+    instant_quantity,
+    hourly_quantity,
+    daily_quantity,
     annual_quantity,
     external_id,
     date_created,
@@ -188,6 +191,9 @@ const createLicenceVersionPurpose = `insert into water.licence_version_purposes 
     $11,
     $12,
     $13,
+    $14,
+    $15,
+    $16,
     now(),
     now()
   ) on conflict (external_id) do update set
@@ -201,6 +207,9 @@ const createLicenceVersionPurpose = `insert into water.licence_version_purposes 
     time_limited_start_date = excluded.time_limited_start_date,
     time_limited_end_date = excluded.time_limited_end_date,
     notes = excluded.notes,
+    instant_quantity = excluded.instant_quantity,
+    hourly_quantity = excluded.hourly_quantity,
+    daily_quantity = excluded.daily_quantity,
     annual_quantity = excluded.annual_quantity,
     date_updated = now()
     returning licence_version_purpose_id;`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4442

In [add abstraction quantities to licence purpose](https://github.com/DEFRA/water-abstraction-import/pull/906) we made changes to the main licence import to capture additional values set in NALD we don't currently have. We need this information to create return requirements from existing abstraction data WATER-4257 . It is used to determine how often returns should be collected and reported.

We added the additional fields and confirmed all was well in the unit tests. But it was only afterwards we spotted an avalanche of errors being thrown by the import process.

```
[09:17:13.443] ERROR (3721): licence-import.import-licence: errored
    err: {
      "type": "DatabaseError",
      "message": "bind message supplies 16 parameters, but prepared statement \"\" requires 13",
      "stack":
          error: bind message supplies 16 parameters, but prepared statement "" requires 13
              at /home/repos/water-abstraction-import/node_modules/pg-pool/index.js:45:11
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async Object.createLicenceVersionPurpose (/home/repos/water-abstraction-import/src/modules/licence-import/load/connectors/index.js:117:18)
              at async /home/repos/water-abstraction-import/src/modules/licence-import/load/licence.js:55:27
              at async Promise.all (index 0)
              at async Promise.all (index 0)
              at async handler (/home/repos/water-abstraction-import/src/modules/licence-import/jobs/import-licence.js:64:5)
      "length": 139,
      "name": "error",
      "severity": "ERROR",
      "code": "08P01",
      "file": "postgres.c",
      "line": "1671",
      "routine": "exec_bind_message"
```

We'd overlooked needing to update the query that upserts the `water.licence_version_purposes` records to handle the extra params.

Doh! 🤦

This change fixes the query and gets the import working again.