### PR TITLE
Move trigger for licence end dates in lic. import

### DIFF
--- a/src/modules/licence-import/jobs/clean.js
+++ b/src/modules/licence-import/jobs/clean.js
@@ -3,7 +3,7 @@
 const config = require('../../../../config')
 const { pool } = require('../../../lib/connectors/db')
 const Queries = require('../connectors/queries/clean-queries.js')
-const TriggerEndDateProcessJob = require('./trigger-end-date-process.js')
+const ImportPurposeConditionTypesJob = require('./import-purpose-condition-types.js')
 
 const JOB_NAME = 'licence-import.clean'
 
@@ -109,7 +109,7 @@ async function _cleanDeletedLicenceVersionData () {
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
-    await messageQueue.publish(TriggerEndDateProcessJob.createMessage())
+    await messageQueue.publish(ImportPurposeConditionTypesJob.createMessage())
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/licence-import/jobs/import-points.js
+++ b/src/modules/licence-import/jobs/import-points.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { pool } = require('../../../lib/connectors/db')
+const TriggerEndDateProcessJob = require('./trigger-end-date-process.js')
 
 const JOB_NAME = 'licence-import.import-points'
 
@@ -25,7 +26,11 @@ async function handler () {
   }
 }
 
-async function onComplete () {
+async function onComplete (messageQueue, job) {
+  if (!job.failed) {
+    await messageQueue.publish(TriggerEndDateProcessJob.createMessage())
+  }
+
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 

--- a/src/modules/licence-import/jobs/import-points.js
+++ b/src/modules/licence-import/jobs/import-points.js
@@ -19,7 +19,7 @@ async function handler () {
   try {
     global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
-    return _importPoints()
+    await _importPoints()
   } catch (error) {
     global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
     throw error

--- a/src/modules/licence-import/jobs/trigger-end-date-process.js
+++ b/src/modules/licence-import/jobs/trigger-end-date-process.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const ImportPurposeConditionTypesJob = require('./import-purpose-condition-types.js')
 const WaterSystemService = require('../../../lib/services/water-system-service.js')
 
 const JOB_NAME = 'licence-import.trigger-end-date-process'
@@ -26,11 +25,7 @@ async function handler () {
   }
 }
 
-async function onComplete (messageQueue, job) {
-  if (!job.failed) {
-    await messageQueue.publish(ImportPurposeConditionTypesJob.createMessage())
-  }
-
+async function onComplete () {
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)
 }
 

--- a/test/modules/licence-import/jobs/clean.test.js
+++ b/test/modules/licence-import/jobs/clean.test.js
@@ -109,12 +109,12 @@ experiment('Licence Import: Clean', () => {
         expect(message).to.equal('licence-import.clean: finished')
       })
 
-      test('the trigger end date process job is published to the queue', async () => {
+      test('the import purpose condition types job is published to the queue', async () => {
         await CleanJob.onComplete(messageQueue, job)
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.name).to.equal('licence-import.trigger-end-date-process')
+        expect(jobMessage.name).to.equal('licence-import.import-purpose-condition-types')
       })
 
       experiment('but an error is thrown', () => {

--- a/test/modules/licence-import/jobs/import-points.test.js
+++ b/test/modules/licence-import/jobs/import-points.test.js
@@ -1,0 +1,147 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+
+// Things we need to stub
+const { pool } = require('../../../../src/lib/connectors/db.js')
+
+// Thing under test
+const ImportPointsJob = require('../../../../src/modules/licence-import/jobs/import-points.js')
+
+experiment('Licence Import: Import Points job', () => {
+  let notifierStub
+
+  beforeEach(async () => {
+    Sinon.stub(pool, 'query').resolves()
+
+    // RequestLib depends on the GlobalNotifier to have been set. This happens in app/plugins/global-notifier.plugin.js
+    // when the app starts up and the plugin is registered. As we're not creating an instance of Hapi server in this
+    // test we recreate the condition by setting it directly with our own stub
+    notifierStub = { omg: Sinon.stub(), omfg: Sinon.stub() }
+    global.GlobalNotifier = notifierStub
+  })
+
+  afterEach(async () => {
+    Sinon.restore()
+    delete global.GlobalNotifier
+  })
+
+  experiment('.createMessage', () => {
+    test('formats a message for the queue', async () => {
+      const message = ImportPointsJob.createMessage()
+
+      expect(message).to.equal({
+        name: 'licence-import.import-points',
+        options: {
+          singletonKey: 'licence-import.import-points',
+          expireIn: '1 hours'
+        }
+      })
+    })
+  })
+
+  experiment('.handler', () => {
+    experiment('when the job is successful', () => {
+      test('a message is logged', async () => {
+        await ImportPointsJob.handler()
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('licence-import.import-points: started')
+      })
+
+      test('import the points', async () => {
+        await ImportPointsJob.handler()
+
+        expect(pool.query.called).to.equal(true)
+      })
+    })
+
+    experiment('when the job fails', () => {
+      const err = new Error('Oops!')
+
+      beforeEach(async () => {
+        pool.query.rejects(err)
+      })
+
+      test('logs an error message', async () => {
+        await expect(ImportPointsJob.handler()).to.reject()
+
+        expect(notifierStub.omfg.calledWith(
+          'licence-import.import-points: errored', err
+        )).to.equal(true)
+      })
+
+      test('rethrows the error', async () => {
+        const err = await expect(ImportPointsJob.handler()).to.reject()
+
+        expect(err.message).to.equal('Oops!')
+      })
+    })
+  })
+
+  experiment('.onComplete', () => {
+    let job
+    let messageQueue
+
+    beforeEach(async () => {
+      messageQueue = {
+        publish: Sinon.stub()
+      }
+    })
+
+    experiment('when the job succeeds', () => {
+      beforeEach(async () => {
+        job = { failed: false }
+      })
+
+      test('a message is logged', async () => {
+        await ImportPointsJob.onComplete(messageQueue, job)
+
+        const [message] = notifierStub.omg.lastCall.args
+
+        expect(message).to.equal('licence-import.import-points: finished')
+      })
+
+      test('the trigger end date process job is published to the queue', async () => {
+        await ImportPointsJob.onComplete(messageQueue, job)
+
+        const jobMessage = messageQueue.publish.lastCall.args[0]
+
+        expect(jobMessage.name).to.equal('licence-import.trigger-end-date-process')
+      })
+
+      experiment('but an error is thrown', () => {
+        const err = new Error('oops')
+
+        beforeEach(async () => {
+          messageQueue.publish.rejects(err)
+        })
+
+        test('rethrows the error', async () => {
+          const error = await expect(ImportPointsJob.onComplete(messageQueue, job)).to.reject()
+
+          expect(error).to.equal(error)
+        })
+      })
+    })
+
+    experiment('when the job fails', () => {
+      beforeEach(async () => {
+        job = { failed: true }
+      })
+
+      test('no further jobs are published', async () => {
+        await ImportPointsJob.onComplete(messageQueue, job)
+
+        expect(messageQueue.publish.called).to.be.false()
+      })
+    })
+  })
+})

--- a/test/modules/licence-import/jobs/trigger-end-date-process.test.js
+++ b/test/modules/licence-import/jobs/trigger-end-date-process.test.js
@@ -55,12 +55,6 @@ experiment('Licence Import: Trigger End Date Process', () => {
 
         expect(message).to.equal('licence-import.trigger-end-date-process: started')
       })
-
-      test('triggers the end date process', async () => {
-        await TriggerEndDateProcessJob.handler()
-
-        expect(WaterSystemService.postLicencesEndDatesProcess.called).to.equal(true)
-      })
     })
 
     experiment('when the job fails', () => {
@@ -87,63 +81,13 @@ experiment('Licence Import: Trigger End Date Process', () => {
   })
 
   experiment('.onComplete', () => {
-    let job
-    let messageQueue
-
-    beforeEach(async () => {
-      messageQueue = {
-        publish: Sinon.stub()
-      }
-    })
-
     experiment('when the job succeeds', () => {
-      beforeEach(async () => {
-        job = {
-          failed: false,
-          data: { request: { data: { replicateReturns: false } } }
-        }
-      })
-
       test('a message is logged', async () => {
-        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
+        await TriggerEndDateProcessJob.onComplete()
 
         const [message] = notifierStub.omg.lastCall.args
 
         expect(message).to.equal('licence-import.trigger-end-date-process: finished')
-      })
-
-      test('the Import Purpose Condition Types job is published to the queue', async () => {
-        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
-
-        const jobMessage = messageQueue.publish.lastCall.args[0]
-
-        expect(jobMessage.name).to.equal('licence-import.import-purpose-condition-types')
-      })
-
-      experiment('but an error is thrown', () => {
-        const err = new Error('oops')
-
-        beforeEach(async () => {
-          messageQueue.publish.rejects(err)
-        })
-
-        test('rethrows the error', async () => {
-          const error = await expect(TriggerEndDateProcessJob.onComplete(messageQueue, job)).to.reject()
-
-          expect(error).to.equal(error)
-        })
-      })
-    })
-
-    experiment('when the job fails', () => {
-      beforeEach(async () => {
-        job = { failed: true }
-      })
-
-      test('no further jobs are published', async () => {
-        await TriggerEndDateProcessJob.onComplete(messageQueue, job)
-
-        expect(messageQueue.publish.called).to.be.false()
       })
     })
   })

--- a/test/modules/licence-import/plugin.test.js
+++ b/test/modules/licence-import/plugin.test.js
@@ -77,37 +77,11 @@ experiment('modules/licence-import/plugin.js', () => {
       })
     })
 
-    experiment('for Trigger End Date Process', () => {
-      test('subscribes its handler to the job queue', async () => {
-        await LicenceImportPlugin.plugin.register(server)
-
-        const subscribeArgs = server.messageQueue.subscribe.getCall(1).args
-
-        expect(subscribeArgs[0]).to.equal(TriggerEndDateProcessJob.name)
-        expect(subscribeArgs[1]).to.equal(TriggerEndDateProcessJob.handler)
-      })
-
-      test('registers its onComplete for the job', async () => {
-        await LicenceImportPlugin.plugin.register(server)
-
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
-
-        expect(onCompleteArgs[0]).to.equal(TriggerEndDateProcessJob.name)
-        expect(onCompleteArgs[1]).to.be.a.function()
-      })
-
-      test('schedules the job to be published', async () => {
-        await LicenceImportPlugin.plugin.register(server)
-
-        expect(cron.schedule.calledWith(config.import.licences.schedule)).to.be.true()
-      })
-    })
-
     experiment('for Import Purpose Condition Types', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(1).args
 
         expect(subscribeArgs[0]).to.equal(ImportPurposeConditionTypesJob.name)
         expect(subscribeArgs[1]).to.equal(ImportPurposeConditionTypesJob.handler)
@@ -116,7 +90,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(1).args
 
         expect(onCompleteArgs[0]).to.equal(ImportPurposeConditionTypesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -127,7 +101,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(2).args
 
         expect(subscribeArgs[0]).to.equal(QueueCompaniesJob.name)
         expect(subscribeArgs[1]).to.equal(QueueCompaniesJob.handler)
@@ -136,7 +110,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(3).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(2).args
 
         expect(onCompleteArgs[0]).to.equal(QueueCompaniesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -147,7 +121,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler and options to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(3).args
 
         expect(subscribeArgs[0]).to.equal(ImportCompanyJob.name)
         expect(subscribeArgs[1]).to.equal(ImportCompanyJob.options)
@@ -157,7 +131,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(4).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(3).args
 
         expect(onCompleteArgs[0]).to.equal(ImportCompanyJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -168,7 +142,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(5).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(4).args
 
         expect(subscribeArgs[0]).to.equal(QueueLicencesJob.name)
         expect(subscribeArgs[1]).to.equal(QueueLicencesJob.handler)
@@ -177,7 +151,7 @@ experiment('modules/licence-import/plugin.js', () => {
       test('registers its onComplete for the job', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const onCompleteArgs = server.messageQueue.onComplete.getCall(5).args
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(4).args
 
         expect(onCompleteArgs[0]).to.equal(QueueLicencesJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
@@ -188,11 +162,30 @@ experiment('modules/licence-import/plugin.js', () => {
       test('subscribes its handler and options to the job queue', async () => {
         await LicenceImportPlugin.plugin.register(server)
 
-        const subscribeArgs = server.messageQueue.subscribe.getCall(6).args
+        const subscribeArgs = server.messageQueue.subscribe.getCall(5).args
 
         expect(subscribeArgs[0]).to.equal(ImportLicenceJob.name)
         expect(subscribeArgs[1]).to.equal(ImportLicenceJob.options)
         expect(subscribeArgs[2]).to.equal(ImportLicenceJob.handler)
+      })
+    })
+
+    experiment('for Trigger End Date Process', () => {
+      test('subscribes its handler to the job queue', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const subscribeArgs = server.messageQueue.subscribe.getCall(7).args
+
+        expect(subscribeArgs[0]).to.equal(TriggerEndDateProcessJob.name)
+        expect(subscribeArgs[1]).to.equal(TriggerEndDateProcessJob.handler)
+      })
+
+      test('registers its onComplete for the job', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(7).args
+
+        expect(onCompleteArgs[0]).to.equal(TriggerEndDateProcessJob.name)
       })
     })
   })

--- a/test/modules/licence-import/plugin.test.js
+++ b/test/modules/licence-import/plugin.test.js
@@ -168,6 +168,15 @@ experiment('modules/licence-import/plugin.js', () => {
         expect(subscribeArgs[1]).to.equal(ImportLicenceJob.options)
         expect(subscribeArgs[2]).to.equal(ImportLicenceJob.handler)
       })
+
+      test('registers its onComplete for the job', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(5).args
+
+        expect(onCompleteArgs[0]).to.equal(ImportLicenceJob.name)
+        expect(onCompleteArgs[1]).to.be.a.function()
+      })
     })
 
     experiment('for Trigger End Date Process', () => {

--- a/test/modules/licence-import/plugin.test.js
+++ b/test/modules/licence-import/plugin.test.js
@@ -13,6 +13,7 @@ const config = require('../../../config.js')
 const CleanJob = require('../../../src/modules/licence-import/jobs/clean.js')
 const ImportCompanyJob = require('../../../src/modules/licence-import/jobs/import-company.js')
 const ImportLicenceJob = require('../../../src/modules/licence-import/jobs/import-licence.js')
+const ImportPointsJob = require('../../../src/modules/licence-import/jobs/import-points.js')
 const ImportPurposeConditionTypesJob = require('../../../src/modules/licence-import/jobs/import-purpose-condition-types.js')
 const QueueCompaniesJob = require('../../../src/modules/licence-import/jobs/queue-companies.js')
 const QueueLicencesJob = require('../../../src/modules/licence-import/jobs/queue-licences.js')
@@ -175,6 +176,27 @@ experiment('modules/licence-import/plugin.js', () => {
         const onCompleteArgs = server.messageQueue.onComplete.getCall(5).args
 
         expect(onCompleteArgs[0]).to.equal(ImportLicenceJob.name)
+        expect(onCompleteArgs[1]).to.be.a.function()
+      })
+    })
+
+    experiment('for Import Points', () => {
+      test('subscribes its handler and options to the job queue', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const subscribeArgs = server.messageQueue.subscribe.getCall(6).args
+
+        expect(subscribeArgs[0]).to.equal(ImportPointsJob.name)
+        expect(subscribeArgs[1]).to.equal(ImportPointsJob.options)
+        expect(subscribeArgs[2]).to.equal(ImportPointsJob.handler)
+      })
+
+      test('registers its onComplete for the job', async () => {
+        await LicenceImportPlugin.plugin.register(server)
+
+        const onCompleteArgs = server.messageQueue.onComplete.getCall(6).args
+
+        expect(onCompleteArgs[0]).to.equal(ImportPointsJob.name)
         expect(onCompleteArgs[1]).to.be.a.function()
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4546

> Part of the work to migrate management of return versions to WRLS from NALD

In [Trigger new licence end date change endpoints](https://github.com/DEFRA/water-abstraction-import/pull/1049), we added new steps to the NALD and Licence import to allow us to trigger functionality in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to trigger functionality linked to changes to licence end dates.

It needs two steps because in the **NALD import**, we need to see the difference between NALD and WRLS end dates _before_ the WRLS licence record is updated. Then, in **Licence import**, we can process the changes _after_ the licence has been updated with the new end date.

Sorry, I did say _after_ didn't I?! 🤦 

We realised in testing that we'd placed the second step in **Licence import** before it updates the licence. This means features that depend on knowing what the change date was and that the licence has been updated with the new end date are failing.

This fix moves the step in **Licence import** to _after_ the steps that update the licence records.