### PR TITLE
Start importing licence version points to 'water'

### DIFF
--- a/src/modules/licence-import/jobs/import-points.js
+++ b/src/modules/licence-import/jobs/import-points.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const { pool } = require('../../../lib/connectors/db')
+
+const JOB_NAME = 'licence-import.import-points'
+
+function createMessage () {
+  return {
+    name: JOB_NAME,
+    options: {
+      singletonKey: JOB_NAME,
+      expireIn: '1 hours'
+    }
+  }
+}
+
+async function handler () {
+  try {
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
+
+    return _importPoints()
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+async function onComplete () {
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
+}
+
+async function _importPoints () {
+  return pool.query(`
+  INSERT INTO water.licence_version_purpose_points (
+    licence_version_purpose_id,
+    description,
+    ngr_1,
+    ngr_2,
+    ngr_3,
+    ngr_4,
+    external_id,
+    nald_point_id
+  )
+    SELECT
+      lvp.licence_version_purpose_id,
+      np."LOCAL_NAME" AS description,
+      concat_ws(' ', np."NGR1_SHEET", np."NGR1_EAST", np."NGR1_NORTH") AS ngr_1,
+      (
+        CASE np."NGR2_SHEET"
+          WHEN 'null' THEN NULL
+          ELSE concat_ws(' ', np."NGR2_SHEET", np."NGR2_EAST", np."NGR2_NORTH")
+        END
+      ) AS ngr_2,
+      (
+        CASE np."NGR3_SHEET"
+          WHEN 'null' THEN NULL
+          ELSE concat_ws(' ', np."NGR3_SHEET", np."NGR3_EAST", np."NGR3_NORTH")
+        END
+      ) AS ngr_3,
+      (
+        CASE np."NGR4_SHEET"
+          WHEN 'null' THEN NULL
+          ELSE concat_ws(' ', np."NGR4_SHEET", np."NGR4_EAST", np."NGR4_NORTH")
+        END
+      ) AS ngr_4,
+      (concat_ws(':', napp."FGAC_REGION_CODE", napp."AABP_ID", napp."AAIP_ID")) AS external_id,
+      napp."AAIP_ID"::integer AS nald_point_id
+    FROM
+      "import"."NALD_ABS_PURP_POINTS" napp
+    INNER JOIN water.licence_version_purposes lvp
+      ON napp."FGAC_REGION_CODE" = split_part(lvp.external_id, ':', 1) AND napp."AABP_ID" = split_part(lvp.external_id, ':', 2)
+    INNER JOIN import."NALD_POINTS" np
+      ON np."ID" = napp."AAIP_ID" AND np."FGAC_REGION_CODE" = napp."FGAC_REGION_CODE"
+  ON CONFLICT(external_id) DO
+  UPDATE SET
+    description=excluded.description,
+    ngr_1=excluded.ngr_1,
+    ngr_2=excluded.ngr_2,
+    ngr_3=excluded.ngr_3,
+    ngr_4=excluded.ngr_4;
+  `)
+}
+
+module.exports = {
+  createMessage,
+  handler,
+  onComplete,
+  name: JOB_NAME
+}

--- a/src/modules/licence-import/plugin.js
+++ b/src/modules/licence-import/plugin.js
@@ -6,6 +6,7 @@ const DeleteRemovedDocumentsJob = require('./jobs/delete-removed-documents.js')
 const ImportCompanyJob = require('./jobs/import-company.js')
 const ImportLicenceJob = require('./jobs/import-licence.js')
 const ImportLicenceSystemJob = require('./jobs/import-licence-system.js')
+const ImportPointsJob = require('./jobs/import-points.js')
 const ImportPurposeConditionTypesJob = require('./jobs/import-purpose-condition-types.js')
 const QueueCompaniesJob = require('./jobs/queue-companies.js')
 const QueueLicencesJob = require('./jobs/queue-licences.js')
@@ -54,6 +55,14 @@ async function register (server, _options) {
   })
 
   await server.messageQueue.subscribe(ImportLicenceJob.name, ImportLicenceJob.options, ImportLicenceJob.handler)
+  await server.messageQueue.onComplete(ImportLicenceJob.name, (executedJob) => {
+    return ImportLicenceJob.onComplete(server.messageQueue, executedJob)
+  })
+
+  await server.messageQueue.subscribe(ImportPointsJob.name, ImportPointsJob.options, ImportPointsJob.handler)
+  await server.messageQueue.onComplete(ImportPointsJob.name, () => {
+    return ImportPointsJob.onComplete()
+  })
 
   cron.schedule(config.import.licences.schedule, async () => {
     await server.messageQueue.publish(DeleteRemovedDocumentsJob.createMessage())


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS to manage them. To support this we [Created a return-requirement-points table](https://github.com/DEFRA/water-abstraction-service/pull/2540) and [updated the import](https://github.com/DEFRA/water-abstraction-import/pull/933) to import them.

Users select these points as part of the return requirements setup journey we've built. We extract them from the JSON blob stored in the `permit.licence` table. The problem we've encountered is the import service only populates the points for licences that.

- Have not ended
- Have a current licence version

Otherwise, `permit.licence` is not populated with the points data our journey relies on, causing it to throw an error. Places like the view licence page are also affected by this.

For example, it is perfectly valid that we have an 'ended' licence that we need to correct the historic return versions. And no matter the state, we can see what points the licence was linked to.

We don't know why the previous team never opted to extract licence points to their own table. But this change imports licence version purpose points to a table so we can stop depending on the `permit.licence` table and its incomplete data.