### PR TITLE
Add missing return version end dates during import

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -31,7 +31,8 @@ const handler = async () => {
       returnVersionQueries.importReturnVersionsMultipleUpload,
       returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
       returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
-      returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements
+      returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements,
+      returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -189,6 +189,29 @@ AND return_version_id NOT IN (
 );
 `
 
+const importReturnVersionsAddMissingReturnVersionEndDates = `UPDATE water.return_versions rv
+SET end_date = bq.new_end_date
+FROM (SELECT rv.return_version_id,
+(SELECT rv3.start_date - 1 FROM water.return_versions rv3 WHERE rv3.licence_id = madness.licence_id AND rv3.version_number = madness.min_version) AS new_end_date
+FROM water.return_versions rv
+INNER JOIN (SELECT no_end.return_version_id, rv1.licence_id, min(rv1.version_number) AS min_version
+  FROM water.return_versions rv1
+  INNER JOIN (SELECT rv2.return_version_id, rv2.licence_id, rv2.version_number
+    FROM water.return_versions rv2
+    INNER JOIN (SELECT licence_id, max(version_number) AS max_version
+      FROM water.return_versions
+      WHERE status != 'draft'
+      GROUP BY licence_id) AS lv
+    ON rv2.licence_id = lv.licence_id
+    AND rv2.version_number != lv.max_version
+    WHERE rv2.end_date IS NULL) AS no_end
+  ON rv1.licence_id = no_end.licence_id
+  AND rv1.version_number > no_end.version_number
+  GROUP BY rv1.licence_id, no_end.return_version_id) AS madness
+ON rv.return_version_id = madness.return_version_id) AS bq
+WHERE rv.return_version_id = bq.return_version_id;
+`
+
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
@@ -197,5 +220,6 @@ module.exports = {
   importReturnVersionsCreateNotesFromDescriptions,
   importReturnVersionsMultipleUpload,
   importReturnVersionsCorrectStatusForWrls,
-  importReturnVersionsSetToDraftMissingReturnRequirements
+  importReturnVersionsSetToDraftMissingReturnRequirements,
+  importReturnVersionsAddMissingReturnVersionEndDates
 }

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -62,7 +62,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             returnVersionQueries.importReturnVersionsMultipleUpload,
             returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
             returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
-            returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements
+            returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements,
+            returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4514

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS for managing them.

We've spotted that some of the return versions we are importing are missing end dates.

|Return Version ID|Licence ID|Version number|Start date|End date  |Status |
|-----------------|----------|--------------|----------|----------|-------|
|RV1              |LV1       |100           |1984-10-22|2008-03-31|Current|
|RV2              |LV1       |101           |2008-04-01|2009-03-31|Current|
|RV3              |LV1       |102           |2009-04-01|          |Current|
|RV4              |LV1       |103           |2023-04-01|          |Current|

We expect the 'latest' return version to have no end date because it reflects the return requirements that should be used for anything in the future. But in this example, `RV3` should have an end date (2023-03-31). This is an error on the part of NALD we should correct during the import.