### PR TITLE
Remove blipp plugin

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,10 +9,6 @@ const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 
 module.exports = {
 
-  blipp: {
-    showAuth: true
-  },
-
   jwt: {
     key: process.env.JWT_SECRET,
     verifyOptions: { algorithms: ['HS256'] }

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 require('dotenv').config()
 
 // -------------- Require vendor code -----------------
-const Blipp = require('blipp')
-
 const HapiAuthJwt2 = require('hapi-auth-jwt2')
 const moment = require('moment')
 
@@ -20,10 +18,6 @@ const HapiPinoPlugin = require('./src/plugins/hapi-pino.plugin.js')
 const server = require('./server')
 
 const plugins = [
-  {
-    plugin: Blipp,
-    options: config.blipp
-  },
   HapiAuthJwt2,
   require('./src/plugins/pg-boss.plugin'),
   require('./src/modules/licence-import/plugin'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@hapi/hoek": "^10.0.1",
         "@hapi/joi": "^15.1.1",
         "aws-sdk": "^2.1657.0",
-        "blipp": "^4.0.2",
         "bluebird": "^3.7.2",
         "csv-stringify": "^5.5.0",
         "db-migrate": "^0.11.14",
@@ -2118,87 +2117,6 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
-    "node_modules/blipp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/blipp/-/blipp-4.0.2.tgz",
-      "integrity": "sha512-QA5amT0IFJgCFgJeWw2udD2zZLui60NgqXTyvbSq+qpVbS6jfqELTRlC8PWW0yD4+chdZ2a+svnN6WE9zqfK5Q==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "chalk": "4.x.x",
-        "easy-table": "1.x.x",
-        "joi": "17.x.x"
-      }
-    },
-    "node_modules/blipp/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/blipp/node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/blipp/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/blipp/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/blipp/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/blipp/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/blipp/node_modules/joi": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
-      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2426,15 +2344,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -2808,15 +2717,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
-      "optional": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2935,17 +2835,6 @@
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/easy-table": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
-      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "optionalDependencies": {
-        "wcwidth": "^1.0.1"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -4323,6 +4212,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8296,6 +8186,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8785,15 +8676,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.48"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "optional": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@hapi/hoek": "^10.0.1",
     "@hapi/joi": "^15.1.1",
     "aws-sdk": "^2.1657.0",
-    "blipp": "^4.0.2",
     "bluebird": "^3.7.2",
     "csv-stringify": "^5.5.0",
     "db-migrate": "^0.11.14",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/111

Along with most other Defra services, we add this as a project standard. But we've been (rightly) challenged on what value this adds.

On [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), we concluded it was very little and was against our ethos of 'minimal and simple', so [we removed it](https://github.com/DEFRA/water-abstraction-system/pull/1080).

This change removes it from this app.

> Note: we don't remove the `description:` property from the routes. Eventually, this repo will become redundant, so it was deemed unnecessary.