### PR TITLE
Add reason mapping query to return version import

### DIFF
--- a/src/modules/charging-import/jobs/charging-data.js
+++ b/src/modules/charging-import/jobs/charging-data.js
@@ -38,7 +38,8 @@ const handler = async () => {
       modLogQueries.linkLicencesToModLogs,
       modLogQueries.linkChargeVersionsToModLogs,
       modLogQueries.linkLicenceVersionsToModLogs,
-      modLogQueries.linkReturnVersionsToModLogs
+      modLogQueries.linkReturnVersionsToModLogs,
+      modLogQueries.updateReturnVersionReasons
     ])
 
     global.GlobalNotifier.omg('import.charging-data: finished')

--- a/src/modules/charging-import/lib/queries/mod-logs.js
+++ b/src/modules/charging-import/lib/queries/mod-logs.js
@@ -100,8 +100,11 @@ const linkReturnVersionsToModLogs = `
 // a table we then JOIN to in the update rather than a sub-query. CTEs are temporary tables that exist just within the
 // scope of the query.
 //
-// This was a massive performance boost (> 10 mins to < 5 secs) for the first run. AFter that the timing comes down to
+// This was a massive performance boost (> 10 mins to < 5 secs) for the first run. After that the timing comes down to
 // milliseconds.
+//
+// For the eagle eye, yes, our CASE statement covers more reasons than we include in the `WHERE IN` clause. We felt this
+// would serve as a handy reference what the agreed mappings were for _all_ NALD reason codes.
 const updateReturnVersionReasons = `
   WITH selected_reasons AS (
     SELECT

--- a/test/modules/charging-import/jobs/charging-data.test.js
+++ b/test/modules/charging-import/jobs/charging-data.test.js
@@ -69,7 +69,8 @@ experiment('modules/charging-import/jobs/charging-data.js', () => {
             modLogQueries.linkLicencesToModLogs,
             modLogQueries.linkChargeVersionsToModLogs,
             modLogQueries.linkLicenceVersionsToModLogs,
-            modLogQueries.linkReturnVersionsToModLogs
+            modLogQueries.linkReturnVersionsToModLogs,
+            modLogQueries.updateReturnVersionReasons
           ]
         )).to.be.true()
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4636

> Part of the work to display a licence's history to users (mod log)

Now that we are [importing the NALD mod logs](https://github.com/DEFRA/water-abstraction-import/pull/998) and linking them to their WRLS version records (charge, licence and returns) we can look to update the WRLS records with their missing reasons.

We've worked with the Billing & Data team to map NALD reasons to those in WRLS. There are a couple that don't map, and for those, [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) will fall back to whatever reason description we have in the mod log. For the rest, though, we can fill in their missing `reason` field with the mapped WRLS reason. We can then start displaying this to users on our new UI screens.

This change adds another query to the charging data import that will do the mapping for those WRLS return versions.

- that have an empty `reason`
- that have mod log records
- the first mod log record has a reason code
- the reason code is mapped to WRLS