### PR TITLE
Tweak date in return version mod log import query

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -226,7 +226,7 @@ const importReturnVersionsModLogs = `
           'code', nmr."CODE",
           'description', nmr."DESCR",
           'note', (CASE nml."TEXT" WHEN 'null' THEN NULL ELSE nml."TEXT" END),
-          'createdAt', (CASE nml."CREATE_DATE" WHEN 'null' THEN NULL ELSE nml."CREATE_DATE" END),
+          'createdAt', (CASE nml."CREATE_DATE" WHEN 'null' THEN NULL ELSE to_date(nml."CREATE_DATE", 'DD/MM/YYYY') END),
           'createdBy', (CASE nml."USER_ID" WHEN 'null' THEN NULL ELSE nml."USER_ID" END)
         )
       )::jsonb AS mod_log


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4565

> Part of the work to display a licence's history to users (mod log)

In [Include mod log info in return versions import](https://github.com/DEFRA/water-abstraction-import/pull/990) we extended the return version import to extract mod log information and import it into WRLS.

We did this using a new query that was populating the mod log with the `createdAt` date with whatever was found in the NALD record. Typically, these are dates in the format `14/06/2022`. Unfortunately, this is an invalid format for creating new date objects in JavaScript. And we need it to be a date object in order to format it ready for the UI, for example, '14 June 2022'.

We could take the string, split it, and do some JavaScript magic to get it into a valid date object. But then we remembered the existing return version query already switches it into a format that JavaScript will accept: '2022-06-14'.

So, this change is a minor tweak to convert the date in the query we added.