### PR TITLE
Cleanup `licence_version_purposes` table

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -21,9 +21,9 @@ const cleanLicenceMonitoringStations = `
   WHERE lms.licence_version_purpose_condition_id IN (
     SELECT lvpc.id FROM public.licence_version_purpose_conditions lvpc
     WHERE NOT EXISTS (
-    SELECT 1
-    FROM nald_licence_version_purpose_conditions nlvpc
-    WHERE lvpc.external_id = nlvpc.nald_id
+      SELECT 1
+      FROM nald_licence_version_purpose_conditions nlvpc
+      WHERE lvpc.external_id = nlvpc.nald_id
     )
   );
 `
@@ -35,14 +35,45 @@ const cleanLicenceVersionPurposeConditions = `
   )
   DELETE FROM public.licence_version_purpose_conditions lvpc
     WHERE NOT EXISTS (
-    SELECT 1
-    FROM nald_licence_version_purpose_conditions nlvpc
-    WHERE lvpc.external_id = nlvpc.nald_id
+      SELECT 1
+      FROM nald_licence_version_purpose_conditions nlvpc
+      WHERE lvpc.external_id = nlvpc.nald_id
     );
+`
+
+const cleanLicenceVersionPurposes = `
+  WITH nald_licence_version_purposes AS (
+    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':' ,nalp."ID") AS nald_id
+    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
+  )
+  DELETE FROM public.licence_version_purposes lvp
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_version_purposes nlvp
+      WHERE lvp.external_id = nlvp.nald_id
+    );
+`
+
+const cleanLicenceVersionPurposePoints = `
+  WITH nald_licence_version_purposes AS (
+    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':' ,nalp."ID") AS nald_id
+    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
+  )
+  DELETE FROM public.licence_version_purpose_points lvpp
+  WHERE lvpp.licence_version_purpose_id IN (
+    SELECT lvp.id FROM public.licence_version_purposes lvp
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_version_purposes nlvp
+      WHERE lvp.external_id = nlvp.nald_id
+    )
+  );
 `
 
 module.exports = {
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
-  cleanLicenceVersionPurposeConditions
+  cleanLicenceVersionPurposeConditions,
+  cleanLicenceVersionPurposes,
+  cleanLicenceVersionPurposePoints
 }

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -29,6 +29,12 @@ async function handler () {
 
       // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
       await pool.query(Queries.cleanLicenceVersionPurposeConditions)
+
+      // Delete any licence version purpose points linked to deleted NALD licence version purposes
+      await pool.query(Queries.cleanLicenceVersionPurposePoints)
+
+      // Delete any licence version purposes linked to deleted NALD licence version purposes
+      await pool.query(Queries.cleanLicenceVersionPurposes)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4732

Update the `licence-import` process to identify records in the `licence_version_purposes` table that no longer exist in NALD and remove those records. Any child records must also be removed before the parent record.

This functionality will temporarily be put behind a feature flag `CLEAN_LICENCE_IMPORTS`, which will need to be set to `true` for the new code to run.