### PR TITLE
Transform return version status to WRLS style

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -29,7 +29,8 @@ const handler = async () => {
       returnVersionQueries.importReturnRequirementPoints,
       returnVersionQueries.importReturnRequirementPurposes,
       returnVersionQueries.importReturnVersionsMultipleUpload,
-      returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions
+      returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
+      returnVersionQueries.importReturnVersionsCorrectStatusForWrls
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -164,11 +164,25 @@ WHERE nrf."ARVN_AABL_ID" = split_part(rv.external_id, ':',2) AND nrf."DESCR" <> 
 );
 `
 
+const importReturnVersionsCorrectStatusForWrls = `UPDATE water.return_versions
+SET status = 'current'
+WHERE status = 'superseded'
+AND return_version_id NOT IN (SELECT rv.return_version_id
+FROM water.return_versions rv
+INNER JOIN water.return_versions rv2
+  ON rv.licence_id = rv2.licence_id
+    AND rv.start_date = rv2.start_date
+    AND rv.return_version_id != rv2.return_version_id
+    AND rv.version_number < rv2.version_number
+WHERE rv.end_date IS NOT NULL);
+`
+
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
   importReturnRequirementPoints,
   importReturnRequirementPurposes,
   importReturnVersionsCreateNotesFromDescriptions,
-  importReturnVersionsMultipleUpload
+  importReturnVersionsMultipleUpload,
+  importReturnVersionsCorrectStatusForWrls
 }

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -60,7 +60,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             returnVersionQueries.importReturnRequirementPoints,
             returnVersionQueries.importReturnRequirementPurposes,
             returnVersionQueries.importReturnVersionsMultipleUpload,
-            returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions
+            returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
+            returnVersionQueries.importReturnVersionsCorrectStatusForWrls
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4505

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS for managing them.

One of the changes is what the status is expected to be. In NALD, as soon as a new return version is added, the previous one is marked as superseded. 'current' means "this is the latest version". In WRLS, if a new version starts later than the previous version, it leaves the previous record alone. 'current' means "all versions with a status of current are still valid". If a new version starts on the same date as the previous one, then the new version 'supersedes' the previous one, so we update the status of the previous one.

To support this, we need to make a change to the import. Once the records have been updated, we'll run a new query that will determine those that are truly superseded from those that are not. It will update the status of those that are _not_ truly 'superseded' to 'current'.