### PR TITLE
Set to 'draft' ret. versions with no requirements

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -30,7 +30,8 @@ const handler = async () => {
       returnVersionQueries.importReturnRequirementPurposes,
       returnVersionQueries.importReturnVersionsMultipleUpload,
       returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
-      returnVersionQueries.importReturnVersionsCorrectStatusForWrls
+      returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
+      returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -177,6 +177,18 @@ INNER JOIN water.return_versions rv2
 WHERE rv.end_date IS NOT NULL);
 `
 
+const importReturnVersionsSetToDraftMissingReturnRequirements = `UPDATE water.return_versions
+SET status = 'draft'
+WHERE status = 'current'
+AND (
+  reason IS NULL
+  OR reason NOT IN ('abstraction-below-100-cubic-metres-per-day', 'returns-exception', 'transfer-licence')
+)
+AND return_version_id NOT IN (
+  SELECT DISTINCT return_version_id FROM water.return_requirements
+);
+`
+
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
@@ -184,5 +196,6 @@ module.exports = {
   importReturnRequirementPurposes,
   importReturnVersionsCreateNotesFromDescriptions,
   importReturnVersionsMultipleUpload,
-  importReturnVersionsCorrectStatusForWrls
+  importReturnVersionsCorrectStatusForWrls,
+  importReturnVersionsSetToDraftMissingReturnRequirements
 }

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -61,7 +61,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             returnVersionQueries.importReturnRequirementPurposes,
             returnVersionQueries.importReturnVersionsMultipleUpload,
             returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
-            returnVersionQueries.importReturnVersionsCorrectStatusForWrls
+            returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
+            returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4510

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS for managing them.

In WRLS, we want to allow users to add new return requirements by copying them from a previous 'current' return version. We also want to display and view them in the UI.

However, we know our new functionality will have to support working with the existing data that was created and vetted in NALD. So, we double checked, and though only a few, we found instances of WRLS 'current' return versions that have no return requirements.

These are not valid records; we cannot copy from them, display them in the UI, or generate return logs. We also don't want to have to consider them when new return versions are added and we have to update the previous ones.

So, this change adds a new query to the return versions import in charging data to update the status to 'draft' those return versions with a status of 'current' that have no return requirements.

It caters for the fact that there will be times it _is_ valid to have a return version that is 'current' but has no return requirements. These will be how we reflect return versions created for licences where no-returns are required. This is a feature that NALD doesn't have, but WRLS will. We expect that the import will be switched off before the new functionality is switched on. But just in case, the query ignores those return versions created with a no-returns required `reason`.