### PR TITLE
Clean up return reqs. linked to due return logs

### DIFF
--- a/src/modules/return-versions/lib/clean-queries.js
+++ b/src/modules/return-versions/lib/clean-queries.js
@@ -39,7 +39,7 @@ const cleanPoints = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status = 'void'
+          AND rl.status IN ('due, 'void')
         LIMIT 1
       )
   );
@@ -84,7 +84,7 @@ const cleanPurposes = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status = 'void'
+          AND rl.status IN ('due, 'void')
         LIMIT 1
       )
   );
@@ -129,7 +129,7 @@ const cleanRequirements = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status = 'void'
+          AND rl.status IN ('due, 'void')
         LIMIT 1
       )
   );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4656

> Part of the work to migrate management of return requirements from NALD to WRLS

Having made return versions and requirements visible to our internal users, they have noticed that there are return requirements displayed in WRLS that don't exist.

We know why this is: NALD allows users to delete records. This means a user can create a record in NALD on day 1; we'll see and import the record that night. They can then delete the record (in most cases, it is because a mistake was spotted) on day 2. The import never deletes records, so the errant return requirement remains.

With us taking over management of return requirements, it has become important to try to get the two systems in sync as much as possible before the import is switched off.

This change builds on the work done in [Add return requirements clean-up step to import](https://github.com/DEFRA/water-abstraction-import/pull/1017). It added the job and the script to remove return requirements that no longer exist in NALD and were not linked to any return logs.

We then moved on to [Clean up return reqs. linked to void return logs](https://github.com/DEFRA/water-abstraction-import/pull/1030). This final change adds the query to delete any return requirements that no longer exist in NALD and are only linked to `due` return logs.