### PR TITLE
Cleanup licence data removed from NALD

### DIFF
--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -286,9 +286,8 @@ const cleanNaldLicenceVersionPurposeConditions = `
       ON lvp.licence_version_id = lv.id
     INNER JOIN public.licences l
       ON lv.licence_id = l.id
-    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+    INNER JOIN "import"."NALD_ABS_LICENCES" nal
+      ON l.licence_ref = nal."LIC_NO"
   ),
   nald_licence_version_purpose_conditions AS (
     SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -287,16 +287,23 @@ const cleanLicenceWorkflows = `
 `
 
 const cleanNaldLicenceVersionPurposeConditions = `
-  WITH nald_licence_version_purpose_conditions AS (
-    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
-    FROM "import"."NALD_LIC_CONDITIONS" nlc
+  WITH purposes_safe_to_remove AS (
+    SELECT lvp.id AS licence_version_purpose_id FROM public.licence_version_purposes lvp
+    INNER JOIN public.licence_versions lv
+      ON lvp.licence_version_id = lv.id
+    INNER JOIN public.licences l
+      ON lv.licence_id = l.id
+    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  ),
+  nald_licence_version_purpose_conditions AS (
+    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id FROM "import"."NALD_LIC_CONDITIONS" nlc
   )
   DELETE FROM public.licence_version_purpose_conditions lvpc
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_version_purpose_conditions nlvpc
-      WHERE lvpc.external_id = nlvpc.nald_id
-    );
+  WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purpose_conditions nlvpc WHERE nlvpc.nald_id = lvpc.external_id)
+  AND NOT EXISTS (SELECT 1 FROM public.licence_monitoring_stations lms WHERE lms.licence_version_purpose_condition_id = lvpc.id)
+  AND lvpc.licence_version_purpose_id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
 `
 
 const cleanNaldLicenceVersionPurposePoints = `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -337,16 +337,26 @@ const cleanNaldLicenceVersionPurposePoints = `
 `
 
 const cleanNaldLicenceVersionPurposes = `
-  WITH nald_licence_version_purposes AS (
-    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
-    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
-  )
-  DELETE FROM public.licence_version_purposes lvp
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_version_purposes nlvp
-      WHERE lvp.external_id = nlvp.nald_id
-    );
+WITH purposes_safe_to_remove AS (
+  SELECT lvp.id AS licence_version_purpose_id
+  FROM public.licence_version_purposes lvp
+  INNER JOIN public.licence_versions lv
+    ON lvp.licence_version_id = lv.id
+  INNER JOIN public.licences l
+    ON lv.licence_id = l.id
+  WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+  AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+  AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id = lvp.id)
+  AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_points lvpp WHERE lvpp.licence_version_purpose_id = lvp.id)
+),
+nald_licence_version_purposes AS (
+  SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
+  FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
+)
+DELETE FROM public.licence_version_purposes lvp
+WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purposes nlvp WHERE lvp.external_id = nlvp.nald_id)
+AND lvp.id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
 `
 
 const cleanNaldLicenceVersions = `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -334,10 +334,9 @@ const cleanNaldLicenceVersionPurposes = `
       ON lvp.licence_version_id = lv.id
     INNER JOIN public.licences l
       ON lv.licence_id = l.id
-    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id = lvp.id)
+    INNER JOIN "import"."NALD_ABS_LICENCES" nal
+      ON l.licence_ref = nal."LIC_NO"
+    WHERE NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id = lvp.id)
     AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_points lvpp WHERE lvpp.licence_version_purpose_id = lvp.id)
   ),
   nald_licence_version_purposes AS (

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -313,10 +313,9 @@ const cleanNaldLicenceVersionPurposePoints = `
       ON lvp.licence_version_id = lv.id
     INNER JOIN public.licences l
       ON lv.licence_id = l.id
-    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-    AND NOT EXISTS (SELECT 1 FROM purposes_not_to_remove pntr WHERE pntr.licence_version_purpose_id = lvp.id)
+    INNER JOIN "import"."NALD_ABS_LICENCES" nal
+      ON l.licence_ref = nal."LIC_NO"
+    WHERE NOT EXISTS (SELECT 1 FROM purposes_not_to_remove pntr WHERE pntr.licence_version_purpose_id = lvp.id)
   ),
   nald_licence_version_purpose_points AS (
     SELECT CONCAT_WS(':', napp."FGAC_REGION_CODE", napp."AABP_ID", napp."AAIP_ID") AS nald_id

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -256,11 +256,7 @@ const cleanLicenceVersionWorkflows = `
   DELETE FROM public.workflows w
   WHERE w.licence_version_id IN (
     SELECT lv.id FROM public.licence_versions lv
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_versions nlv
-      WHERE lv.external_id = nlv.nald_id
-    )
+    WHERE NOT EXISTS (SELECT 1 FROM nald_licence_versions nlv WHERE lv.external_id = nlv.nald_id)
     AND NOT EXISTS (SELECT 1 FROM public.licence_version_purposes lvp WHERE lvp.licence_version_id = lv.id)
   );
 `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -173,11 +173,11 @@ const cleanLicenceMonitoringStationsPassTwo = `
 `
 
 const cleanLicences = `
