### PR TITLE
Stop 'return leg' processes with feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,12 @@ WATER_SERVICE_MAILBOX=
 # run in production that we often need to re-run in local and non-production environments
 IMPORT_LICENCE_AGREEMENTS=false
 
+# In preparation for switching management of the returns leg from NALD to WRLS we need the ability to disable
+# the import of return versions and return logs (and their connected data). On the day of go live the env var will be
+# set to 'true'. Assuming all is well, we'll then remove the jobs completely. If not, we can revert with a simple env
+# var change.
+DISABLE_RETURNS_IMPORTS=false
+
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug
 

--- a/config.js
+++ b/config.js
@@ -127,5 +127,10 @@ module.exports = {
     templates: {
       service_status_alert: 'c34d1b16-694b-4364-8e7e-83e9dbd34a62'
     }
+  },
+  // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
+  // converting the env var to a boolean
+  featureFlags : {
+    disableReturnsImports: String(process.env.DISABLE_RETURNS_IMPORTS) === 'true' || false
   }
 }

--- a/config.js
+++ b/config.js
@@ -130,7 +130,7 @@ module.exports = {
   },
   // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
   // converting the env var to a boolean
-  featureFlags : {
+  featureFlags: {
     disableReturnsImports: String(process.env.DISABLE_RETURNS_IMPORTS) === 'true' || false
   }
 }

--- a/src/modules/nald-import/load.js
+++ b/src/modules/nald-import/load.js
@@ -12,6 +12,8 @@ const { persistReturns } = require('./lib/persist-returns')
 
 const repository = require('./repositories')
 
+const { featureFlags } = require('../../../config.js')
+
 /**
  * Loads data into the permit repository and CRM doc header
  * @param {String} licenceNumber
@@ -54,7 +56,10 @@ const load = async (licenceNumber, replicateReturns) => {
 
   if (licenceData.data.versions.length > 0) {
     await loadPermitAndDocumentHeader(licenceNumber, licenceData)
-    await loadReturns(licenceNumber, replicateReturns)
+
+    if (!featureFlags.disableReturnsImports) {
+      await loadReturns(licenceNumber, replicateReturns)
+    }
   }
 }
 

--- a/src/modules/return-versions/plugin.js
+++ b/src/modules/return-versions/plugin.js
@@ -22,7 +22,9 @@ async function register (server, _options) {
 
   // Schedule clean job using cron. The clean job will then queue the import job in its onComplete
   cron.schedule(config.import.returnVersions.schedule, async () => {
-    await server.messageQueue.publish(CleanJob.createMessage())
+    if (!config.featureFlags.disableReturnsImports) {
+      await server.messageQueue.publish(CleanJob.createMessage())
+    }
   })
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4890

> Part of the work to migrate management of return requirements from NALD to WRLS

We are now getting ready for the switchover of management of the 'returns leg' from NALD to WRLS. On the day this goes live, we must stop any changes to our data via the over night processes.

To be ready, this changes adds a new feature flag that, when enabled, will block

- the **return-versions** import job
- the return logs being updated as part of the **nald-import** job

It defaults to `false`, so we don't stop anything.

We won't remove the processes until we are happy that WRLS is working as expected, just in case we need to revert back to NALD.