### PR TITLE
Import return requirement points

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -26,6 +26,7 @@ const handler = async () => {
       purposesQueries.importValidPurposeCombinations,
       returnVersionQueries.importReturnVersions,
       returnVersionQueries.importReturnRequirements,
+      returnVersionQueries.importReturnRequirementPoints,
       returnVersionQueries.importReturnRequirementPurposes,
       returnVersionQueries.importReturnVersionsMultipleUpload,
       returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -57,6 +57,7 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             purposesQueries.importValidPurposeCombinations,
             returnVersionQueries.importReturnVersions,
             returnVersionQueries.importReturnRequirements,
+            returnVersionQueries.importReturnRequirementPoints,
             returnVersionQueries.importReturnRequirementPurposes,
             returnVersionQueries.importReturnVersionsMultipleUpload,
             returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4475

As part of our plan to replace NALD we need to import the abstraction point detail. This PR adds a script that will get the information from the import tables and add it to the newly created return-requirement-points table. 