### PR TITLE
Delete "licences" that are not in NALD

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -159,23 +159,6 @@ AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.
 AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL);
 `
 
-const cleanLicenceVersionPurposes = `
-  WITH licences_to_remove AS (
-    SELECT l.id AS licence_id
-    FROM public.licences l
-    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  )
-  DELETE FROM public.licence_version_purposes lvp
-    WHERE lvp.licence_version_id IN (
-      SELECT lv.id from public.licence_versions lv
-      INNER JOIN licences_to_remove ltr
-        ON ltr.licence_id = lv.licence_id
-    );
-`
-
 const cleanLicenceVersionPurposeConditions = `
   WITH licences_to_remove AS (
     SELECT l.id AS licence_id
@@ -214,6 +197,23 @@ const cleanLicenceVersionPurposePoints = `
   );
 `
 
+const cleanLicenceVersionPurposes = `
+  WITH licences_to_remove AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  )
+  DELETE FROM public.licence_version_purposes lvp
+    WHERE lvp.licence_version_id IN (
+      SELECT lv.id from public.licence_versions lv
+      INNER JOIN licences_to_remove ltr
+        ON ltr.licence_id = lv.licence_id
+    );
+`
+
 const cleanLicenceVersions = `
   WITH licences_to_remove AS (
     SELECT l.id AS licence_id
@@ -225,6 +225,44 @@ const cleanLicenceVersions = `
   )
   DELETE FROM public.licence_versions lv
     WHERE lv.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
+`
+
+const cleanLicenceVersionWorkflows = `
+  WITH nald_licence_versions AS (
+    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
+  ),
+  licences_to_remove AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  )
+  DELETE FROM public.workflows w
+  WHERE w.licence_version_id IN (
+    SELECT lv.id FROM public.licence_versions lv
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_versions nlv
+      WHERE lv.external_id = nlv.nald_id
+    )
+  )
+  OR w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
+`
+
+const cleanLicenceWorkflows = `
+  WITH licences_to_remove AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  )
+  DELETE FROM public.workflows w
+  WHERE w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
 `
 
 const cleanNaldLicenceVersionPurposeConditions = `
@@ -281,44 +319,6 @@ const cleanNaldLicenceVersions = `
       WHERE lv.external_id = nlv.nald_id
     );
 `
