### PR TITLE
Import abstraction method for lic. purpose points

### DIFF
--- a/src/modules/points/jobs/licences.js
+++ b/src/modules/points/jobs/licences.js
@@ -41,21 +41,27 @@ function _query () {
     INSERT INTO water.licence_version_purpose_points (
       licence_version_purpose_id,
       external_id,
-      point_id
+      point_id,
+      abstraction_method
     )
     SELECT
       lvp.licence_version_purpose_id,
       (concat_ws(':', napp."FGAC_REGION_CODE", napp."AABP_ID", napp."AAIP_ID")) AS external_id,
-      p.id AS point_id
+      p.id AS point_id,
+      nmoa."DESCR" AS abstraction_method
     FROM
       "import"."NALD_ABS_PURP_POINTS" napp
     INNER JOIN water.licence_version_purposes lvp
       ON napp."FGAC_REGION_CODE" = split_part(lvp.external_id, ':', 1) AND napp."AABP_ID" = split_part(lvp.external_id, ':', 2)
     INNER JOIN water.points p
       ON napp."FGAC_REGION_CODE"=split_part(p.external_id, ':',1) AND napp."AAIP_ID"=split_part(p.external_id, ':',2)
-    ON CONFLICT(external_id) DO
-    UPDATE SET
-      point_id = excluded.point_id;
+    LEFT JOIN "import"."NALD_MEANS_OF_ABS" nmoa
+      ON nmoa."CODE" = napp."AMOA_CODE"
+    ON CONFLICT(external_id)
+    DO UPDATE
+    SET
+      point_id = excluded.point_id,
+      abstraction_method = excluded.abstraction_method;
   `
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

In [Implement new 'points' job](https://github.com/DEFRA/water-abstraction-import/pull/1028) we amended the import service to include a new 'points' job. Having realised that the way we intended to store point information was insufficient, we made enough changes to our points schema to warrant its own job to manage importing the NALD data.

We thought we'd captured everything 'point' related in the change but have since spotted 'Means of abstraction'. This is linked to an abstraction purpose in NALD and gives how water will be abstracted, for example, "Surface Mounted Pump (Fixed)". We are required to display this in the UI. Having [added the new column](https://github.com/DEFRA/water-abstraction-service/pull/2642), this ensures it gets populated.