### PR TITLE
Amend system licence import route

### DIFF
--- a/src/lib/services/water-system-service.js
+++ b/src/lib/services/water-system-service.js
@@ -5,7 +5,7 @@ const { serviceRequest } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
 
 const postImportLicence = async (data) => {
-  const url = new URL(`${config.services.system}/import/licence`)
+  const url = new URL(`${config.services.system}/import/licence/legacy`)
 
   return serviceRequest.post(url.href, {
     body: data,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4575

> Part of the work to migrate the legacy licence import job

In [Import Licence versions](https://github.com/DEFRA/water-abstraction-system/pull/1195), following some feedback, we've decided to amend the endpoint that this repo will hit in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to trigger the import of a licence from NALD.

This change updates the URL to `/import/licence/legacy`.