-DELETE FROM public.licences l
-WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
-AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL);
+  DELETE FROM public.licences l
+  WHERE NOT EXISTS (SELECT 1 FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = l.licence_ref)
+  AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+  AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+  AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL);
 `
 
 const cleanLicenceVersionPurposeConditions = `
@@ -249,20 +249,20 @@ const cleanLicenceVersions = `
 `
 
 const cleanLicenceVersionWorkflows = `
-WITH nald_licence_versions AS (
-  SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
-  FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
-)
-DELETE FROM public.workflows w
-WHERE w.licence_version_id IN (
-  SELECT lv.id FROM public.licence_versions lv
-  WHERE NOT EXISTS (
-    SELECT 1
-    FROM nald_licence_versions nlv
-    WHERE lv.external_id = nlv.nald_id
+  WITH nald_licence_versions AS (
+    SELECT CONCAT_WS(':', nalv."FGAC_REGION_CODE", nalv."AABL_ID", nalv."ISSUE_NO", nalv."INCR_NO") AS nald_id
+    FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
   )
-  AND NOT EXISTS (SELECT 1 FROM public.licence_version_purposes lvp WHERE lvp.licence_version_id = lv.id)
-);
+  DELETE FROM public.workflows w
+  WHERE w.licence_version_id IN (
+    SELECT lv.id FROM public.licence_versions lv
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM nald_licence_versions nlv
+      WHERE lv.external_id = nlv.nald_id
+    )
+    AND NOT EXISTS (SELECT 1 FROM public.licence_version_purposes lvp WHERE lvp.licence_version_id = lv.id)
+  );
 `
 
 const cleanLicenceWorkflows = `
@@ -329,26 +329,26 @@ const cleanNaldLicenceVersionPurposePoints = `
 `
 
 const cleanNaldLicenceVersionPurposes = `
-WITH purposes_safe_to_remove AS (
-  SELECT lvp.id AS licence_version_purpose_id
-  FROM public.licence_version_purposes lvp
-  INNER JOIN public.licence_versions lv
-    ON lvp.licence_version_id = lv.id
-  INNER JOIN public.licences l
-    ON lv.licence_id = l.id
-  WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-  AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-  AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id = lvp.id)
-  AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_points lvpp WHERE lvpp.licence_version_purpose_id = lvp.id)
-),
-nald_licence_version_purposes AS (
-  SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
-  FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
-)
-DELETE FROM public.licence_version_purposes lvp
-WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purposes nlvp WHERE lvp.external_id = nlvp.nald_id)
-AND lvp.id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
+  WITH purposes_safe_to_remove AS (
+    SELECT lvp.id AS licence_version_purpose_id
+    FROM public.licence_version_purposes lvp
+    INNER JOIN public.licence_versions lv
+      ON lvp.licence_version_id = lv.id
+    INNER JOIN public.licences l
+      ON lv.licence_id = l.id
+    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id = lvp.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_version_purpose_points lvpp WHERE lvpp.licence_version_purpose_id = lvp.id)
+  ),
+  nald_licence_version_purposes AS (
+    SELECT CONCAT(nalp."FGAC_REGION_CODE", ':', nalp."ID") AS nald_id
+    FROM "import"."NALD_ABS_LIC_PURPOSES" nalp
+  )
+  DELETE FROM public.licence_version_purposes lvp
+  WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purposes nlvp WHERE lvp.external_id = nlvp.nald_id)
+  AND lvp.id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
 `
 
 const cleanNaldLicenceVersions = `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -155,9 +155,8 @@ const cleanLicenceMonitoringStationsPassTwo = `
   WITH licences_safe_to_remove AS (
     SELECT l.id AS licence_id
     FROM public.licences l
-    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+    INNER JOIN "import"."NALD_ABS_LICENCES" nal
+    ON l.licence_ref = nal."LIC_NO"
   ),
   nald_licence_version_purpose_conditions AS (
     SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -309,31 +309,31 @@ const cleanNaldLicenceVersionPurposeConditions = `
 `
 
 const cleanNaldLicenceVersionPurposePoints = `
