### PR TITLE
Clean up return reqs. linked to void return logs

### DIFF
--- a/src/modules/return-versions/lib/clean-queries.js
+++ b/src/modules/return-versions/lib/clean-queries.js
@@ -23,6 +23,25 @@ const cleanPoints = `
           rl.return_requirement = rr.legacy_id::varchar
         LIMIT 1
       )
+    UNION ALL
+    SELECT
+      rr.return_requirement_id
+    FROM
+      water.return_requirements rr
+    WHERE
+      NOT EXISTS (
+        SELECT 1
+        FROM nald_return_requirements nrr
+        WHERE rr.external_id = nrr.nald_id
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM "returns"."returns" rl
+        WHERE
+          rl.return_requirement = rr.legacy_id::varchar
+          AND rl.status = 'void'
+        LIMIT 1
+      )
   );
 `
 
@@ -49,6 +68,25 @@ const cleanPurposes = `
           rl.return_requirement = rr.legacy_id::varchar
         LIMIT 1
       )
+    UNION ALL
+    SELECT
+      rr.return_requirement_id
+    FROM
+      water.return_requirements rr
+    WHERE
+      NOT EXISTS (
+        SELECT 1
+        FROM nald_return_requirements nrr
+        WHERE rr.external_id = nrr.nald_id
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM "returns"."returns" rl
+        WHERE
+          rl.return_requirement = rr.legacy_id::varchar
+          AND rl.status = 'void'
+        LIMIT 1
+      )
   );
 `
 
@@ -73,6 +111,25 @@ const cleanRequirements = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
+        LIMIT 1
+      )
+    UNION ALL
+    SELECT
+      rr.return_requirement_id
+    FROM
+      water.return_requirements rr
+    WHERE
+      NOT EXISTS (
+        SELECT 1
+        FROM nald_return_requirements nrr
+        WHERE rr.external_id = nrr.nald_id
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM "returns"."returns" rl
+        WHERE
+          rl.return_requirement = rr.legacy_id::varchar
+          AND rl.status = 'void'
         LIMIT 1
       )
   );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4657

> Part of the work to migrate management of return requirements from NALD to WRLS

Having made return versions and requirements visible to our internal users, they have noticed that there are return requirements displayed in WRLS that don't exist.

We know why this is: NALD allows users to delete records. This means a user can create a record in NALD on day 1; we'll see and import the record that night. They can then delete the record (in most cases, it is because a mistake was spotted) on day 2. The import never deletes records, so the errant return requirement remains.

With us taking over management of return requirements, it has become important to try to get the two systems in sync as much as possible before the import is switched off.

This change builds on the work done in [Add return requirements clean-up step to import](https://github.com/DEFRA/water-abstraction-import/pull/1017). It added the job and the script to remove return requirements that no longer exist in NALD and were not linked to any return logs.

Now, we're adding a query to delete any return requirements that no longer exist in NALD and are only linked to `void` return logs.