### PR TITLE
Fix invalid return version clean query change

### DIFF
--- a/src/modules/return-versions/lib/clean-queries.js
+++ b/src/modules/return-versions/lib/clean-queries.js
@@ -39,7 +39,7 @@ const cleanPoints = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status IN ('due, 'void')
+          AND rl.status IN ('due', 'void')
         LIMIT 1
       )
   );
@@ -84,7 +84,7 @@ const cleanPurposes = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status IN ('due, 'void')
+          AND rl.status IN ('due', 'void')
         LIMIT 1
       )
   );
@@ -129,7 +129,7 @@ const cleanRequirements = `
         FROM "returns"."returns" rl
         WHERE
           rl.return_requirement = rr.legacy_id::varchar
-          AND rl.status IN ('due, 'void')
+          AND rl.status IN ('due', 'void')
         LIMIT 1
       )
   );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4656

> Part of the work to migrate management of return requirements from NALD to WRLS

In [Clean up return reqs. linked to due return logs](https://github.com/DEFRA/water-abstraction-import/pull/1041), we amended our return versions clean job to also allow return requirements linked to 'due' return logs to be deleted.

Only, our amendment was missing a `'`, so it broke the job! 🤦

This change fixes the query (and we properly checked this time 😳😬)