-WITH purposes_not_to_remove AS (
-  SELECT lvpc.licence_version_purpose_id
-  FROM public.licence_version_purpose_conditions lvpc
-  INNER JOIN public.licence_monitoring_stations lms
-    ON lms.licence_version_purpose_condition_id = lvpc.id
-),
-purposes_safe_to_remove AS (
-  SELECT lvp.id AS licence_version_purpose_id
-  FROM public.licence_version_purposes lvp
-  INNER JOIN public.licence_versions lv
-    ON lvp.licence_version_id = lv.id
-  INNER JOIN public.licences l
-    ON lv.licence_id = l.id
-  WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-  AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
-  AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
-  AND NOT EXISTS (SELECT 1 FROM purposes_not_to_remove pntr WHERE pntr.licence_version_purpose_id = lvp.id)
-),
-nald_licence_version_purpose_points AS (
-  SELECT CONCAT_WS(':', napp."FGAC_REGION_CODE", napp."AABP_ID", napp."AAIP_ID") AS nald_id
-  FROM "import"."NALD_ABS_PURP_POINTS" napp
-)
-DELETE FROM public.licence_version_purpose_points lvpp
-WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purpose_points nlvpp WHERE lvpp.external_id = nlvpp.nald_id)
-AND lvpp.licence_version_purpose_id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
+  WITH purposes_not_to_remove AS (
+    SELECT lvpc.licence_version_purpose_id
+    FROM public.licence_version_purpose_conditions lvpc
+    INNER JOIN public.licence_monitoring_stations lms
+      ON lms.licence_version_purpose_condition_id = lvpc.id
+  ),
+  purposes_safe_to_remove AS (
+    SELECT lvp.id AS licence_version_purpose_id
+    FROM public.licence_version_purposes lvp
+    INNER JOIN public.licence_versions lv
+      ON lvp.licence_version_id = lv.id
+    INNER JOIN public.licences l
+      ON lv.licence_id = l.id
+    WHERE NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
+    AND NOT EXISTS (SELECT 1 FROM purposes_not_to_remove pntr WHERE pntr.licence_version_purpose_id = lvp.id)
+  ),
+  nald_licence_version_purpose_points AS (
+    SELECT CONCAT_WS(':', napp."FGAC_REGION_CODE", napp."AABP_ID", napp."AAIP_ID") AS nald_id
+    FROM "import"."NALD_ABS_PURP_POINTS" napp
+  )
+  DELETE FROM public.licence_version_purpose_points lvpp
+  WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purpose_points nlvpp WHERE lvpp.external_id = nlvpp.nald_id)
+  AND lvpp.licence_version_purpose_id IN (SELECT pstr.licence_version_purpose_id FROM purposes_safe_to_remove pstr);
 `
 
 const cleanNaldLicenceVersionPurposes = `

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -288,7 +288,8 @@ const cleanLicenceWorkflows = `
 
 const cleanNaldLicenceVersionPurposeConditions = `
   WITH purposes_safe_to_remove AS (
-    SELECT lvp.id AS licence_version_purpose_id FROM public.licence_version_purposes lvp
+    SELECT lvp.id AS licence_version_purpose_id
+    FROM public.licence_version_purposes lvp
     INNER JOIN public.licence_versions lv
       ON lvp.licence_version_id = lv.id
     INNER JOIN public.licences l
@@ -298,7 +299,8 @@ const cleanNaldLicenceVersionPurposeConditions = `
     AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
   ),
   nald_licence_version_purpose_conditions AS (
-    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id FROM "import"."NALD_LIC_CONDITIONS" nlc
+    SELECT CONCAT_WS(':', nlc."ID", nlc."FGAC_REGION_CODE", nlc."AABP_ID") AS nald_id
+    FROM "import"."NALD_LIC_CONDITIONS" nlc
   )
   DELETE FROM public.licence_version_purpose_conditions lvpc
   WHERE NOT EXISTS (SELECT 1 FROM nald_licence_version_purpose_conditions nlvpc WHERE nlvpc.nald_id = lvpc.external_id)

--- a/src/modules/licence-import/connectors/queries/clean-queries.js
+++ b/src/modules/licence-import/connectors/queries/clean-queries.js
@@ -357,11 +357,8 @@ const cleanNaldLicenceVersions = `
     FROM "import"."NALD_ABS_LIC_VERSIONS" nalv
   )
   DELETE FROM public.licence_versions lv
