### PR TITLE
Fix create notes from RTN FORMATS desc for versions

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -142,15 +142,15 @@ from (
   select distinct on (rr.return_version_id) rr.return_version_id, rr.is_upload
   from water.return_requirements rr
 ) as distinctReturnRequirements
-where water.return_versions.return_version_id = distinctReturnRequirements.return_version_id
+where water.return_versions.return_version_id = distinctReturnRequirements.return_version_id;
 `
 
-const importReturnVersionsCreateNotesFromDescriptions = `update water.return_versions rv
-set notes = (
-select string_agg(nrf."DESCR", ', ')
-from import."NALD_RET_FORMATS" nrf
-where nrf."ARVN_AABL_ID" = split_part(rv.external_id, ':',2)
-)
+const importReturnVersionsCreateNotesFromDescriptions = `UPDATE water.return_versions rv
+SET notes = (
+SELECT string_agg(nrf."DESCR", ', ')
+FROM import."NALD_RET_FORMATS" nrf
+WHERE nrf."ARVN_AABL_ID" = split_part(rv.external_id, ':',2) AND nrf."DESCR" <> 'null'
+);
 `
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4472

As part of migrating the return requirement functionality from NALD to WRLS we've had to expand how the existing legacy code is importing the current from NALD.

One of the changes we made was to capture the descriptions from each return version's return formats (return requirements) and combine them as the 'note'. We don't intend to use `description` at the return requirement level, but this is a way of still being able to capture the info and make them visible to users should they need them.

However, we hadn't catered for the fact that the files we're importing state `'null'` for empty fields. This means `'null'` gets imported rather than the field being left as `NULL`. This messed up the notes because where there was no return format description, `'null'` was being used, resulting in notes like 'null, null'.