### PR TITLE
Fix return version note creation from requirements

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -157,9 +157,9 @@ where water.return_versions.return_version_id = distinctReturnRequirements.retur
 `
 
 // NOTE: Our first version of this query was flawed when shipped so has updated notes incorrectly. So, the first thing
-// we hae to do in this query is blank what is there.
+// we have to do in this query is blank what is already there.
 //
-// > We can remove the set all notes to NULL part once this has been fixed and run at least once!
+// > We can remove the set all notes to NULL part once this has been fixed and run at least once.
 //
 // Our next version used a sub-query to generate the note but was too slow. So, we've used a solution we also applied
 // to a mod logs query: a common table expression (CTE).

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -156,12 +156,37 @@ from (
 where water.return_versions.return_version_id = distinctReturnRequirements.return_version_id;
 `
 
-const importReturnVersionsCreateNotesFromDescriptions = `UPDATE water.return_versions rv
-SET notes = (
-SELECT string_agg(nrf."DESCR", ', ')
-FROM import."NALD_RET_FORMATS" nrf
-WHERE nrf."ARVN_AABL_ID" = split_part(rv.external_id, ':',2) AND nrf."DESCR" <> 'null'
-);
+// NOTE: Our first version of this query was flawed when shipped so has updated notes incorrectly. So, the first thing
+// we hae to do in this query is blank what is there.
+//
+// > We can remove the set all notes to NULL part once this has been fixed and run at least once!
+//
+// Our next version used a sub-query to generate the note but was too slow. So, we've used a solution we also applied
+// to a mod logs query: a common table expression (CTE).
+//
+// The sub-query version locally took more than 5 minutes. Even with the set all notes to NULL part, this version with
+// the CTE took 2 seconds!
+const importReturnVersionsCreateNotesFromDescriptions = `
+  UPDATE water.return_versions rv SET notes = NULL WHERE rv.notes IS NOT NULL;
+  WITH aggregated_notes AS (
+    SELECT
+      rr.return_version_id,
+      string_agg(rr.description, ', ') AS notes
+    FROM
+      water.return_requirements rr
+    WHERE
+      rr.description IS NOT NULL
+    GROUP BY
+      rr.return_version_id
+  )
+  UPDATE
+    water.return_versions rv
+  SET
+    notes = an.notes
+  FROM
+    aggregated_notes an
+  WHERE
+    rv.return_version_id = an.return_version_id;
 `
 
 const importReturnVersionsCorrectStatusForWrls = `UPDATE water.return_versions


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4472

> Part of the work to migrate return version management from NALD to WRLS

Notes can be saved at the return requirement level in NALD, but they will be held at the return version level in WRLS.

Previously, we changed the import to [Add notes to return-versions from return-requirements](https://github.com/DEFRA/water-abstraction-import/pull/929) by concatenating what we find at the return requirement level as the return version note.

- `return_version` - _Note 1, Note 2_
  - `return_requirement` - _Note 1_
  - `return_requirement` - _Note 2_

But we've spotted that the query we wrote was flawed. It does not take into account the region code. NALD, for whatever reason, doesn't generate a unique ID for each record. This means you will see the following in its `NALD_RET_VERSIONS` table.

| id   | region |
|------|--------|
|100101|      6 |
|100101|      2 |
|100101|      3 |

You have to combine the 2 values to make a unique ID. The same goes for `NALD_RET_FORMATS` (return requirements).

Our problem is the query we wrote selected the return requirements just using the ID. This means notes from return requirements linked to other return versions are getting mixed into the notes we're generating.

This change corrects the query. It is run during every import, so all records will be fixed during the next run.