### PR TITLE
Update set to draft invalid return version query

### DIFF
--- a/src/modules/charging-import/lib/queries/return-versions.js
+++ b/src/modules/charging-import/lib/queries/return-versions.js
@@ -207,7 +207,7 @@ SET status = 'draft'
 WHERE status = 'current'
 AND (
   reason IS NULL
-  OR reason NOT IN ('abstraction-below-100-cubic-metres-per-day', 'returns-exception', 'transfer-licence')
+  OR reason NOT IN ('abstraction-below-100-cubic-metres-per-day', 'licence-conditions-do-not-require-returns', 'returns-exception', 'temporary-trade')
 )
 AND return_version_id NOT IN (
   SELECT DISTINCT return_version_id FROM water.return_requirements


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4612
https://eaflood.atlassian.net/browse/WATER-4510

> Part of the work to migrate return requirements from NALD to WRLS

In [Set to 'draft' ret. versions with no requirements](https://github.com/DEFRA/water-abstraction-import/pull/950) we added a query to deal with return versions imported from NALD with no return requirements. These should have been impossible because NALD doesn't have the concept of 'no returns required' return versions. So, they are just the result of NALD's rubbish data validation.

We don't want them impacting our work, such as generating form logs or displaying return versions in the UI. But we also don't want them interfering with the 'no returns required' records we are adding because WRLS _will_ have that ability.

So, the query sets the status to 'draft' any return version with no linked return requirements and where the reason is not one of our 'no returns required' ones.

That was till WATER-4612 changed what the 'no returns required' reasons are!

This change updates the query to match the latest set of reasons.