### PR TITLE
Include mod log info in return versions import

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -32,7 +32,8 @@ const handler = async () => {
       returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
       returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
       returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements,
-      returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates
+      returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates,
+      returnVersionQueries.importReturnVersionsModLogs
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -212,6 +212,33 @@ ON rv.return_version_id = madness.return_version_id) AS bq
 WHERE rv.return_version_id = bq.return_version_id;
 `
 
+// NOTE: At the time of this note there were 66K return versions imported from NALD. 30K matched to a mod log with a
+// reason against it. A further 13K matched (so we have USER_ID and CREATE_DATE) but there is no reason). The remaining
+// 23K have no matches. Our brief analysis suggests it's the early records that are affected by this.
+const importReturnVersionsModLogs = `
+  UPDATE water.return_versions AS tgt
+  SET mod_log=src.mod_log
+  FROM (
+    SELECT
+      (concat_ws(':', nml."FGAC_REGION_CODE", nml."ARVN_AABL_ID", nml."ARVN_VERS_NO")) AS mod_log_id,
+      (
+        json_build_object(
+          'code', nmr."CODE",
+          'description', nmr."DESCR",
+          'note', (CASE nml."TEXT" WHEN 'null' THEN NULL ELSE nml."TEXT" END),
+          'createdAt', (CASE nml."CREATE_DATE" WHEN 'null' THEN NULL ELSE nml."CREATE_DATE" END),
+          'createdBy', (CASE nml."USER_ID" WHEN 'null' THEN NULL ELSE nml."USER_ID" END)
+        )
+      )::jsonb AS mod_log
+    FROM "import"."NALD_MOD_LOGS" nml
+    LEFT JOIN "import"."NALD_MOD_REASONS" nmr ON nmr."AMRE_TYPE" = nml."AMRE_AMRE_TYPE" AND nmr."CODE" = nml."AMRE_CODE"
+    WHERE nml."EVENT" = 'DRFVER'
+  )
+  AS src
+  WHERE tgt.external_id=src.mod_log_id
+  AND tgt.mod_log = '{}'::jsonb;
+`
+
 module.exports = {
   importReturnVersions,
   importReturnRequirements,
@@ -221,5 +248,6 @@ module.exports = {
   importReturnVersionsMultipleUpload,
   importReturnVersionsCorrectStatusForWrls,
   importReturnVersionsSetToDraftMissingReturnRequirements,
-  importReturnVersionsAddMissingReturnVersionEndDates
+  importReturnVersionsAddMissingReturnVersionEndDates,
+  importReturnVersionsModLogs
 }

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -63,7 +63,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             returnVersionQueries.importReturnVersionsCreateNotesFromDescriptions,
             returnVersionQueries.importReturnVersionsCorrectStatusForWrls,
             returnVersionQueries.importReturnVersionsSetToDraftMissingReturnRequirements,
-            returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates
+            returnVersionQueries.importReturnVersionsAddMissingReturnVersionEndDates,
+            returnVersionQueries.importReturnVersionsModLogs
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4565

> Part of the work to display a licence's history to users (mod log)

NALD has a concept called 'mod log'. Essentially, when someone creates a new licence, charge, or return version, they are required to provide a reason and can also add a note.

Rather than this being stored against each record, the 'mod log' is stored in a single place. Users can then view a licence's 'mod logs' to get a sense of the history of the licence.

When charging switched from NALD to WRLS, we (the previous team) built the ability to record a reason and note against a new charge version but didn't import any historic data. With return requirements also soon to switch from NALD to WRLS, there is a concern that this view of changes made to a licence will be lost.

Having reviewed how the information is held in NALD, we've confirmed that we can extract this information and import it as part of the import.

This first change tackles the extraction of mod log information in the existing return version import process.