### PR TITLE
Cleanup `licence_versions` table

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -83,11 +83,28 @@ const cleanLicenceVersionPurposePoints = `
   );
 `
 
+const cleanWorkflows = `
+  WITH nald_licence_versions AS (
+    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
+  )
+  DELETE FROM public.workflows w
+  WHERE w.licence_version_id IN (
+    SELECT lv.id FROM public.licence_versions lv
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_versions nlv
+      WHERE lv.external_id = nlv.nald_id
+    )
+  );
+`
+
 module.exports = {
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
   cleanLicenceVersions,
   cleanLicenceVersionPurposes,
   cleanLicenceVersionPurposeConditions,
-  cleanLicenceVersionPurposePoints
+  cleanLicenceVersionPurposePoints,
+  cleanWorkflows
 }

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -28,6 +28,19 @@ const cleanLicenceMonitoringStations = `
   );
 `
 
+const cleanLicenceVersionPurposes = `
+  WITH nald_licence_version_purposes AS (
+    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
+    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
+  )
+  DELETE FROM public.licence_version_purposes lvp
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_version_purposes nlvp
+      WHERE lvp.external_id = nlvp.nald_id
+    );
+`
+
 const cleanLicenceVersionPurposeConditions = `
   WITH nald_licence_version_purpose_conditions AS (
     SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
@@ -41,22 +54,9 @@ const cleanLicenceVersionPurposeConditions = `
     );
 `
 
-const cleanLicenceVersionPurposes = `
-  WITH nald_licence_version_purposes AS (
-    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':' ,nalp."ID") AS nald_id
-    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
-  )
-  DELETE FROM public.licence_version_purposes lvp
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_version_purposes nlvp
-      WHERE lvp.external_id = nlvp.nald_id
-    );
-`
-
 const cleanLicenceVersionPurposePoints = `
   WITH nald_licence_version_purposes AS (
-    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':' ,nalp."ID") AS nald_id
+    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
     FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
   )
   DELETE FROM public.licence_version_purpose_points lvpp
@@ -73,7 +73,7 @@ const cleanLicenceVersionPurposePoints = `
 module.exports = {
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
-  cleanLicenceVersionPurposeConditions,
   cleanLicenceVersionPurposes,
+  cleanLicenceVersionPurposeConditions,
   cleanLicenceVersionPurposePoints
 }

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -29,16 +29,16 @@ const cleanLicenceMonitoringStations = `
 `
 
 const cleanLicenceVersions = `
-WITH nald_licence_versions AS (
-  SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
-  FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
-)
-DELETE FROM public.licence_versions lv
-  WHERE NOT EXISTS (
-    SELECT 1
-    FROM nald_licence_versions nlv
-    WHERE lv.external_id = nlv.nald_id
-  );
+  WITH nald_licence_versions AS (
+    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
+  )
+  DELETE FROM public.licence_versions lv
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_versions nlv
+      WHERE lv.external_id = nlv.nald_id
+    );
 `
 
 const cleanLicenceVersionPurposes = `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -28,6 +28,19 @@ const cleanLicenceMonitoringStations = `
   );
 `
 
+const cleanLicenceVersions = `
+WITH nald_licence_versions AS (
+  SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+  FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
+)
+DELETE FROM public.licence_versions lv
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM nald_licence_versions nlv
+    WHERE lv.external_id = nlv.nald_id
+  );
+`
+
 const cleanLicenceVersionPurposes = `
   WITH nald_licence_version_purposes AS (
     SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
@@ -73,6 +86,7 @@ const cleanLicenceVersionPurposePoints = `
 module.exports = {
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
+  cleanLicenceVersions,
   cleanLicenceVersionPurposes,
   cleanLicenceVersionPurposeConditions,
   cleanLicenceVersionPurposePoints

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -35,6 +35,9 @@ async function handler () {
 
       // Delete any licence version purposes linked to deleted NALD licence version purposes
       await pool.query(Queries.cleanLicenceVersionPurposes)
+
+      // Delete any licence versions linked to deleted NALD licence versions
+      await pool.query(Queries.cleanLicenceVersions)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -36,6 +36,9 @@ async function handler () {
       // Delete any licence version purposes linked to deleted NALD licence version purposes
       await pool.query(Queries.cleanLicenceVersionPurposes)
 
+      // Delete any Workflows linked to deleted NALD licence versions
+      await pool.query(Queries.cleanWorkflows)
+
       // Delete any licence versions linked to deleted NALD licence versions
       await pool.query(Queries.cleanLicenceVersions)
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4733

Update the `licence-import` process to identify records in the `licence_versions` table that no longer exist in NALD and remove those records.

`workflows` records can potentially hang off this table, so these need to be removed. The `licence_version_purposes` have already been removed in a previous PR https://github.com/DEFRA/water-abstraction-import/pull/1036

This functionality will temporarily be put behind a feature flag `CLEAN_LICENCE_IMPORTS`, which will need to be set to `true` for the new code to run.