-    WHERE NOT EXISTS (
-      SELECT 1
-      FROM nald_licence_versions nlv
-      WHERE lv.external_id = nlv.nald_id
-    );
+    WHERE NOT EXISTS (SELECT 1 FROM nald_licence_versions nlv WHERE lv.external_id = nlv.nald_id)
+    AND NOT EXISTS (SELECT 1 FROM public.licence_version_purposes lvp WHERE lvp.licence_version_id = lv.id);
 `
 const cleanPermitLicences = `
   WITH licences_to_remove AS (

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -76,6 +76,9 @@ async function handler () {
       // Delete any licences linked to deleted NALD licences
       await pool.query(Queries.cleanLicences)
 
+      // Delete any soft deleted licence monitoring stations linked to deleted NALD licence version purpose conditions
+      await pool.query(Queries.cleanLicenceMonitoringStationsPassTwo)
+
       // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
       await pool.query(Queries.cleanNaldLicenceVersionPurposeConditions)
 

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -25,79 +25,86 @@ async function handler () {
     await pool.query(Queries.cleanCrmV2Documents)
 
     if (config.import.licences.isCleanLicenceImportsEnabled) {
-      // NOTE: To improve performance these queries can all be run together as the data removed has no dependencies
-      await Promise.all([
-        // Delete any charge elements linked to deleted NALD licences
-        pool.query(Queries.cleanChargeElements),
-
-        // Delete any charge version notes linked to deleted NALD licences
-        pool.query(Queries.cleanChargeVersionNotes),
-
-        // Delete any licence agreements linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceAgreements),
-
-        // Delete any licence document headers linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceDocumentHeaders),
-
-        // Delete any licence document roles linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceDocumentRoles),
-
-        // Delete any licence monitoring stations linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceMonitoringStations),
-
-        // Delete any licence version purpose points linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceVersionPurposePoints),
-
-        // Delete any workflows linked to deleted NALD licences
-        pool.query(Queries.cleanLicenceWorkflows),
-
-        // Delete any permit licences linked to deleted NALD licences
-        pool.query(Queries.cleanPermitLicences)
-      ])
-
-      // Delete any licence version purpose conditions linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceVersionPurposeConditions)
-
-      // Delete any licence version purposes linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceVersionPurposes)
-
-      // Delete any licence versions linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceVersions)
-
-      // Delete any charge references linked to deleted NALD licences
-      await pool.query(Queries.cleanChargeReferences)
-
-      // Delete any charge versions linked to deleted NALD licences
-      await pool.query(Queries.cleanChargeVersions)
-
-      // Delete any licence documents linked to deleted NALD licences
-      await pool.query(Queries.cleanLicenceDocuments)
-
-      // Delete any licences linked to deleted NALD licences
-      await pool.query(Queries.cleanLicences)
-
-      // Delete any soft deleted licence monitoring stations linked to deleted NALD licence version purpose conditions
-      await pool.query(Queries.cleanLicenceMonitoringStationsPassTwo)
-
-      // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
-      await pool.query(Queries.cleanNaldLicenceVersionPurposeConditions)
-
-      // Delete any licence version purpose points linked to deleted NALD licence version purpose points
-      await pool.query(Queries.cleanNaldLicenceVersionPurposePoints)
-
-      // Delete any licence version purposes linked to deleted NALD licence version purposes
-      await pool.query(Queries.cleanNaldLicenceVersionPurposes)
-
-      // Delete any workflows linked to deleted NALD licence versions
-      await pool.query(Queries.cleanLicenceVersionWorkflows)
-
-      // Delete any licence versions linked to deleted NALD licence versions
-      await pool.query(Queries.cleanNaldLicenceVersions)
+      await _cleanDeletedLicences()
+      await _cleanDeletedLicenceVersionData()
     }
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error
   }
+}
+
+async function _cleanDeletedLicences () {
+  // NOTE: To improve performance these queries can all be run together as the data removed has no dependencies
+  await Promise.all([
+    // Delete any charge elements linked to deleted NALD licences
+    pool.query(Queries.cleanChargeElements),
+
+    // Delete any charge version notes linked to deleted NALD licences
+    pool.query(Queries.cleanChargeVersionNotes),
+
+    // Delete any licence agreements linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceAgreements),
+
+    // Delete any licence document headers linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceDocumentHeaders),
+
+    // Delete any licence document roles linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceDocumentRoles),
+
+    // Delete any licence monitoring stations linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceMonitoringStations),
+
+    // Delete any licence version purpose points linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceVersionPurposePoints),
+
+    // Delete any workflows linked to deleted NALD licences
+    pool.query(Queries.cleanLicenceWorkflows),
+
+    // Delete any permit licences linked to deleted NALD licences
+    pool.query(Queries.cleanPermitLicences)
+  ])
+
+  // Delete any licence version purpose conditions linked to deleted NALD licences
+  await pool.query(Queries.cleanLicenceVersionPurposeConditions)
+
+  // Delete any licence version purposes linked to deleted NALD licences
+  await pool.query(Queries.cleanLicenceVersionPurposes)
+
+  // Delete any licence versions linked to deleted NALD licences
+  await pool.query(Queries.cleanLicenceVersions)
+
+  // Delete any charge references linked to deleted NALD licences
+  await pool.query(Queries.cleanChargeReferences)
+
+  // Delete any charge versions linked to deleted NALD licences
+  await pool.query(Queries.cleanChargeVersions)
+
+  // Delete any licence documents linked to deleted NALD licences
+  await pool.query(Queries.cleanLicenceDocuments)
+
+  // Delete any licences linked to deleted NALD licences
+  await pool.query(Queries.cleanLicences)
+}
+
+async function _cleanDeletedLicenceVersionData () {
+  // Delete any soft deleted licence monitoring stations linked to deleted NALD licence version purpose conditions
+  await pool.query(Queries.cleanLicenceMonitoringStationsPassTwo)
+
+  // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
+  await pool.query(Queries.cleanNaldLicenceVersionPurposeConditions)
+
+  // Delete any licence version purpose points linked to deleted NALD licence version purpose points
+  await pool.query(Queries.cleanNaldLicenceVersionPurposePoints)
+
+  // Delete any licence version purposes linked to deleted NALD licence version purposes
+  await pool.query(Queries.cleanNaldLicenceVersionPurposes)
+
+  // Delete any workflows linked to deleted NALD licence versions
+  await pool.query(Queries.cleanLicenceVersionWorkflows)
+
+  // Delete any licence versions linked to deleted NALD licence versions
+  await pool.query(Queries.cleanNaldLicenceVersions)
 }
 
 async function onComplete (messageQueue, job) {

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -82,7 +82,7 @@ async function handler () {
       // Delete any licence version purpose conditions linked to deleted NALD licence version purpose conditions
       await pool.query(Queries.cleanNaldLicenceVersionPurposeConditions)
 
-      // Delete any licence version purpose points linked to deleted NALD licence version purposes
+      // Delete any licence version purpose points linked to deleted NALD licence version purpose points
       await pool.query(Queries.cleanNaldLicenceVersionPurposePoints)
 
       // Delete any licence version purposes linked to deleted NALD licence version purposes


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4662

Following a requirements analysis meeting on November 21st, we need to update the queries we have written to remove licence data from WRLS that no longer exists in NALD.

A PR that deals with the scenario where the licence record has been removed from NALD has already been completed in PR https://github.com/DEFRA/water-abstraction-import/pull/1044

This PR will focus on the child records of the licence that may have been removed from NALD while the licence remains. The exception to this would be a licence that has been removed from NALD but has not been removed from WRLS as it has been involved in a bill run, has a return version, or is linked to an external entity.

The individual tickets covered by this PR are:
- https://eaflood.atlassian.net/browse/WATER-4726
- https://eaflood.atlassian.net/browse/WATER-4751
- https://eaflood.atlassian.net/browse/WATER-4732
- https://eaflood.atlassian.net/browse/WATER-4733