### PR TITLE
Cleanup `licence_version_purpose_conditions` table

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -28,7 +28,21 @@ const cleanLicenceMonitoringStations = `
   );
 `
 
+const cleanLicenceVersionPurposeConditions = `
+  WITH nald_licence_version_purpose_conditions AS (
+    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
+    FROM "import"."NALD_LIC_CONDITIONS" nlc
+  )
+  DELETE FROM public.licence_version_purpose_conditions lvpc
+    WHERE NOT EXISTS (
+    SELECT 1
+    FROM nald_licence_version_purpose_conditions nlvpc
+    WHERE lvpc.external_id = nlvpc.nald_id
+    );
+`
+
 module.exports = {
   cleanCrmV2Documents,
-  cleanLicenceMonitoringStations
+  cleanLicenceMonitoringStations,
+  cleanLicenceVersionPurposeConditions
 }

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -1,4 +1,6 @@
-const deleteCrmV2Documents = `
+'use strict'
+
+const cleanCrmV2Documents = `
   update crm_v2.documents
   set date_deleted = now()
   where document_ref not in (
@@ -11,5 +13,5 @@ const deleteCrmV2Documents = `
 `
 
 module.exports = {
-  deleteCrmV2Documents
+  cleanCrmV2Documents
 }

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -12,6 +12,23 @@ const cleanCrmV2Documents = `
   and document_type = 'abstraction_licence';
 `
 
+const cleanLicenceMonitoringStations = `
+  WITH nald_licence_version_purpose_conditions AS (
+    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
+    FROM "import"."NALD_LIC_CONDITIONS" nlc
+  )
+  DELETE FROM public.licence_monitoring_stations lms
+  WHERE lms.licence_version_purpose_condition_id IN (
+    SELECT lvpc.id FROM public.licence_version_purpose_conditions lvpc
+    WHERE NOT EXISTS (
+    SELECT 1
+    FROM nald_licence_version_purpose_conditions nlvpc
+    WHERE lvpc.external_id = nlvpc.nald_id
+    )
+  );
+`
+
 module.exports = {
-  cleanCrmV2Documents
+  cleanCrmV2Documents,
+  cleanLicenceMonitoringStations
 }

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -23,11 +23,13 @@ async function handler () {
     // Mark records in crm_v2.documents as deleted if the licence numbers no longer exist in import.NALD_ABS_LICENCES
     await pool.query(Queries.cleanCrmV2Documents)
 
-    // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
-    await pool.query(Queries.cleanLicenceMonitoringStations)
+    if (process.env.CLEAN_LICENCE_IMPORTS === 'true') {
+      // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
+      await pool.query(Queries.cleanLicenceMonitoringStations)
 
-    // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
-    await pool.query(Queries.cleanLicenceVersionPurposeConditions)
+      // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
+      await pool.query(Queries.cleanLicenceVersionPurposeConditions)
+    }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -25,6 +25,9 @@ async function handler () {
 
     // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
     await pool.query(Queries.cleanLicenceMonitoringStations)
+
+    // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
+    await pool.query(Queries.cleanLicenceVersionPurposeConditions)
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -21,7 +21,7 @@ async function handler () {
     global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     // Mark records in crm_v2.documents as deleted if the licence numbers no longer exist in import.NALD_ABS_LICENCES
-    await pool.query(Queries.deleteCrmV2Documents)
+    await pool.query(Queries.cleanCrmV2Documents)
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -22,6 +22,9 @@ async function handler () {
 
     // Mark records in crm_v2.documents as deleted if the licence numbers no longer exist in import.NALD_ABS_LICENCES
     await pool.query(Queries.cleanCrmV2Documents)
+
+    // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
+    await pool.query(Queries.cleanLicenceMonitoringStations)
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4726

Update the `licence-import` process to identify records in the `licence_version_purpose_conditions` table that no longer exist in NALD and remove those records. Any child records must also be removed before the parent record.

This functionality will temporarily be put behind a feature flag `CLEAN_LICENCE_IMPORTS`, which will need to be set to `true` for the new code to run.