### PR TITLE
Trigger new licence end date change endpoints

### DIFF
--- a/src/lib/services/water-system-service.js
+++ b/src/lib/services/water-system-service.js
@@ -4,15 +4,12 @@ const { serviceRequest } = require('@envage/water-abstraction-helpers')
 
 const config = require('../../../config')
 
-const postImportLicence = async (data) => {
-  const url = new URL(`${config.services.system}/import/licence/legacy`)
+const postLicencesEndDatesCheck = async () => {
+  const url = new URL(`${config.services.system}/licences/end-dates/check`)
 
-  return serviceRequest.post(url.href, {
-    body: data,
-    resolveWithFullResponse: true
-  })
+  return serviceRequest.post(url.href)
 }
 
 module.exports = {
-  postImportLicence
+  postLicencesEndDatesCheck
 }

--- a/src/lib/services/water-system-service.js
+++ b/src/lib/services/water-system-service.js
@@ -10,6 +10,13 @@ const postLicencesEndDatesCheck = async () => {
   return serviceRequest.post(url.href)
 }
 
+const postLicencesEndDatesProcess = async () => {
+  const url = new URL(`${config.services.system}/licences/end-dates/process`)
+
+  return serviceRequest.post(url.href)
+}
+
 module.exports = {
-  postLicencesEndDatesCheck
+  postLicencesEndDatesCheck,
+  postLicencesEndDatesProcess
 }

--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -3,7 +3,7 @@
 const config = require('../../../../config')
 const { pool } = require('../../../lib/connectors/db')
 const Queries = require('../connectors/queries/clean-queries.js')
-const ImportPurposeConditionTypesJob = require('./import-purpose-condition-types.js')
+const TriggerEndDateProcessJob = require('./trigger-end-date-process.js')
 
 const JOB_NAME = 'licence-import.clean'
 
@@ -109,7 +109,7 @@ async function _cleanDeletedLicenceVersionData () {
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
-    await messageQueue.publish(ImportPurposeConditionTypesJob.createMessage())
+    await messageQueue.publish(TriggerEndDateProcessJob.createMessage())
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/licence-import/jobs/trigger-end-date-process.js
+++ b/src/modules/licence-import/jobs/trigger-end-date-process.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const ImportPurposeConditionTypesJob = require('./import-purpose-condition-types.js')
+const WaterSystemService = require('../../../lib/services/water-system-service.js')
+
+const JOB_NAME = 'licence-import.trigger-end-date-process'
+
+function createMessage () {
+  return {
+    name: JOB_NAME,
+    options: {
+      singletonKey: JOB_NAME,
+      expireIn: '1 hours'
+    }
+  }
+}
+
+async function handler () {
+  try {
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
+
+    await WaterSystemService.postLicencesEndDatesProcess()
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+async function onComplete (messageQueue, job) {
+  if (!job.failed) {
+    await messageQueue.publish(ImportPurposeConditionTypesJob.createMessage())
+  }
+
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
+}
+
+module.exports = {
+  createMessage,
+  handler,
+  onComplete,
+  name: JOB_NAME
+}

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -6,6 +6,7 @@ const extractService = require('../services/extract-service.js')
 const ImportLicenceJob = require('./import-licence.js')
 const QueueLicences = require('./queue-licences')
 const s3Service = require('../services/s3-service.js')
+const TriggerEndDateCheckJob = require('./trigger-end-date-check.js')
 
 const JOB_NAME = 'nald-import.s3-download'
 
@@ -50,13 +51,14 @@ async function onComplete (messageQueue, job) {
     if (isRequired) {
       // Delete existing PG boss import queues
       await Promise.all([
-        messageQueue.deleteQueue(ImportLicenceJob.name),
+        messageQueue.deleteQueue(TriggerEndDateCheckJob.name),
         messageQueue.deleteQueue(DeleteRemovedDocumentsJob.name),
-        messageQueue.deleteQueue(QueueLicences.name)
+        messageQueue.deleteQueue(QueueLicences.name),
+        messageQueue.deleteQueue(ImportLicenceJob.name)
       ])
 
-      // Publish a new job to delete any removed documents
-      await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(replicateReturns))
+      // Publish a new job to trigger the licences end date check
+      await messageQueue.publish(TriggerEndDateCheckJob.createMessage(replicateReturns))
     }
   }
 

--- a/src/modules/nald-import/jobs/trigger-end-date-check.js
+++ b/src/modules/nald-import/jobs/trigger-end-date-check.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const DeleteRemovedDocumentsJob = require('./delete-removed-documents.js')
+const WaterSystemService = require('../../../lib/services/water-system-service.js')
+
+const JOB_NAME = 'nald-import.trigger-end-date-check'
+
+function createMessage (replicateReturns) {
+  return {
+    name: JOB_NAME,
+    options: {
+      expireIn: '1 hours',
+      singletonKey: JOB_NAME
+    },
+    data: {
+      replicateReturns
+    }
+  }
+}
+
+async function handler () {
+  try {
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
+
+    await WaterSystemService.postLicencesEndDatesCheck()
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+async function onComplete (messageQueue, job) {
+  if (!job.failed) {
+    const { replicateReturns } = job.data.request.data
+
+    // Publish a new job to delete any removed documents
+    await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(replicateReturns))
+  }
+
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
+}
+
+module.exports = {
+  createMessage,
+  handler,
+  onComplete,
+  name: JOB_NAME
+}

--- a/test/modules/licence-import/jobs/clean.test.js
+++ b/test/modules/licence-import/jobs/clean.test.js
@@ -109,12 +109,12 @@ experiment('Licence Import: Clean', () => {
         expect(message).to.equal('licence-import.clean: finished')
       })
 
-      test('the import purpose condition types job is published to the queue', async () => {
+      test('the trigger end date process job is published to the queue', async () => {
         await CleanJob.onComplete(messageQueue, job)
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('licence-import.import-purpose-condition-types')
+        expect(jobMessage.name).to.equal('licence-import.trigger-end-date-process')
       })
 
       experiment('but an error is thrown', () => {

--- a/test/modules/licence-import/jobs/trigger-end-date-process.test.js
+++ b/test/modules/licence-import/jobs/trigger-end-date-process.test.js
@@ -1,0 +1,150 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const WaterSystemService = require('../../../../src/lib/services/water-system-service.js')
+
+// Thing under test
+const TriggerEndDateProcessJob = require('../../../../src/modules/licence-import/jobs/trigger-end-date-process.js')
+
+experiment('Licence Import: Trigger End Date Process', () => {
+  let notifierStub
+
+  beforeEach(async () => {
+    Sinon.stub(WaterSystemService, 'postLicencesEndDatesProcess').resolves()
+
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+    delete global.GlobalNotifier
+  })
+
+  experiment('.createMessage', () => {
+    test('formats a message for PG boss', async () => {
+      const message = TriggerEndDateProcessJob.createMessage()
+
+      expect(message).to.equal({
+        name: 'licence-import.trigger-end-date-process',
+        options: {
+          expireIn: '1 hours',
+          singletonKey: 'licence-import.trigger-end-date-process'
+        }
+      })
+    })
+  })
+
+  experiment('.handler', () => {
+    experiment('when the job is successful', () => {
+      test('a message is logged', async () => {
+        await TriggerEndDateProcessJob.handler()
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('licence-import.trigger-end-date-process: started')
+      })
+
+      test('triggers the end date process', async () => {
+        await TriggerEndDateProcessJob.handler()
+
+        expect(WaterSystemService.postLicencesEndDatesProcess.called).to.equal(true)
+      })
+    })
+
+    experiment('when the job fails', () => {
+      const err = new Error('Oops!')
+
+      beforeEach(async () => {
+        WaterSystemService.postLicencesEndDatesProcess.throws(err)
+      })
+
+      test('logs an error message', async () => {
+        await expect(TriggerEndDateProcessJob.handler()).to.reject()
+
+        expect(notifierStub.omfg.calledWith(
+          'licence-import.trigger-end-date-process: errored', err
+        )).to.equal(true)
+      })
+
+      test('rethrows the error', async () => {
+        const err = await expect(TriggerEndDateProcessJob.handler()).to.reject()
+
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+
+  experiment('.onComplete', () => {
+    let job
+    let messageQueue
+
+    beforeEach(async () => {
+      messageQueue = {
+        publish: Sinon.stub()
+      }
+    })
+
+    experiment('when the job succeeds', () => {
+      beforeEach(async () => {
+        job = {
+          failed: false,
+          data: { request: { data: { replicateReturns: false } } }
+        }
+      })
+
+      test('a message is logged', async () => {
+        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('licence-import.trigger-end-date-process: finished')
+      })
+
+      test('the Import Purpose Condition Types job is published to the queue', async () => {
+        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
+
+        const jobMessage = messageQueue.publish.lastCall.args[0]
+
+        expect(jobMessage.name).to.equal('licence-import.import-purpose-condition-types')
+      })
+
+      experiment('but an error is thrown', () => {
+        const err = new Error('oops')
+
+        beforeEach(async () => {
+          messageQueue.publish.rejects(err)
+        })
+
+        test('rethrows the error', async () => {
+          const error = await expect(TriggerEndDateProcessJob.onComplete(messageQueue, job)).to.reject()
+
+          expect(error).to.equal(error)
+        })
+      })
+    })
+
+    experiment('when the job fails', () => {
+      beforeEach(async () => {
+        job = { failed: true }
+      })
+
+      test('no further jobs are published', async () => {
+        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
+
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/plugin.test.js
+++ b/test/modules/licence-import/plugin.test.js
@@ -16,6 +16,7 @@ const ImportLicenceJob = require('../../../src/modules/licence-import/jobs/impor
 const ImportPurposeConditionTypesJob = require('../../../src/modules/licence-import/jobs/import-purpose-condition-types.js')
 const QueueCompaniesJob = require('../../../src/modules/licence-import/jobs/queue-companies.js')
 const QueueLicencesJob = require('../../../src/modules/licence-import/jobs/queue-licences.js')
+const TriggerEndDateProcessJob = require('../../../src/modules/licence-import/jobs/trigger-end-date-process.js')
 
 // Things we need to stub
 const cron = require('node-cron')
@@ -76,11 +77,37 @@ experiment('modules/licence-import/plugin.js', () => {
       })
     })
 
-    experiment('for Import Purpose Condition Types', () => {
+    experiment('for Trigger End Date Process', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
         const subscribeArgs = server.messageQueue.subscribe.getCall(1).args
+
+        expect(subscribeArgs[0]).to.equal(TriggerEndDateProcessJob.name)
+        expect(subscribeArgs[1]).to.equal(TriggerEndDateProcessJob.handler)
+      })
+
+      test('registers its onComplete for the job', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
+
+        expect(onCompleteArgs[0]).to.equal(TriggerEndDateProcessJob.name)
+        expect(onCompleteArgs[1]).to.be.a.function()
+      })
+
+      test('schedules the job to be published', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        expect(cron.schedule.calledWith(config.import.licences.schedule)).to.be.true()
+      })
+    })
+
+    experiment('for Import Purpose Condition Types', () => {
+      test('subscribes its handler to the job queue', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
 
         expect(subscribeArgs[0]).to.equal(ImportPurposeConditionTypesJob.name)
         expect(subscribeArgs[1]).to.equal(ImportPurposeConditionTypesJob.handler)
@@ -89,7 +116,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
 
         expect(onCompleteArgs[0]).to.equal(ImportPurposeConditionTypesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -100,7 +127,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
 
         expect(subscribeArgs[0]).to.equal(QueueCompaniesJob.name)
         expect(subscribeArgs[1]).to.equal(QueueCompaniesJob.handler)
@@ -109,7 +136,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(3).args
 
         expect(onCompleteArgs[0]).to.equal(QueueCompaniesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -120,7 +147,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler and options to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
 
         expect(subscribeArgs[0]).to.equal(ImportCompanyJob.name)
         expect(subscribeArgs[1]).to.equal(ImportCompanyJob.options)
@@ -130,7 +157,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(3).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(4).args
 
         expect(onCompleteArgs[0]).to.equal(ImportCompanyJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -141,7 +168,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(5).args
 
         expect(subscribeArgs[0]).to.equal(QueueLicencesJob.name)
         expect(subscribeArgs[1]).to.equal(QueueLicencesJob.handler)
@@ -150,7 +177,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(4).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(5).args
 
         expect(onCompleteArgs[0]).to.equal(QueueLicencesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -161,7 +188,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler and options to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(5).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(6).args
 
         expect(subscribeArgs[0]).to.equal(ImportLicenceJob.name)
         expect(subscribeArgs[1]).to.equal(ImportLicenceJob.options)

--- a/test/modules/nald-import/jobs/s3-download.test.js
+++ b/test/modules/nald-import/jobs/s3-download.test.js
@@ -325,17 +325,18 @@ experiment('NALD Import: S3 Download job', () => {
         test('the existing job queues are deleted', async () => {
           await S3DownloadJob.onComplete(messageQueue, job)
 
-          expect(messageQueue.deleteQueue.calledWith('nald-import.import-licence')).to.be.true()
-          expect(messageQueue.deleteQueue.calledWith('nald-import.queue-licences')).to.be.true()
+          expect(messageQueue.deleteQueue.calledWith('nald-import.trigger-end-date-check')).to.be.true()
           expect(messageQueue.deleteQueue.calledWith('nald-import.delete-removed-documents')).to.be.true()
+          expect(messageQueue.deleteQueue.calledWith('nald-import.queue-licences')).to.be.true()
+          expect(messageQueue.deleteQueue.calledWith('nald-import.import-licence')).to.be.true()
         })
 
-        test('the delete removed documents job is published to the queue', async () => {
+        test('the trigger end date check job is published to the queue', async () => {
           await S3DownloadJob.onComplete(messageQueue, job)
 
           const jobMessage = messageQueue.publish.lastCall.args[0]
 
-          expect(jobMessage.name).to.equal('nald-import.delete-removed-documents')
+          expect(jobMessage.name).to.equal('nald-import.trigger-end-date-check')
         })
 
         experiment('but an error is thrown', () => {

--- a/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
+++ b/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
@@ -61,7 +61,7 @@ experiment('NALD Import: Trigger End Date Check job', () => {
         expect(message).to.equal('nald-import.trigger-end-date-check: started')
       })
 
-      test('deletes the removed documents', async () => {
+      test('triggers the end date checks', async () => {
         await TriggerEndDateCheckJob.handler()
 
         expect(WaterSystemService.postLicencesEndDatesCheck.called).to.equal(true)

--- a/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
+++ b/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
@@ -1,0 +1,155 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const WaterSystemService = require('../../../../src/lib/services/water-system-service.js')
+
+// Thing under test
+const TriggerEndDateCheckJob = require('../../../../src/modules/nald-import/jobs/trigger-end-date-check.js')
+
+experiment('NALD Import: Trigger End Date Check job', () => {
+  const replicateReturns = false
+
+  let notifierStub
+
+  beforeEach(async () => {
+    Sinon.stub(WaterSystemService, 'postLicencesEndDatesCheck').resolves()
+
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+    delete global.GlobalNotifier
+  })
+
+  experiment('.createMessage', () => {
+    test('formats a message for PG boss', async () => {
+      const message = TriggerEndDateCheckJob.createMessage(replicateReturns)
+
+      expect(message).to.equal({
+        name: 'nald-import.trigger-end-date-check',
+        options: {
+          expireIn: '1 hours',
+          singletonKey: 'nald-import.trigger-end-date-check'
+        },
+        data: {
+          replicateReturns: false
+        }
+      })
+    })
+  })
+
+  experiment('.handler', () => {
+    experiment('when the job is successful', () => {
+      test('a message is logged', async () => {
+        await TriggerEndDateCheckJob.handler()
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('nald-import.trigger-end-date-check: started')
+      })
+
+      test('deletes the removed documents', async () => {
+        await TriggerEndDateCheckJob.handler()
+
+        expect(WaterSystemService.postLicencesEndDatesCheck.called).to.equal(true)
+      })
+    })
+
+    experiment('when the job fails', () => {
+      const err = new Error('Oops!')
+
+      beforeEach(async () => {
+        WaterSystemService.postLicencesEndDatesCheck.throws(err)
+      })
+
+      test('logs an error message', async () => {
+        await expect(TriggerEndDateCheckJob.handler()).to.reject()
+
+        expect(notifierStub.omfg.calledWith(
+          'nald-import.trigger-end-date-check: errored', err
+        )).to.equal(true)
+      })
+
+      test('rethrows the error', async () => {
+        const err = await expect(TriggerEndDateCheckJob.handler()).to.reject()
+
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+
+  experiment('.onComplete', () => {
+    let job
+    let messageQueue
+
+    beforeEach(async () => {
+      messageQueue = {
+        publish: Sinon.stub()
+      }
+    })
+
+    experiment('when the job succeeds', () => {
+      beforeEach(async () => {
+        job = {
+          failed: false,
+          data: { request: { data: { replicateReturns: false } } }
+        }
+      })
+
+      test('a message is logged', async () => {
+        await TriggerEndDateCheckJob.onComplete(messageQueue, job)
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('nald-import.trigger-end-date-check: finished')
+      })
+
+      test('the delete removed documents job is published to the queue', async () => {
+        await TriggerEndDateCheckJob.onComplete(messageQueue, job)
+
+        const jobMessage = messageQueue.publish.lastCall.args[0]
+
+        expect(jobMessage.name).to.equal('nald-import.delete-removed-documents')
+      })
+
+      experiment('but an error is thrown', () => {
+        const err = new Error('oops')
+
+        beforeEach(async () => {
+          messageQueue.publish.rejects(err)
+        })
+
+        test('rethrows the error', async () => {
+          const error = await expect(TriggerEndDateCheckJob.onComplete(messageQueue, job)).to.reject()
+
+          expect(error).to.equal(error)
+        })
+      })
+    })
+
+    experiment('when the job fails', () => {
+      beforeEach(async () => {
+        job = { failed: true }
+      })
+
+      test('no further jobs are published', async () => {
+        await TriggerEndDateCheckJob.onComplete(messageQueue, job)
+
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/nald-import/plugin.test.js
+++ b/test/modules/nald-import/plugin.test.js
@@ -14,6 +14,7 @@ const DeleteRemovedDocumentsJob = require('../../../src/modules/nald-import/jobs
 const ImportLicenceJob = require('../../../src/modules/nald-import/jobs/import-licence.js')
 const QueueLicencesJob = require('../../../src/modules/nald-import/jobs/queue-licences.js')
 const S3DownloadJob = require('../../../src/modules/nald-import/jobs/s3-download.js')
+const TriggerEndDateCheckJob = require('../../../src/modules/nald-import/jobs/trigger-end-date-check.js')
 
 // Things we need to stub
 const cron = require('node-cron')
@@ -74,11 +75,37 @@ experiment('modules/nald-import/plugin', () => {
       })
     })
 
-    experiment('for Delete Removed Documents', () => {
+    experiment('for Trigger End Date Check', () => {
       test('subscribes its handler to the job queue', async () => {
         await NaldImportPlugin.plugin.register(server)
 
         const subscribeArgs = server.messageQueue.subscribe.getCall(1).args
+
+        expect(subscribeArgs[0]).to.equal(TriggerEndDateCheckJob.name)
+        expect(subscribeArgs[1]).to.equal(TriggerEndDateCheckJob.handler)
+      })
+
+      test('registers its onComplete for the job', async () => {
+        await NaldImportPlugin.plugin.register(server)
+
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
+
+        expect(onCompleteArgs[0]).to.equal(TriggerEndDateCheckJob.name)
+        expect(onCompleteArgs[1]).to.be.a.function()
+      })
+
+      test('schedules the job to be published', async () => {
+        await NaldImportPlugin.plugin.register(server)
+
+        expect(cron.schedule.calledWith(config.import.nald.schedule)).to.be.true()
+      })
+    })
+
+    experiment('for Delete Removed Documents', () => {
+      test('subscribes its handler to the job queue', async () => {
+        await NaldImportPlugin.plugin.register(server)
+
+        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
 
         expect(subscribeArgs[0]).to.equal(DeleteRemovedDocumentsJob.name)
         expect(subscribeArgs[1]).to.equal(DeleteRemovedDocumentsJob.handler)
@@ -87,7 +114,7 @@ experiment('modules/nald-import/plugin', () => {
       test('registers its onComplete for the job', async () => {
         await NaldImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
 
         expect(onCompleteArgs[0]).to.equal(DeleteRemovedDocumentsJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -98,7 +125,7 @@ experiment('modules/nald-import/plugin', () => {
       test('subscribes its handler to the job queue', async () => {
         await NaldImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
 
         expect(subscribeArgs[0]).to.equal(QueueLicencesJob.name)
         expect(subscribeArgs[1]).to.equal(QueueLicencesJob.handler)
@@ -107,7 +134,7 @@ experiment('modules/nald-import/plugin', () => {
       test('registers its onComplete for the job', async () => {
         await NaldImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(3).args
 
         expect(onCompleteArgs[0]).to.equal(QueueLicencesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -118,7 +145,7 @@ experiment('modules/nald-import/plugin', () => {
       test('subscribes its handler to the job queue', async () => {
         await NaldImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
 
         expect(subscribeArgs[0]).to.equal(ImportLicenceJob.name)
         expect(subscribeArgs[1]).to.equal(ImportLicenceJob.options)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4546

> Part of the work to migrate management of return versions to WRLS from NALD

During the import from NALD, if a licence end date is changed, for example, if it has been revoked in NALD, our return version functionality needs to know about it. This is so we can reissue the return logs for the licence to match the changed end date.

We are actively trying to move away from the legacy code base, so this work was always going to be done in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). Initially, it would be triggered by our [own import process](https://eaflood.atlassian.net/browse/WATER-4535), which was due to replace the legacy one. But that was when we thought ReSP would be taking over from NALD.

Now, the plan is for WRLS to encompass the final abstraction leg and take over from NALD. So, there is little point in replacing a complex import we intend to switch off in the next year.

But, knowing we'd need something in the interim, we created the [/jobs/licence-changes job](https://github.com/DEFRA/water-abstraction-system/pull/1593). The intent was to schedule this after the first [NALD import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#nald-import) had completed (the one that downloads and extracts the NALD data) but before the main [licence import
  job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#licence-import). That way, our job could compare the NALD and WRLS licence records to determine if an end date has changed.

But then we had our 'doh!' moment.

Our reissue return logs engine expects to be given a licence ID and the date the change applies. However, the WRLS licence record needs to have been updated for it to determine the start and end dates of the new return logs.

If we schedule `/jobs/licence-changes` before the licence import job, it will see the change but won't reissue anything because the WRLS record won't have been updated. If we schedule it after, it won't see any difference and won't trigger the reissue.

Doh!

So, we've needed to change tact on this completely. Now, we intend to

- _trigger_ `/licences/end-dates/check` from the [NALD import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#nald-import) rather than schedule it
- refactor `/jobs/licence-changes` as `/licences/end-dates`, but instead of processing changed licences, it [stores the details of the change in a table](https://github.com/DEFRA/water-abstraction-service/pull/2666)
- add a new `/licences/end-dates/process` endpoint that processes these 'licence change' records, which will be triggered from the [licence import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#licence-import)

This change adds new steps to the NALD and Licence import jobs to trigger these new endpoints.