### PR TITLE
Fix return req frequency fields being imported

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -31,6 +31,7 @@ const importReturnRequirements = `insert into water.return_requirements  ( retur
   is_upload,
   external_id,
   returns_frequency,
+  reporting_frequency,
   collection_frequency,
   two_part_tariff,
   date_created,
@@ -63,6 +64,15 @@ const importReturnRequirements = `insert into water.return_requirements  ( retur
     when 'Q' then 'quarter'
     when 'A' then 'year'
     end
+  ) as reporting_frequency,
+  (case nrf."ARTC_CODE"
+    when 'D' then 'day'
+    when 'W' then 'week'
+    when 'F' then 'fortnight'
+    when 'M' then 'month'
+    when 'Q' then 'quarter'
+    when 'A' then 'year'
+    end
   ) as collection_frequency,
   (case
     when nrf."TPT_FLAG" = 'Y' then TRUE
@@ -79,6 +89,7 @@ const importReturnRequirements = `insert into water.return_requirements  ( retur
   is_summer=excluded.is_summer,
   is_upload=excluded.is_upload,
   returns_frequency=excluded.returns_frequency,
+  reporting_frequency=excluded.reporting_frequency,
   collection_frequency=excluded.collection_frequency,
   two_part_tariff=excluded.two_part_tariff,
   date_updated=excluded.date_updated;`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4473

We recently extended the import of return requirements from NALD to include the frequency with which returns need to be collected. We thought with this and `returns_frequency` we would have the data we need to support the return requirements setup journey.

However, we now realise we made an incorrect assumption about what `returns_frequency` represents. We thought it was the reporting frequency; however it turns out NALD has 3 frequency levels.

- Return to agency (`ARTC_RET_FREQ_CODE`)
- Recording (`ARTC_REC_FREQ_CODE`)
- Collection (`ARTC_CODE`)

Because we assumed `ARTC_RET_FREQ_CODE` was reporting, we're importing `ARTC_REC_FREQ_CODE` as collection. Now we know it should have been

- `ARTC_REC_FREQ_CODE` is reporting frequency
- `ARTC_CODE` is collection frequency

We don't want to touch `ARTC_RET_FREQ_CODE` because we're still not 100% sure that nothing in the legacy code is using these tables. So, this change corrects how we're populating collection frequency and adds a new field specifically for 'reporting frequency'.