### PR TITLE
Fix broken crm_v2.documents constraint

### DIFF
--- a/src/modules/licence-import/load/connectors/queries.js
+++ b/src/modules/licence-import/load/connectors/queries.js
@@ -1,7 +1,7 @@
 const createDocument = `
   INSERT INTO crm_v2.documents (regime, document_type, document_ref, start_date, end_date, external_id, date_created, date_updated, date_deleted)
   VALUES ('water', 'abstraction_licence', $1, $2, $3, $4, NOW(), NOW(), null)
-  ON CONFLICT (regime, document_type, document_ref)
+  ON CONFLICT (document_ref)
   DO UPDATE SET
     start_date=EXCLUDED.start_date,
     end_date=EXCLUDED.end_date,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4708

In a [recent change to water-abstraction-tactical-crm](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1053), we altered the constraint on the `crm_v2.documents` table to remove fields that are always set to the same values. It helped simplify our work to look at migrating the import process to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

However, we failed to realise that the import refers to those fields in a query it uses to import NALD licences to the `crm_v2.documents` table. This means our change has broken this element of the NALD import.

This change updates the query to match the constraint's current signature. Once deployed, the import will automatically pick up any NALD licences that need updates applying in `crm_v2.documents`.