### PR TITLE
Include NALD point ID in return reqs import

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -113,7 +113,8 @@ const importReturnRequirementPoints = `insert into water.return_requirement_poin
   ngr_2,
   ngr_3,
   ngr_4,
-  external_id
+  external_id,
+  nald_point_id
   )
   select
   rr.return_requirement_id,
@@ -122,7 +123,8 @@ const importReturnRequirementPoints = `insert into water.return_requirement_poin
   case np."NGR2_SHEET" when 'null' then null else concat_ws(' ', np."NGR2_SHEET", np."NGR2_EAST", np."NGR2_NORTH") end AS ngr_2,
   case np."NGR3_SHEET" when 'null' then null else concat_ws(' ', np."NGR3_SHEET", np."NGR3_EAST", np."NGR3_NORTH") end AS ngr_3,
   case np."NGR4_SHEET" when 'null' then null else concat_ws(' ', np."NGR4_SHEET", np."NGR4_EAST", np."NGR4_NORTH") end AS ngr_4,
-  concat_ws(':', nrfp."FGAC_REGION_CODE", nrfp."ARTY_ID", nrfp."AAIP_ID") as external_id
+  concat_ws(':', nrfp."FGAC_REGION_CODE", nrfp."ARTY_ID", nrfp."AAIP_ID") as external_id,
+  nrfp."AAIP_ID"::integer as nald_point_id
   from import."NALD_RET_FMT_POINTS" nrfp
   join water.return_requirements rr on nrfp."FGAC_REGION_CODE"=split_part(rr.external_id, ':',1) and nrfp."ARTY_ID"=split_part(rr.external_id, ':',2)
   join import."NALD_POINTS" np on np."ID"=nrfp."AAIP_ID" and np."FGAC_REGION_CODE"=nrfp."FGAC_REGION_CODE"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4493

Returns submitted to the service are sent back to NALD. There are then data reports that link the return submissions to their relevant points. But when we take over the returns functionality from NALD the link between a return submission (form log) and the point will be lost if we don't have some way of capturing the NALD unique point ID.

The submissions (returns.returns) link to `water.return_requirements` which in turn is linked to `water.return_requirement_points`. If that table contains the NALD point ID then they should be able to link submissions to specific points when creating reports.

In [Add NALD point ID to return req points table](https://github.com/DEFRA/water-abstraction-service/pull/2552) we made sure the table has a new field to hold the point ID. In this change, we alter the import job to ensure it gets populated.