### PR TITLE
Cleanup `licences` table

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -146,6 +146,13 @@ const cleanLicenceMonitoringStations = `
   );
 `
 
+const cleanLicences = `
+DELETE FROM public.licences l
+WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id);
+`
+
 const cleanLicenceVersions = `
   WITH nald_licence_versions AS (
     SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
@@ -248,6 +255,7 @@ module.exports = {
   cleanLicenceDocumentRoles,
   cleanLicenceDocuments,
   cleanLicenceMonitoringStations,
+  cleanLicences,
   cleanLicenceVersions,
   cleanLicenceVersionPurposes,
   cleanLicenceVersionPurposeConditions,

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -74,6 +74,17 @@ const cleanCrmV2Documents = `
   and document_type = 'abstraction_licence';
 `
 
+const cleanLicenceAgreements = `
+WITH licences_not_in_nald_or_bill_run AS (
+  SELECT l.licence_ref
+  FROM public.licences l
+  WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+  AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+)
+DELETE FROM public.licence_agreements la
+WHERE la.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
+`
+
 const cleanLicenceDocumentRoles = `
   WITH licences_not_in_nald_or_bill_run AS (
     SELECT l.licence_ref
@@ -193,6 +204,7 @@ module.exports = {
   cleanChargeVersionNotes,
   cleanChargeVersions,
   cleanCrmV2Documents,
+  cleanLicenceAgreements,
   cleanLicenceDocumentRoles,
   cleanLicenceDocuments,
   cleanLicenceMonitoringStations,

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -201,6 +201,18 @@ const cleanLicenceVersionPurposePoints = `
   );
 `
 
+const cleanPermitLicences = `
+  WITH licences_to_remove AS (
+    SELECT l.licence_ref
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+  )
+  DELETE FROM public.permit_licences pl
+  WHERE pl.licence_ref IN (SELECT ltr.licence_ref FROM licences_to_remove ltr);
+`
+
 const cleanWorkflows = `
   WITH nald_licence_versions AS (
     SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
@@ -232,5 +244,6 @@ module.exports = {
   cleanLicenceVersionPurposes,
   cleanLicenceVersionPurposeConditions,
   cleanLicenceVersionPurposePoints,
+  cleanPermitLicences,
   cleanWorkflows
 }

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -19,6 +19,23 @@ const cleanChargeElements = `
   );
 `
 
+const cleanChargeReferences = `
+  WITH licences_not_in_nald_or_bill_run AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  )
+  DELETE FROM public.charge_references cr
+  WHERE cr.id IN (
+  SELECT cr.id FROM public.charge_references cr
+    INNER JOIN public.charge_versions cv
+      ON cr.charge_version_id = cv.id
+    INNER JOIN licences_not_in_nald_or_bill_run lnin
+      ON cv.licence_id = lnin.licence_id
+  );
+`
+
 const cleanCrmV2Documents = `
   update crm_v2.documents
   set date_deleted = now()
@@ -120,6 +137,7 @@ const cleanWorkflows = `
 
 module.exports = {
   cleanChargeElements,
+  cleanChargeReferences,
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
   cleanLicenceVersions,

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -51,6 +51,17 @@ const cleanChargeVersionNotes = `
   );
 `
 
+const cleanChargeVersions = `
+  WITH licences_not_in_nald_or_bill_run AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  )
+  DELETE FROM public.charge_versions cv
+  WHERE cv.licence_id IN (SELECT lnin.licence_id FROM licences_not_in_nald_or_bill_run lnin);
+`
+
 const cleanCrmV2Documents = `
   update crm_v2.documents
   set date_deleted = now()
