### PR TITLE
Remove note reset in Ret. Vers. note update

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -179,7 +179,8 @@ const importReturnVersionsCreateNotesFromDescriptions = `
   FROM
     aggregated_notes an
   WHERE
-    rv.return_version_id = an.return_version_id;
+    rv.return_version_id = an.return_version_id
+    AND rv.notes IS NULL;
 `
 
 const importReturnVersionsCorrectStatusForWrls = `UPDATE water.return_versions

--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -156,18 +156,11 @@ from (
 where water.return_versions.return_version_id = distinctReturnRequirements.return_version_id;
 `
 
-// NOTE: Our first version of this query was flawed when shipped so has updated notes incorrectly. So, the first thing
-// we have to do in this query is blank what is already there.
+// NOTE: Our first attempt used a sub-query to generate the note but was too slow. So, we've used a solution we also
+// applied to a mod logs query: a common table expression (CTE).
 //
-// > We can remove the set all notes to NULL part once this has been fixed and run at least once.
-//
-// Our next version used a sub-query to generate the note but was too slow. So, we've used a solution we also applied
-// to a mod logs query: a common table expression (CTE).
-//
-// The sub-query version locally took more than 5 minutes. Even with the set all notes to NULL part, this version with
-// the CTE took 2 seconds!
+// The sub-query version locally took more than 5 minutes. This version with the CTE took 2 seconds!
 const importReturnVersionsCreateNotesFromDescriptions = `
-  UPDATE water.return_versions rv SET notes = NULL WHERE rv.notes IS NOT NULL;
   WITH aggregated_notes AS (
     SELECT
       rr.return_version_id,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4472

> Part of the work to migrate return version management from NALD to WRLS

In [Fix return version note creation from requirements](https://github.com/DEFRA/water-abstraction-import/pull/1004), we amended the way we updated `water.return_versions` notes from `water.return_requirements` descriptions after spotting a flaw in the original logic.

However, because the flaw shipped, we needed to reset all notes before running the new version of the query. We only needed to run the reset once, but we don't have the luxury of doing that easily in production!

So, instead, we had the notes update query always run the reset before updating the notes.

The fix has [now been released](https://github.com/DEFRA/water-abstraction-import/releases/tag/v2.30.0), and we've confirmed it corrected the return version notes. So we can remove the reset from the query we are running.