-const cleanLicenceVersionWorkflows = `
-  WITH nald_licence_versions AS (
-    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
-    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
-  ),
-  licences_to_remove AS (
-    SELECT l.id AS licence_id
-    FROM public.licences l
-    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  )
-  DELETE FROM public.workflows w
-  WHERE w.licence_version_id IN (
-    SELECT lv.id FROM public.licence_versions lv
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_versions nlv
-      WHERE lv.external_id = nlv.nald_id
-    )
-  )
-  OR w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
-`
-
-const cleanLicenceWorkflows = `
-  WITH licences_to_remove AS (
-    SELECT l.id AS licence_id
-    FROM public.licences l
-    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  )
-  DELETE FROM public.workflows w
-  WHERE w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
-`
-
 const cleanPermitLicences = `
   WITH licences_to_remove AS (
     SELECT l.licence_ref

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -227,19 +227,6 @@ const cleanLicenceVersions = `
     WHERE lv.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
 `
 
-const cleanLicenceWorkflows = `
-  WITH licences_to_remove AS (
-    SELECT l.id AS licence_id
-    FROM public.licences l
-    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  )
-  DELETE FROM public.workflows w
-  WHERE w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
-`
-
 const cleanNaldLicenceVersionPurposeConditions = `
   WITH nald_licence_version_purpose_conditions AS (
     SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
@@ -294,6 +281,43 @@ const cleanNaldLicenceVersions = `
       WHERE lv.external_id = nlv.nald_id
     );
 `
+const cleanLicenceVersionWorkflows = `
+  WITH nald_licence_versions AS (
+    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
+  ),
+  licences_to_remove AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  )
+  DELETE FROM public.workflows w
+  WHERE w.licence_version_id IN (
+    SELECT lv.id FROM public.licence_versions lv
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_versions nlv
+      WHERE lv.external_id = nlv.nald_id
+    )
+  )
+  OR w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
+`
+
+const cleanLicenceWorkflows = `
+  WITH licences_to_remove AS (
+    SELECT l.id AS licence_id
+    FROM public.licences l
+    WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+    AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  )
+  DELETE FROM public.workflows w
+  WHERE w.licence_id IN (SELECT ltr.licence_id FROM licences_to_remove ltr);
+`
 
 const cleanPermitLicences = `
   WITH licences_to_remove AS (
@@ -324,6 +348,7 @@ module.exports = {
   cleanLicenceVersionPurposeConditions,
   cleanLicenceVersionPurposePoints,
   cleanLicenceVersions,
+  cleanLicenceVersionWorkflows,
   cleanLicenceWorkflows,
   cleanNaldLicenceVersionPurposeConditions,
   cleanNaldLicenceVersionPurposePoints,

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -27,6 +27,9 @@ async function handler () {
     if (config.import.licences.isCleanLicenceImportsEnabled) {
       // NOTE: To improve performance these queries can all be run together as the data removed has no dependencies
       await Promise.all([
+        // Delete any charge elements linked to deleted NALD licences
+        pool.query(Queries.cleanChargeElements),
+
         // Delete any charge version notes linked to deleted NALD licences
         pool.query(Queries.cleanChargeVersionNotes),
 
@@ -39,30 +42,27 @@ async function handler () {
         // Delete any licence document roles linked to deleted NALD licences
         pool.query(Queries.cleanLicenceDocumentRoles),
 
-        // Delete any licence monitoring stations linked to deleted NALD licence version purpose conditions
+        // Delete any licence monitoring stations linked to deleted NALD licences
         pool.query(Queries.cleanLicenceMonitoringStations),
 
-        // Delete any licence version purpose points linked to deleted NALD licence version purposes
+        // Delete any licence version purpose points linked to deleted NALD licences
         pool.query(Queries.cleanLicenceVersionPurposePoints),
 
         // Delete any permit licences linked to deleted NALD licences
         pool.query(Queries.cleanPermitLicences),
 
-        // Delete any Workflows linked to deleted NALD licence versions
-        pool.query(Queries.cleanWorkflows)
+        // Delete any workflows linked to deleted NALD licences
+        pool.query(Queries.cleanLicenceWorkflows)
       ])
 
-      // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
+      // Delete any licence version purpose conditions linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceVersionPurposeConditions)
 
-      // Delete any licence version purposes linked to deleted NALD licence version purposes
+      // Delete any licence version purposes linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceVersionPurposes)
 
-      // Delete any licence versions linked to deleted NALD licence versions
+      // Delete any licence versions linked to deleted NALD licences
       await pool.query(Queries.cleanLicenceVersions)
-
-      // Delete any charge elements linked to deleted NALD licences
-      await pool.query(Queries.cleanChargeElements)
 
       // Delete any charge references linked to deleted NALD licences
       await pool.query(Queries.cleanChargeReferences)
@@ -75,6 +75,18 @@ async function handler () {
 
       // Delete any licences linked to deleted NALD licences
       await pool.query(Queries.cleanLicences)
+
+      // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
+      await pool.query(Queries.cleanNaldLicenceVersionPurposeConditions)
+
+      // Delete any licence version purpose points linked to deleted NALD licence version purposes
+      await pool.query(Queries.cleanNaldLicenceVersionPurposePoints)
+
+      // Delete any licence version purposes linked to deleted NALD licence version purposes
+      await pool.query(Queries.cleanNaldLicenceVersionPurposes)
+
+      // Delete any licence versions linked to deleted NALD licence versions
+      await pool.query(Queries.cleanNaldLicenceVersions)
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -85,6 +85,9 @@ async function handler () {
       // Delete any licence version purposes linked to deleted NALD licence version purposes
       await pool.query(Queries.cleanNaldLicenceVersionPurposes)
 
+      // Delete any workflows linked to deleted NALD licence versions
+      await pool.query(Queries.cleanLicenceVersionWorkflows)
+
       // Delete any licence versions linked to deleted NALD licence versions
       await pool.query(Queries.cleanNaldLicenceVersions)
     }

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -48,11 +48,11 @@ async function handler () {
         // Delete any licence version purpose points linked to deleted NALD licences
         pool.query(Queries.cleanLicenceVersionPurposePoints),
 
-        // Delete any permit licences linked to deleted NALD licences
-        pool.query(Queries.cleanPermitLicences),
-
         // Delete any workflows linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceWorkflows)
+        pool.query(Queries.cleanLicenceWorkflows),
+
+        // Delete any permit licences linked to deleted NALD licences
+        pool.query(Queries.cleanPermitLicences)
       ])
 
       // Delete any licence version purpose conditions linked to deleted NALD licences


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4734

Update the `licence-import` process to identify records in the `licences` table that no longer exist in NALD and remove those records.

If the licence has been involved in a bill run, has a return version, or is linked to an external entity, it should not be removed. All child records also need to be removed.

This functionality will temporarily be behind a feature flag `CLEAN_LICENCE_IMPORTS` which will need to be set to `true` for the new code to run.