@@ -154,6 +165,7 @@ module.exports = {
   cleanChargeElements,
   cleanChargeReferences,
   cleanChargeVersionNotes,
+  cleanChargeVersions,
   cleanCrmV2Documents,
   cleanLicenceMonitoringStations,
   cleanLicenceVersions,

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -75,14 +75,25 @@ const cleanCrmV2Documents = `
 `
 
 const cleanLicenceAgreements = `
-WITH licences_not_in_nald_or_bill_run AS (
-  SELECT l.licence_ref
-  FROM public.licences l
-  WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-  AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-)
-DELETE FROM public.licence_agreements la
-WHERE la.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
+  WITH licences_not_in_nald_or_bill_run AS (
+    SELECT l.licence_ref
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  )
+  DELETE FROM public.licence_agreements la
+  WHERE la.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
+`
+
+const cleanLicenceDocumentHeaders = `
+  WITH licences_not_in_nald_or_bill_run AS (
+    SELECT l.licence_ref
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  )
+  DELETE FROM public.licence_document_headers ldh
+  WHERE ldh.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
 `
 
 const cleanLicenceDocumentRoles = `
@@ -101,14 +112,14 @@ const cleanLicenceDocumentRoles = `
 `
 
 const cleanLicenceDocuments = `
-WITH licences_not_in_nald_or_bill_run AS (
-  SELECT l.licence_ref
-  FROM public.licences l
-  WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-  AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-)
-DELETE FROM public.licence_documents ld
-WHERE ld.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
+  WITH licences_not_in_nald_or_bill_run AS (
+    SELECT l.licence_ref
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  )
+  DELETE FROM public.licence_documents ld
+  WHERE ld.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
 `
 
 const cleanLicenceMonitoringStations = `
@@ -205,6 +216,7 @@ module.exports = {
   cleanChargeVersions,
   cleanCrmV2Documents,
   cleanLicenceAgreements,
+  cleanLicenceDocumentHeaders,
   cleanLicenceDocumentRoles,
   cleanLicenceDocuments,
   cleanLicenceMonitoringStations,

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -89,6 +89,17 @@ const cleanLicenceDocumentRoles = `
   );
 `
 
+const cleanLicenceDocuments = `
+WITH licences_not_in_nald_or_bill_run AS (
+  SELECT l.licence_ref
+  FROM public.licences l
+  WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+  AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+)
+DELETE FROM public.licence_documents ld
+WHERE ld.licence_ref IN (SELECT lnin.licence_ref FROM licences_not_in_nald_or_bill_run lnin);
+`
+
 const cleanLicenceMonitoringStations = `
   WITH nald_licence_version_purpose_conditions AS (
     SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
@@ -183,6 +194,7 @@ module.exports = {
   cleanChargeVersions,
   cleanCrmV2Documents,
   cleanLicenceDocumentRoles,
+  cleanLicenceDocuments,
   cleanLicenceMonitoringStations,
   cleanLicenceVersions,
   cleanLicenceVersionPurposes,

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -53,6 +53,9 @@ async function handler () {
 
       // Delete any charge versions linked to deleted NALD licences
       await pool.query(Queries.cleanChargeVersions)
+
+      // Delete any licence document roles linked to deleted NALD licences
+      await pool.query(Queries.cleanLicenceDocumentRoles)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -41,6 +41,9 @@ async function handler () {
 
       // Delete any licence versions linked to deleted NALD licence versions
       await pool.query(Queries.cleanLicenceVersions)
+
+      // Delete any charge elements linked to deleted NALD licences
+      await pool.query(Queries.cleanChargeElements)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -54,14 +54,17 @@ async function handler () {
       // Delete any charge versions linked to deleted NALD licences
       await pool.query(Queries.cleanChargeVersions)
 
+      // Delete any licence agreements linked to deleted NALD licences
+      await pool.query(Queries.cleanLicenceAgreements)
+
+      // Delete any licence document headers linked to deleted NALD licences
+      await pool.query(Queries.cleanLicenceDocumentHeaders)
+
       // Delete any licence document roles linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocumentRoles)
 
       // Delete any licence documents linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocuments)
-
-      // Delete any licence agreements linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceAgreements)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -42,6 +42,7 @@ async function handler () {
       // Delete any licence versions linked to deleted NALD licence versions
       await pool.query(Queries.cleanLicenceVersions)
 
+      // NOTE: Licences are removed if they no longer exist in NALD, are not in a bill run and have no return versions
       // Delete any charge elements linked to deleted NALD licences
       await pool.query(Queries.cleanChargeElements)
 

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -47,6 +47,9 @@ async function handler () {
 
       // Delete any charge references linked to deleted NALD licences
       await pool.query(Queries.cleanChargeReferences)
+
+      // Delete any charge version notes linked to deleted NALD licences
+      await pool.query(Queries.cleanChargeVersionNotes)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -50,6 +50,9 @@ async function handler () {
 
       // Delete any charge version notes linked to deleted NALD licences
       await pool.query(Queries.cleanChargeVersionNotes)
+
+      // Delete any charge versions linked to deleted NALD licences
+      await pool.query(Queries.cleanChargeVersions)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -56,6 +56,9 @@ async function handler () {
 
       // Delete any licence document roles linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocumentRoles)
+
+      // Delete any licence documents linked to deleted NALD licences
+      await pool.query(Queries.cleanLicenceDocuments)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -66,6 +66,9 @@ async function handler () {
 
       // Delete any licence documents linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocuments)
+
+      // Delete any permit licences linked to deleted NALD licences
+      await pool.query(Queries.cleanPermitLicences)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -24,51 +24,53 @@ async function handler () {
     await pool.query(Queries.cleanCrmV2Documents)
 
     if (process.env.CLEAN_LICENCE_IMPORTS === 'true') {
-      // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
-      await pool.query(Queries.cleanLicenceMonitoringStations)
+      // NOTE: To improve performance these queries can all be run together as the data removed has no dependencies
+      await Promise.all([
+        // Delete any charge version notes linked to deleted NALD licences
+        pool.query(Queries.cleanChargeVersionNotes),
+
+        // Delete any licence agreements linked to deleted NALD licences
+        pool.query(Queries.cleanLicenceAgreements),
+
+        // Delete any licence document headers linked to deleted NALD licences
+        pool.query(Queries.cleanLicenceDocumentHeaders),
+
+        // Delete any licence document roles linked to deleted NALD licences
+        pool.query(Queries.cleanLicenceDocumentRoles),
+
+        // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
+        pool.query(Queries.cleanLicenceMonitoringStations),
+
+        // Delete any licence version purpose points linked to deleted NALD licence version purposes
+        pool.query(Queries.cleanLicenceVersionPurposePoints),
+
+        // Delete any permit licences linked to deleted NALD licences
+        pool.query(Queries.cleanPermitLicences),
+
+        // Delete any Workflows linked to deleted NALD licence versions
+        pool.query(Queries.cleanWorkflows)
+      ])
 
       // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
       await pool.query(Queries.cleanLicenceVersionPurposeConditions)
 
-      // Delete any licence version purpose points linked to deleted NALD licence version purposes
-      await pool.query(Queries.cleanLicenceVersionPurposePoints)
-
       // Delete any licence version purposes linked to deleted NALD licence version purposes
       await pool.query(Queries.cleanLicenceVersionPurposes)
-
-      // Delete any Workflows linked to deleted NALD licence versions
-      await pool.query(Queries.cleanWorkflows)
 
       // Delete any licence versions linked to deleted NALD licence versions
       await pool.query(Queries.cleanLicenceVersions)
 
-      // NOTE: Licences are removed if they no longer exist in NALD, are not in a bill run and have no return versions
       // Delete any charge elements linked to deleted NALD licences
       await pool.query(Queries.cleanChargeElements)
 
       // Delete any charge references linked to deleted NALD licences
       await pool.query(Queries.cleanChargeReferences)
 
-      // Delete any charge version notes linked to deleted NALD licences
-      await pool.query(Queries.cleanChargeVersionNotes)
-
       // Delete any charge versions linked to deleted NALD licences
       await pool.query(Queries.cleanChargeVersions)
 
-      // Delete any licence agreements linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceAgreements)
-
-      // Delete any licence document headers linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceDocumentHeaders)
-
-      // Delete any licence document roles linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceDocumentRoles)
-
       // Delete any licence documents linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocuments)
-
-      // Delete any permit licences linked to deleted NALD licences
-      await pool.query(Queries.cleanPermitLicences)
 
       // Delete any licences linked to deleted NALD licences
       await pool.query(Queries.cleanLicences)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -44,6 +44,9 @@ async function handler () {
 
       // Delete any charge elements linked to deleted NALD licences
       await pool.query(Queries.cleanChargeElements)
+
+      // Delete any charge references linked to deleted NALD licences
+      await pool.query(Queries.cleanChargeReferences)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -59,6 +59,9 @@ async function handler () {
 
       // Delete any licence documents linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceDocuments)
+
+      // Delete any licence agreements linked to deleted NALD licences
+      await pool.query(Queries.cleanLicenceAgreements)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -69,6 +69,9 @@ async function handler () {
 
       // Delete any permit licences linked to deleted NALD licences
       await pool.query(Queries.cleanPermitLicences)
+
+      // Delete any licences linked to deleted NALD licences
+      await pool.query(Queries.cleanLicences)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4734

Update the `licence-import` process to identify records in the `licences` table that no longer exist in NALD and remove those records. If the licence has been involved in a bill run or has a return version, it should not be removed.

All child records also need to be removed. The `licence_versions` and its child records have already been removed in previous PRs https://github.com/DEFRA/water-abstraction-import/pull/1037

This functionality will temporarily be put behind a feature flag `CLEAN_LICENCE_IMPORTS`, which will need to be set to `true` for the new code to run.