### PR TITLE
Add notes to return-versions from return-requirements

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -27,7 +27,8 @@ const handler = async () => {
       returnVersionQueries.importReturnVersions,
       returnVersionQueries.importReturnRequirements,
       returnVersionQueries.importReturnRequirementPurposes,
-      returnVersionQueries.importReturnVersionsMultipleUpload
+      returnVersionQueries.importReturnVersionsMultipleUpload,
+      returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -109,9 +109,18 @@ from (
 where water.return_versions.return_version_id = distinctReturnRequirements.return_version_id
 `
 
+const importReturnVersionsCreateNotesFromDescriptions = `update water.return_versions rv
+set notes = (
+select string_agg(nrf."DESCR", ', ')
+from import."NALD_RET_FORMATS" nrf
+where nrf."ARVN_AABL_ID" = split_part(rv.external_id, ':',2)
+)
+`
+
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
   importReturnRequirementPurposes,
+  importReturnVersionsCreateNotesFromDescriptions,
   importReturnVersionsMultipleUpload
 }

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -58,7 +58,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             returnVersionQueries.importReturnVersions,
             returnVersionQueries.importReturnRequirements,
             returnVersionQueries.importReturnRequirementPurposes,
-            returnVersionQueries.importReturnVersionsMultipleUpload
+            returnVersionQueries.importReturnVersionsMultipleUpload,
+            returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4472

As part of our work to get ready to replace NALD for handling returns we need to be able to let users store a note against the return. This is currently handled at the return-requirement description but we want to do it in the return-version level. This PR updates the import job to concatenate the descriptions from the return-requirements table and put them in the notes section of the return-version