### PR TITLE
Move import of return logs into their own job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ WRLS_LOG_LEVEL=debug
 # Use Cron type syntax to set timings for these background processes
 WRLS_CRON_NALD='15 23 * * *'
 WRLS_CRON_LICENCES='15 3 * * 1,2,3,4,5'
+WRLS_CRON_RETURN_LOGS='30 1 * * 1,2,3,4,5'
 WRLS_CRON_RETURN_VERSIONS='15 7 * * 1,2,3,4,5'
 WRLS_CRON_POINTS='45 7 * * 1,2,3,4,5'
 WRLS_CRON_MOD_LOGS='30 7 * * 1,2,3,4,5'

--- a/config.js
+++ b/config.js
@@ -108,6 +108,9 @@ module.exports = {
     points: {
       schedule: process.env.WRLS_CRON_MOD_LOGS || '45 7 * * 1,2,3,4,5'
     },
+    returnLogs: {
+      schedule: process.env.WRLS_CRON_RETURN_LOGS || '30 1 * * 1,2,3,4,5'
+    },
     returnVersions: {
       schedule: process.env.WRLS_CRON_RETURN_VERSIONS || '15 7 * * 1,2,3,4,5'
     },

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const plugins = [
   require('./src/modules/charging-import/plugin'),
   require('./src/modules/mod-logs/plugin'),
   require('./src/modules/points/plugin'),
+  require('./src/modules/return-logs/plugin.js'),
   require('./src/modules/return-versions/plugin.js'),
   require('./src/modules/nald-import/plugin'),
   require('./src/modules/bill-runs-import/plugin'),

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -15,6 +15,17 @@ pg.types.setTypeParser(pg.types.builtins.DATE, dateMapper)
 
 const pool = helpers.db.createPool(config.pg, logger)
 
+async function query (query, params = []) {
+  const { error, rows } = await pool.query(query, params)
+
+  if (error) {
+    throw error
+  }
+
+  return rows
+}
+
 module.exports = {
-  pool
+  pool,
+  query
 }

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -2,7 +2,6 @@
 
 const Boom = require('@hapi/boom')
 
-const { buildReturnsPacket } = require('./transform-returns')
 const { getLicenceJson } = require('./transform-permit')
 const importLicenceJob = require('./jobs/import-licence.js')
 const s3DownloadJob = require('./jobs/s3-download.js')
@@ -23,69 +22,6 @@ const getLicence = async (request, h) => {
       return data
     }
     return Boom.notFound('The requested licence number could not be found')
-  } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 })
-  }
-}
-
-/**
- * For test purposes, builds returns data
- * @param {String} request.query.filter - a JSON encoded string with property 'licenceNumber'
- */
-const getReturns = async (request, h) => {
-  try {
-    const filter = JSON.parse(request.query.filter)
-    const data = await buildReturnsPacket(filter.licenceNumber)
-
-    if (data) {
-      return data
-    }
-    return Boom.notFound('The requested licence number could not be found')
-  } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 })
-  }
-}
-
-/**
- * For test purposes, gets returns formats for given licence number
- * @param {String} request.query.filter - JSON encoded filter
- */
-const getReturnsFormats = async (request, h) => {
-  try {
-    const filter = JSON.parse(request.query.filter)
-    const data = await getFormats(filter.licenceNumber)
-
-    return data
-  } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 })
-  }
-}
-
-/**
- * For test purposes, gets returns formats for given licence number
- * @param {String} request.query - JSON encoded filter
- */
-const getReturnsLogs = async (request, h) => {
-  try {
-    const filter = JSON.parse(request.query.filter)
-    const { formatId, regionCode } = filter
-    const data = await getLogs(formatId, regionCode)
-    return data
-  } catch (err) {
-    throw Boom.boomify(err, { statusCode: 400 })
-  }
-}
-
-/**
- * For test purposes, gets returns formats for given licence number
- * @param {String} request.query - JSON encoded filter
- */
-const getReturnsLogLines = async (request, h) => {
-  try {
-    const filter = JSON.parse(request.query.filter)
-    const { formatId, regionCode, dateFrom } = filter
-    const data = await getLogLines(formatId, regionCode, dateFrom)
-    return data
   } catch (err) {
     throw Boom.boomify(err, { statusCode: 400 })
   }
@@ -130,10 +66,6 @@ const postImportLicences = async (request, h) => {
 
 module.exports = {
   getLicence,
-  getReturns,
-  getReturnsFormats,
-  getReturnsLogs,
-  getReturnsLogLines,
   postImportLicence,
   postImportLicences
 }

--- a/src/modules/nald-import/controller.js
+++ b/src/modules/nald-import/controller.js
@@ -6,8 +6,6 @@ const { getLicenceJson } = require('./transform-permit')
 const importLicenceJob = require('./jobs/import-licence.js')
 const s3DownloadJob = require('./jobs/s3-download.js')
 
-const { getFormats, getLogs, getLogLines } = require('./lib/nald-queries/returns')
-
 /**
  * For test purposes, builds licence from the data in the NALD import
  * tables.  This is used in the NALD import unit test

--- a/src/modules/nald-import/jobs/delete-removed-documents.js
+++ b/src/modules/nald-import/jobs/delete-removed-documents.js
@@ -5,15 +5,12 @@ const QueueLicencesJob = require('./queue-licences')
 
 const JOB_NAME = 'nald-import.delete-removed-documents'
 
-function createMessage (replicateReturns) {
+function createMessage () {
   return {
     name: JOB_NAME,
     options: {
       expireIn: '1 hours',
       singletonKey: JOB_NAME
-    },
-    data: {
-      replicateReturns
     }
   }
 }
@@ -32,9 +29,7 @@ async function handler () {
 async function onComplete (messageQueue, job) {
   // Publish a new job to populate pending import table but only if delete removed documents was successful
   if (!job.failed) {
-    const { replicateReturns } = job.data.request.data
-
-    await messageQueue.publish(QueueLicencesJob.createMessage(replicateReturns))
+    await messageQueue.publish(QueueLicencesJob.createMessage())
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/nald-import/jobs/import-licence.js
+++ b/src/modules/nald-import/jobs/import-licence.js
@@ -55,7 +55,7 @@ async function handler (job) {
     }
 
     // Import the licence
-    await licenceLoader.load(job.data.licenceNumber, job.data.replicateReturns)
+    await licenceLoader.load(job.data.licenceNumber)
 
     if (job.data.jobNumber === job.data.numberOfJobs) {
       global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { numberOfJobs: job.data.numberOfJobs })

--- a/src/modules/nald-import/jobs/queue-licences.js
+++ b/src/modules/nald-import/jobs/queue-licences.js
@@ -6,15 +6,12 @@ const importService = require('../../../lib/services/import')
 
 const JOB_NAME = 'nald-import.queue-licences'
 
-function createMessage (replicateReturns) {
+function createMessage () {
   return {
     name: JOB_NAME,
     options: {
       expireIn: '1 hours',
       singletonKey: JOB_NAME
-    },
-    data: {
-      replicateReturns
     }
   }
 }
@@ -35,7 +32,6 @@ async function handler () {
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
-    const { replicateReturns } = job.data.request.data
     const { licenceNumbers } = job.data.response
     const numberOfJobs = licenceNumbers.length
 
@@ -45,8 +41,7 @@ async function onComplete (messageQueue, job) {
       const data = {
         licenceNumber,
         jobNumber: index + 1,
-        numberOfJobs,
-        replicateReturns
+        numberOfJobs
       }
       await messageQueue.publish(ImportLicenceJob.createMessage(data))
     }

--- a/src/modules/nald-import/jobs/s3-download.js
+++ b/src/modules/nald-import/jobs/s3-download.js
@@ -10,7 +10,7 @@ const TriggerEndDateCheckJob = require('./trigger-end-date-check.js')
 
 const JOB_NAME = 'nald-import.s3-download'
 
-function createMessage (checkEtag = true, replicateReturns = false) {
+function createMessage (checkEtag = true) {
   return {
     name: JOB_NAME,
     options: {
@@ -18,8 +18,7 @@ function createMessage (checkEtag = true, replicateReturns = false) {
       singletonKey: JOB_NAME
     },
     data: {
-      checkEtag,
-      replicateReturns
+      checkEtag
     }
   }
 }
@@ -46,7 +45,6 @@ async function handler (job) {
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
     const { isRequired } = job.data.response
-    const { replicateReturns } = job.data.request.data
 
     if (isRequired) {
       // Delete existing PG boss import queues
@@ -58,7 +56,7 @@ async function onComplete (messageQueue, job) {
       ])
 
       // Publish a new job to trigger the licences end date check
-      await messageQueue.publish(TriggerEndDateCheckJob.createMessage(replicateReturns))
+      await messageQueue.publish(TriggerEndDateCheckJob.createMessage())
     }
   }
 

--- a/src/modules/nald-import/jobs/trigger-end-date-check.js
+++ b/src/modules/nald-import/jobs/trigger-end-date-check.js
@@ -5,15 +5,12 @@ const WaterSystemService = require('../../../lib/services/water-system-service.j
 
 const JOB_NAME = 'nald-import.trigger-end-date-check'
 
-function createMessage (replicateReturns) {
+function createMessage () {
   return {
     name: JOB_NAME,
     options: {
       expireIn: '1 hours',
       singletonKey: JOB_NAME
-    },
-    data: {
-      replicateReturns
     }
   }
 }
@@ -31,10 +28,8 @@ async function handler () {
 
 async function onComplete (messageQueue, job) {
   if (!job.failed) {
-    const { replicateReturns } = job.data.request.data
-
     // Publish a new job to delete any removed documents
-    await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage(replicateReturns))
+    await messageQueue.publish(DeleteRemovedDocumentsJob.createMessage())
   }
 
   global.GlobalNotifier.omg(`${JOB_NAME}: finished`)

--- a/src/modules/nald-import/lib/nald-queries/returns.js
+++ b/src/modules/nald-import/lib/nald-queries/returns.js
@@ -1,19 +1,7 @@
 'use strict'
 
-const server = require('../../../../../server')
-const moment = require('moment')
 const db = require('../db')
-const cache = require('./cache')
 const sql = require('./sql/returns')
-
-/**
- * Gets form logs for specified licence number
- * @param {String} licenceNumber
- * @return {Promise} resolves with array of DB records
- */
-const getFormats = (licenceNumber) => {
-  return db.dbQuery(sql.getFormats, [licenceNumber])
-}
 
 /**
  * Get purposes attached to a returns format
@@ -35,106 +23,7 @@ const getFormatPoints = (formatId, regionCode) => {
   return db.dbQuery(sql.getFormatPoints, [formatId, regionCode])
 }
 
-/**
- * Get form logs for specified return format
- * @param {Number} formatId - the ARTY_ID
- * @return {Promise} resolves with array of DB records
- */
-const getLogs = (formatId, regionCode) => {
-  return db.dbQuery(sql.getLogs, [formatId, regionCode])
-}
-
-/**
- * Get returns lines
- * @param {Number} formatId - the ARTY_ID=
- * @param {Number} region code - FGAC_REGION_CODE
- * @param {String} dateFrom - e.g. YYYY-MM-DD
- * @param {String} dateTo - e.g. YYYY-MM-DD
- * @return {Promise} resolves with array of DB records
- */
-const getLines = (formatId, regionCode, dateFrom, dateTo) => {
-  const params = [formatId, regionCode, dateFrom, dateTo]
-  return db.dbQuery(sql.getLines, params)
-}
-
-/**
- * Get returns lines for log
- * @param {Number} formatId - the ARTY_ID=
- * @param {Number} region code - FGAC_REGION_CODE
- * @param {String} logDateFrom - e.g. DD/MM/YYYY
- * @return {Promise} resolves with array of DB records
- */
-const getLogLines = (formatId, regionCode, logDateFrom) => {
-  const from = moment(logDateFrom, 'DD/MM/YYYY').format('YYYYMMDD') + '000000'
-  const params = [formatId, regionCode, from]
-  return db.dbQuery(sql.getLogLines, params)
-}
-
-/**
- * Checks for nil return over the specified time period
- * @param {Number} formatId - the ARTY_ID=
- * @param {Number} region code - FGAC_REGION_CODE
- * @param {String} dateFrom - e.g. YYYY-MM-DD
- * @param {String} dateTo - e.g. YYYY-MM-DD
- * @return {Promise} resolves with boolean
- */
-const isNilReturn = async (formatId, regionCode, dateFrom, dateTo) => {
-  const params = [formatId, regionCode, dateFrom, dateTo]
-  const rows = await db.dbQuery(sql.isNilReturn, params)
-  return rows[0].total_qty === 0
-}
-
-/**
- * Gets the split date for considering returns as either current / non current
- * Originally this date was the EFF_ST_DATE of the current licence version
- * however this has been modified to only split if a licence version has
- * a mod log reason code of SUCC - 'Succession To A Whole Licence/Licence Transfer'
- * @param {String} licenceNumber - the licence number
- * @return {String|null} split date in format YYYY-MM-DD, or null if none found
- */
-const getSplitDate = async (licenceNumber) => {
-  const rows = await db.dbQuery(sql.getSplitDate, [licenceNumber])
-
-  return (rows.length === 1)
-    ? moment(rows[0].EFF_ST_DATE, 'DD/MM/YYYY').format('YYYY-MM-DD')
-    : null
-}
-
-/**
- * Gets the reason code from the mod log relating to a new return version
- * @param  {Number}  licenceId     - the NALD licence ID
- * @param  {Number}  regionCode    - the NALD FGAC_REGION_CODE
- * @param  {Number}  versionNumber - the version number of the return
- * @return {Promise<Array>}          resolves with reason codes
- */
-const getReturnVersionReason = async (licenceId, regionCode, versionNumber) => {
-  const id = cache.createId('returnVersionReason', {
-    licenceId,
-    regionCode,
-    versionNumber
-  })
-  return _getReturnVersionReasonCache.get(id)
-}
-
-const _createReturnVersionReasonCache = () => {
-  return cache.createCachedQuery(server, 'getReturnVersionReason', id => {
-    const params = [id.licenceId, id.versionNumber, id.regionCode]
-    return db.dbQuery(sql.getReturnVersionReason, params)
-  })
-}
-
-const _getReturnVersionReasonCache = _createReturnVersionReasonCache()
-
 module.exports = {
-  _createReturnVersionReasonCache,
-  _getReturnVersionReasonCache,
-  getFormats,
-  getFormatPurposes,
   getFormatPoints,
-  getLogs,
-  getLines,
-  getLogLines,
-  isNilReturn,
-  getSplitDate,
-  getReturnVersionReason
+  getFormatPurposes
 }

--- a/src/modules/nald-import/load.js
+++ b/src/modules/nald-import/load.js
@@ -5,14 +5,9 @@
  */
 const { v4: uuidV4 } = require('uuid')
 const { buildCRMPacket } = require('./transform-crm')
-const { buildReturnsPacket } = require('./transform-returns')
 const { getLicenceJson, buildPermitRepoPacket } = require('./transform-permit')
-const returnsConnector = require('../../lib/connectors/returns')
-const { persistReturns } = require('./lib/persist-returns')
 
 const repository = require('./repositories')
-
-const { featureFlags } = require('../../../config.js')
 
 /**
  * Loads data into the permit repository and CRM doc header
@@ -30,36 +25,15 @@ const loadPermitAndDocumentHeader = async (licenceNumber, licenceData) => {
 }
 
 /**
- * Calculates and imports a list of return cycles for the given licence
- * based on NALD formats and form logs
- * @param {String} licenceNumber
- * @param {Boolean} replicateReturns
- * @return {Promise} resolves when returns imported
- */
-const loadReturns = async (licenceNumber, replicateReturns) => {
-  const { returns } = await buildReturnsPacket(licenceNumber)
-  await persistReturns(returns, replicateReturns)
-
-  // Clean up invalid cycles
-  const returnIds = returns.map(row => row.return_id)
-  await returnsConnector.voidReturns(licenceNumber, returnIds)
-}
-
-/**
  * Imports the whole licence
  * @param {String} licenceNumber
- * @param {Boolean} replicateReturns
  * @return {Promise} resolves when complete
  */
-const load = async (licenceNumber, replicateReturns) => {
+const load = async (licenceNumber) => {
   const licenceData = await getLicenceJson(licenceNumber)
 
   if (licenceData.data.versions.length > 0) {
     await loadPermitAndDocumentHeader(licenceNumber, licenceData)
-
-    if (!featureFlags.disableReturnsImports) {
-      await loadReturns(licenceNumber, replicateReturns)
-    }
   }
 }
 

--- a/src/modules/nald-import/routes.js
+++ b/src/modules/nald-import/routes.js
@@ -12,30 +12,6 @@ module.exports = [
     config: { description: 'Get permit repo packet by licence number' }
   },
   {
-    method: 'GET',
-    path: '/import/1.0/nald/returns',
-    handler: controller.getReturns,
-    config: { description: 'Get a returns data packet by licence number' }
-  },
-  {
-    method: 'GET',
-    path: '/import/1.0/nald/returns/formats',
-    handler: controller.getReturnsFormats,
-    config: { description: 'Gets a returns formats for given licence number' }
-  },
-  {
-    method: 'GET',
-    path: '/import/1.0/nald/returns/logs',
-    handler: controller.getReturnsLogs,
-    config: { description: 'Gets a returns logs for given format' }
-  },
-  {
-    method: 'GET',
-    path: '/import/1.0/nald/returns/lines',
-    handler: controller.getReturnsLogLines,
-    config: { description: 'Gets a returns lines for a given log' }
-  },
-  {
     method: 'POST',
     path: '/import/1.0/nald/licence',
     handler: controller.postImportLicence,

--- a/src/modules/return-logs/controller.js
+++ b/src/modules/return-logs/controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const QueueJob = require('./jobs/queue.js')
+
+async function importReturnLogs (request, h) {
+  await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
+  await request.messageQueue.publish(QueueJob.createMessage())
+
+  return h.response().code(204)
+}
+
+module.exports = {
+  importReturnLogs
+}

--- a/src/modules/return-logs/controller.js
+++ b/src/modules/return-logs/controller.js
@@ -1,7 +1,9 @@
 'use strict'
 
+const Boom = require('@hapi/boom')
+
 const QueueJob = require('./jobs/queue.js')
-const { getFormats } = require('./lib/return-helpers.js')
+const { getFormats, getLogLines, getLogs } = require('./lib/return-helpers.js')
 const { buildReturnsPacket } = require('./lib/transform-returns.js')
 
 async function importReturnLogs (request, h) {

--- a/src/modules/return-logs/controller.js
+++ b/src/modules/return-logs/controller.js
@@ -5,15 +5,19 @@ const { getFormats } = require('./lib/return-helpers.js')
 const { buildReturnsPacket } = require('./lib/transform-returns.js')
 
 async function importReturnLogs (request, h) {
+  const licenceRef = request.payload?.licenceRef ?? null
+
   await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
-  await request.messageQueue.publish(QueueJob.createMessage(false))
+  await request.messageQueue.publish(QueueJob.createMessage(false, licenceRef))
 
   return h.response().code(204)
 }
 
 async function replicateReturnLogs (request, h) {
+  const licenceRef = request.payload?.licenceRef ?? null
+
   await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
-  await request.messageQueue.publish(QueueJob.createMessage(true))
+  await request.messageQueue.publish(QueueJob.createMessage(true, licenceRef))
 
   return h.response().code(204)
 }

--- a/src/modules/return-logs/controller.js
+++ b/src/modules/return-logs/controller.js
@@ -1,14 +1,88 @@
 'use strict'
 
 const QueueJob = require('./jobs/queue.js')
+const { getFormats } = require('./lib/return-helpers.js')
+const { buildReturnsPacket } = require('./lib/transform-returns.js')
 
 async function importReturnLogs (request, h) {
   await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
-  await request.messageQueue.publish(QueueJob.createMessage())
+  await request.messageQueue.publish(QueueJob.createMessage(false))
 
   return h.response().code(204)
 }
 
+async function replicateReturnLogs (request, h) {
+  await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
+  await request.messageQueue.publish(QueueJob.createMessage(true))
+
+  return h.response().code(204)
+}
+
+/**
+ * For test purposes, gets returns formats for given licence number
+ * @param {String} request.query.filter - JSON encoded filter
+ */
+async function returnFormats (request, h) {
+  try {
+    const filter = JSON.parse(request.query.filter)
+    const data = await getFormats(filter.licenceNumber)
+
+    return h.response(data).code(200)
+  } catch (err) {
+    throw Boom.boomify(err, { statusCode: 400 })
+  }
+}
+
+/**
+ * For test purposes, gets returns formats for given licence number
+ * @param {String} request.query - JSON encoded filter
+ */
+async function returnLogs (request, h) {
+  try {
+    const filter = JSON.parse(request.query.filter)
+    const data = await getLogs(filter.formatId, filter.regionCode)
+
+    return h.response(data).code(200)
+  } catch (err) {
+    throw Boom.boomify(err, { statusCode: 400 })
+  }
+}
+
+/**
+ * For test purposes, gets returns formats for given licence number
+ * @param {String} request.query - JSON encoded filter
+ */
+async function returnLogLines (request, h) {
+  try {
+    const filter = JSON.parse(request.query.filter)
+    const data = await getLogLines(filter.formatId, filter.regionCode, filter.dateFrom)
+
+    return h.response(data).code(200)
+  } catch (err) {
+    throw Boom.boomify(err, { statusCode: 400 })
+  }
+}
+
+/**
+ * For test purposes, builds returns data
+ * @param {String} request.query.filter - a JSON encoded string with property 'licenceNumber'
+ */
+async function returns (request, h) {
+  try {
+    const filter = JSON.parse(request.query.filter)
+    const data = await buildReturnsPacket(filter.licenceNumber)
+
+    return h.response(data).code(200)
+  } catch (err) {
+    throw Boom.boomify(err, { statusCode: 400 })
+  }
+}
+
 module.exports = {
-  importReturnLogs
+  importReturnLogs,
+  replicateReturnLogs,
+  returnFormats,
+  returnLogs,
+  returnLogLines,
+  returns
 }

--- a/src/modules/return-logs/jobs/import.js
+++ b/src/modules/return-logs/jobs/import.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const { pool } = require('../../../lib/connectors/db.js')
+
+const JOB_NAME = 'return-logs.import'
+
+function createMessage (data) {
+  return {
+    name: JOB_NAME,
+    data,
+    options: {
+      singletonKey: `${JOB_NAME}.${data.licence.id}.${data.licence.regionCode}`
+    }
+  }
+}
+
+async function handler (job) {
+  try {
+    // Most 'jobs' are single operation things, for example, delete any removed documents or import purposes types.
+    // However, there are typically 73K instances of this job queued up as part of the process! If we logged everyone it
+    // would just be noise in the logs. But that leaves us with no way of confirming the job is running. So, instead we
+    // get `queue.js` to include details on the total number of jobs plus a job number for each one added. We then use
+    // this information to log when the first is picked up and the last.
+    //
+    // N.B. It's not entirely accurate. If you added logging for all back in you might see the start message appear
+    // after a few jobs and likewise the finished message a few before the end. But it's good enough to give an
+    // indication that the 'jobs' did start and finish.
+    if (job.data.jobNumber === 1) {
+      global.GlobalNotifier.omg(`${JOB_NAME}: started`, { numberOfJobs: job.data.numberOfJobs })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+async function onComplete (job) {
+  try {
+    const { data } = job.data.request
+
+    if (data.jobNumber === data.numberOfJobs) {
+      global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { numberOfJobs: job.data.request.data.numberOfJobs })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+module.exports = {
+  JOB_NAME,
+  createMessage,
+  handler,
+  onComplete
+}

--- a/src/modules/return-logs/jobs/queue.js
+++ b/src/modules/return-logs/jobs/queue.js
@@ -23,7 +23,7 @@ async function handler (messageQueue, job) {
     global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
     // Get _all_ licences in NALD
-    const licences =  await _licences(job.data.licenceRef)
+    const licences = await _licences(job.data.licenceRef)
     const numberOfJobs = licences.length
 
     for (const [index, licence] of licences.entries()) {
@@ -46,7 +46,7 @@ async function handler (messageQueue, job) {
 async function _licences (licenceRef) {
   if (licenceRef) {
     return db.query(
-      `SELECT nal."ID", nal."LIC_NO", nal."FGAC_REGION_CODE" FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = $1;`,
+      'SELECT nal."ID", nal."LIC_NO", nal."FGAC_REGION_CODE" FROM "import"."NALD_ABS_LICENCES" nal WHERE nal."LIC_NO" = $1;',
       [licenceRef]
     )
   }

--- a/src/modules/return-logs/jobs/queue.js
+++ b/src/modules/return-logs/jobs/queue.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+const ImportJob = require('./import.js')
+
+const JOB_NAME = 'return-logs.queue'
+
+const QUERY = `
+  SELECT
+    nal."ID",
+    nal."LIC_NO",
+    nal."FGAC_REGION_CODE"
+  FROM
+    "import"."NALD_ABS_LICENCES" nal;
+`
+
+function createMessage () {
+  return {
+    name: JOB_NAME,
+    options: {
+      singletonKey: JOB_NAME
+    }
+  }
+}
+
+async function handler (messageQueue) {
+  try {
+    global.GlobalNotifier.omg(`${JOB_NAME}: started`)
+
+    // Get _all_ licences in NALD
+    const licences =  await db.query(QUERY)
+    const numberOfJobs = licences.length
+
+    for (const [index, licence] of licences.entries()) {
+      const data = {
+        licence: { id: licence.ID, licenceRef: licence.LIC_NO, regionCode: licence.FGAC_REGION_CODE },
+        jobNumber: index + 1,
+        numberOfJobs
+      }
+      await messageQueue.publish(ImportJob.createMessage(data))
+    }
+
+    return numberOfJobs
+  } catch (error) {
+    global.GlobalNotifier.omfg(`${JOB_NAME}: errored`, error)
+    throw error
+  }
+}
+
+async function onComplete (job) {
+  if (job.failed) {
+    global.GlobalNotifier.omg(`${JOB_NAME}: failed`)
+
+    return
+  }
+
+  global.GlobalNotifier.omg(`${JOB_NAME}: finished`, { queuedJobs: job.data.response.value })
+}
+
+module.exports = {
+  JOB_NAME,
+  createMessage,
+  handler,
+  onComplete
+}

--- a/src/modules/return-logs/jobs/queue.js
+++ b/src/modules/return-logs/jobs/queue.js
@@ -15,16 +15,19 @@ const QUERY = `
     "import"."NALD_ABS_LICENCES" nal;
 `
 
-function createMessage () {
+function createMessage (replicateReturnLogs) {
   return {
     name: JOB_NAME,
+    data: {
+      replicateReturnLogs
+    },
     options: {
       singletonKey: JOB_NAME
     }
   }
 }
 
-async function handler (messageQueue) {
+async function handler (messageQueue, job) {
   try {
     global.GlobalNotifier.omg(`${JOB_NAME}: started`)
 
@@ -36,7 +39,8 @@ async function handler (messageQueue) {
       const data = {
         licence: { id: licence.ID, licenceRef: licence.LIC_NO, regionCode: licence.FGAC_REGION_CODE },
         jobNumber: index + 1,
-        numberOfJobs
+        numberOfJobs,
+        replicateReturnLogs: job.data.replicateReturnLogs
       }
       await messageQueue.publish(ImportJob.createMessage(data))
     }

--- a/src/modules/return-logs/lib/cache.js
+++ b/src/modules/return-logs/lib/cache.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const createCachedQuery = (server, methodName, generate) => {
+  return server.cache({
+    segment: methodName,
+    expiresIn: 5 * 60 * 1000, // cache for 5 mins
+    generateFunc: id => {
+      return generate(id)
+    },
+    generateTimeout: 5000
+  })
+}
+
+const createId = (key, params) => {
+  return {
+    id: `${key}:${Object.entries(params).flatMap(num => num).join(':')}`,
+    ...params
+  }
+}
+module.exports = {
+  createCachedQuery,
+  createId
+}

--- a/src/modules/return-logs/lib/due-date.js
+++ b/src/modules/return-logs/lib/due-date.js
@@ -3,7 +3,7 @@
 const moment = require('moment')
 const { returns: { date: { getPeriodEnd } } } = require('@envage/water-abstraction-helpers')
 
-const { getReturnVersionReason } = require('./return-helpers.js')
+const returnHelpers = require('./return-helpers.js')
 const { mapProductionMonth } = require('./transform-returns-helpers.js')
 
 /**
@@ -48,7 +48,7 @@ const getDueDate = async (endDate, format) => {
   if (endDate === returnVersionEndDate) {
     // Find the mod log reason codes for the following return version
     const nextReturnVersion = parseInt(format.VERS_NO) + 1
-    const results = await getReturnVersionReason(format.AABL_ID, format.FGAC_REGION_CODE, nextReturnVersion)
+    const results = await returnHelpers.getReturnVersionReason(format.AABL_ID, format.FGAC_REGION_CODE, nextReturnVersion)
 
     // If the code matches, use the end date of the full return cycle to
     // calculate the due date

--- a/src/modules/return-logs/lib/due-date.js
+++ b/src/modules/return-logs/lib/due-date.js
@@ -1,7 +1,10 @@
+'use strict'
+
 const moment = require('moment')
-const returnsQueries = require('./nald-queries/returns')
 const { returns: { date: { getPeriodEnd } } } = require('@envage/water-abstraction-helpers')
-const { mapProductionMonth } = require('./transform-returns-helpers')
+
+const { getReturnVersionReason } = require('./return-helpers.js')
+const { mapProductionMonth } = require('./transform-returns-helpers.js')
 
 /**
  * Gets the return version end date of the supplied format
@@ -45,9 +48,7 @@ const getDueDate = async (endDate, format) => {
   if (endDate === returnVersionEndDate) {
     // Find the mod log reason codes for the following return version
     const nextReturnVersion = parseInt(format.VERS_NO) + 1
-    const results = await returnsQueries.getReturnVersionReason(
-      format.AABL_ID, format.FGAC_REGION_CODE, nextReturnVersion
-    )
+    const results = await getReturnVersionReason(format.AABL_ID, format.FGAC_REGION_CODE, nextReturnVersion)
 
     // If the code matches, use the end date of the full return cycle to
     // calculate the due date

--- a/src/modules/return-logs/lib/persist-returns.js
+++ b/src/modules/return-logs/lib/persist-returns.js
@@ -5,7 +5,7 @@
  */
 const moment = require('moment')
 
-const { replicateReturnsDataFromNaldForNonProductionEnvironments } = require('./returns-helper')
+const ReplicateReturnsDataFromNaldForNonProductionEnvironments = require('./replicate-returns.js')
 const returnsApi = require('../../../lib/connectors/returns')
 const config = require('../../../../config')
 const { returns } = returnsApi
@@ -59,7 +59,7 @@ const createOrUpdateReturn = async (row, replicateReturns) => {
 
     /* For non-production environments, we allow the system to import the returns data so we can test billing */
     if (!config.isProduction && replicateReturns) {
-      await replicateReturnsDataFromNaldForNonProductionEnvironments(row)
+      await ReplicateReturnsDataFromNaldForNonProductionEnvironments.go(row)
     }
     return thisReturn
   }

--- a/src/modules/return-logs/lib/queries.js
+++ b/src/modules/return-logs/lib/queries.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const getFormats = `
+  SELECT f.*,
+    v.*,
+    l."AREP_AREA_CODE",
+    l."EXPIRY_DATE" as "LICENCE_EXPIRY_DATE",
+    l."REV_DATE" as "LICENCE_REVOKED_DATE",
+    l."LAPSED_DATE" as "LICENCE_LAPSED_DATE"
+  FROM "import"."NALD_ABS_LICENCES" l
+    LEFT JOIN "import"."NALD_RET_FORMATS" f
+      ON l."ID"=f."ARVN_AABL_ID"
+      AND l."FGAC_REGION_CODE"=f."FGAC_REGION_CODE"
+    JOIN "import"."NALD_RET_VERSIONS" v
+      ON f."ARVN_VERS_NO"=v."VERS_NO"
+      AND f."ARVN_AABL_ID"=v."AABL_ID"
+      AND f."FGAC_REGION_CODE"=v."FGAC_REGION_CODE"
+  WHERE l."LIC_NO"=$1
+  ORDER BY to_date(v."EFF_ST_DATE", 'DD/MM/YYYY');
+`
+
+const getFormatPurposes = `
+  SELECT p.*,
+    p1."DESCR" AS primary_purpose,
+    p2."DESCR" AS secondary_purpose,
+    p3."DESCR" AS tertiary_purpose
+  FROM "import"."NALD_RET_FMT_PURPOSES" p
+    LEFT JOIN "import"."NALD_PURP_PRIMS" p1
+      ON p."APUR_APPR_CODE" = p1."CODE"
+    LEFT JOIN "import"."NALD_PURP_SECS" p2
+      ON p."APUR_APSE_CODE" = p2."CODE"
+    LEFT JOIN "import"."NALD_PURP_USES" p3
+      ON p."APUR_APUS_CODE" = p3."CODE"
+  WHERE p."ARTY_ID" = $1 AND p."FGAC_REGION_CODE" = $2;
+`
+
+const getFormatPoints = `
+  SELECT p.*
+  FROM "import"."NALD_RET_FMT_POINTS" fp
+    LEFT JOIN "import"."NALD_POINTS" p
+      ON fp."AAIP_ID" = p."ID" AND fp."FGAC_REGION_CODE" = p."FGAC_REGION_CODE"
+  WHERE fp."ARTY_ID" = $1
+  AND fp."FGAC_REGION_CODE" = $2;
+`
+
+const getLogs = `
+  SELECT l.*
+  FROM "import"."NALD_RET_FORM_LOGS" l
+  WHERE l."ARTY_ID" = $1 AND l."FGAC_REGION_CODE" = $2
+  ORDER BY to_date(l."DATE_FROM", 'DD/MM/YYYY');
+`
+
+const getLines = `
+  SELECT l.*
+  FROM "import"."NALD_RET_LINES" l
+  WHERE l."ARFL_ARTY_ID" = $1
+  AND l."FGAC_REGION_CODE" = $2
+  AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')>=to_date($3, 'YYYY-MM-DD')
+  AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')<=to_date($4, 'YYYY-MM-DD')
+  ORDER BY "RET_DATE";
+`
+
+const getLogLines = `
+  SELECT l.*
+  FROM "import"."NALD_RET_LINES" l
+  WHERE l."ARFL_ARTY_ID" = $1
+  AND l."FGAC_REGION_CODE" = $2
+  AND "ARFL_DATE_FROM" = $3
+  ORDER BY "RET_DATE";
+`
+
+const isNilReturn = `
+  SELECT SUM(
+    CASE
+      WHEN l."RET_QTY"='' THEN 0
+      ELSE l."RET_QTY"::float
+    END
+  ) AS total_qty
+  FROM "import"."NALD_RET_LINES" l
+  WHERE l."ARFL_ARTY_ID"=$1
+  AND l."FGAC_REGION_CODE"=$2
+  AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')>=to_date($3, 'YYYY-MM-DD')
+  AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')<=to_date($4, 'YYYY-MM-DD');
+`
+
+const getSplitDate = `
+  SELECT l."ID", v."ISSUE_NO", v."INCR_NO", v."EFF_ST_DATE", m.*
+  FROM "import"."NALD_ABS_LICENCES" l
+    JOIN "import"."NALD_ABS_LIC_VERSIONS" v
+      ON l."ID"=v."AABL_ID" AND l."FGAC_REGION_CODE"=v."FGAC_REGION_CODE"
+    JOIN "import"."NALD_MOD_LOGS" m
+      ON l."ID"=m."AABL_ID"
+      AND l."FGAC_REGION_CODE" = m."FGAC_REGION_CODE"
+      AND v."ISSUE_NO" = m."AABV_ISSUE_NO"
+      AND v."INCR_NO" = m."AABV_INCR_NO"
+  WHERE l."LIC_NO" = $1
+  AND m."AMRE_CODE" = 'SUCC'
+  ORDER BY to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') DESC
+  LIMIT 1;
+`
+
+const getReturnVersionReason = `
+  SELECT l."AMRE_CODE"
+  FROM import."NALD_RET_VERSIONS" rv
+    JOIN import."NALD_MOD_LOGS" l
+      ON l."ARVN_AABL_ID" = rv."AABL_ID"
+      AND l."ARVN_VERS_NO" = rv."VERS_NO"
+      AND l."FGAC_REGION_CODE" = rv."FGAC_REGION_CODE"
+      AND l."AMRE_AMRE_TYPE" = 'RET'
+  WHERE rv."AABL_ID" = $1
+  AND rv."VERS_NO" = $2
+  AND rv."FGAC_REGION_CODE" = $3;
+`
+
+module.exports = {
+  getFormats,
+  getFormatPurposes,
+  getFormatPoints,
+  getLogs,
+  getLines,
+  getLogLines,
+  isNilReturn,
+  getSplitDate,
+  getReturnVersionReason
+}

--- a/src/modules/return-logs/lib/return-helpers.js
+++ b/src/modules/return-logs/lib/return-helpers.js
@@ -1,0 +1,141 @@
+'use strict'
+
+const moment = require('moment')
+
+const server = require('../../../../server.js')
+const db = require('../../../lib/connectors/db.js')
+const cache = require('./cache.js')
+const queries = require('./queries.js')
+
+/**
+ * Gets form logs for specified licence number
+ * @param {String} licenceNumber
+ * @return {Promise} resolves with array of DB records
+ */
+const getFormats = (licenceNumber) => {
+  return db.query(queries.getFormats, [licenceNumber])
+}
+
+/**
+ * Get purposes attached to a returns format
+ * @param {Number} formatId - the ARTY_ID=
+ * @param {Number} region code - FGAC_REGION_CODE
+ * @return {Promise} resolves with array of DB records
+ */
+const getFormatPurposes = (formatId, regionCode) => {
+  return db.query(queries.getFormatPurposes, [formatId, regionCode])
+}
+
+/**
+ * Get points attached to a returns format
+ * @param {Number} formatId - the ARTY_ID=
+ * @param {Number} region code - FGAC_REGION_CODE
+ * @return {Promise} resolves with array of DB records
+ */
+const getFormatPoints = (formatId, regionCode) => {
+  return db.query(queries.getFormatPoints, [formatId, regionCode])
+}
+
+/**
+ * Get form logs for specified return format
+ * @param {Number} formatId - the ARTY_ID
+ * @return {Promise} resolves with array of DB records
+ */
+const getLogs = (formatId, regionCode) => {
+  return db.query(queries.getLogs, [formatId, regionCode])
+}
+
+/**
+ * Get returns lines
+ * @param {Number} formatId - the ARTY_ID=
+ * @param {Number} region code - FGAC_REGION_CODE
+ * @param {String} dateFrom - e.g. YYYY-MM-DD
+ * @param {String} dateTo - e.g. YYYY-MM-DD
+ * @return {Promise} resolves with array of DB records
+ */
+const getLines = (formatId, regionCode, dateFrom, dateTo) => {
+  const params = [formatId, regionCode, dateFrom, dateTo]
+  return db.query(queries.getLines, params)
+}
+
+/**
+ * Get returns lines for log
+ * @param {Number} formatId - the ARTY_ID=
+ * @param {Number} region code - FGAC_REGION_CODE
+ * @param {String} logDateFrom - e.g. DD/MM/YYYY
+ * @return {Promise} resolves with array of DB records
+ */
+const getLogLines = (formatId, regionCode, logDateFrom) => {
+  const from = moment(logDateFrom, 'DD/MM/YYYY').format('YYYYMMDD') + '000000'
+  const params = [formatId, regionCode, from]
+  return db.query(queries.getLogLines, params)
+}
+
+/**
+ * Checks for nil return over the specified time period
+ * @param {Number} formatId - the ARTY_ID=
+ * @param {Number} region code - FGAC_REGION_CODE
+ * @param {String} dateFrom - e.g. YYYY-MM-DD
+ * @param {String} dateTo - e.g. YYYY-MM-DD
+ * @return {Promise} resolves with boolean
+ */
+const isNilReturn = async (formatId, regionCode, dateFrom, dateTo) => {
+  const params = [formatId, regionCode, dateFrom, dateTo]
+  const rows = await db.query(queries.isNilReturn, params)
+  return rows[0].total_qty === 0
+}
+
+/**
+ * Gets the split date for considering returns as either current / non current
+ * Originally this date was the EFF_ST_DATE of the current licence version
+ * however this has been modified to only split if a licence version has
+ * a mod log reason code of SUCC - 'Succession To A Whole Licence/Licence Transfer'
+ * @param {String} licenceNumber - the licence number
+ * @return {String|null} split date in format YYYY-MM-DD, or null if none found
+ */
+const getSplitDate = async (licenceNumber) => {
+  const rows = await db.query(queries.getSplitDate, [licenceNumber])
+
+  return (rows.length === 1)
+    ? moment(rows[0].EFF_ST_DATE, 'DD/MM/YYYY').format('YYYY-MM-DD')
+    : null
+}
+
+/**
+ * Gets the reason code from the mod log relating to a new return version
+ * @param  {Number}  licenceId     - the NALD licence ID
+ * @param  {Number}  regionCode    - the NALD FGAC_REGION_CODE
+ * @param  {Number}  versionNumber - the version number of the return
+ * @return {Promise<Array>}          resolves with reason codes
+ */
+const getReturnVersionReason = async (licenceId, regionCode, versionNumber) => {
+  const id = cache.createId('returnVersionReason', {
+    licenceId,
+    regionCode,
+    versionNumber
+  })
+  return _getReturnVersionReasonCache.get(id)
+}
+
+const _createReturnVersionReasonCache = () => {
+  return cache.createCachedQuery(server, 'getReturnVersionReason', id => {
+    const params = [id.licenceId, id.versionNumber, id.regionCode]
+    return db.query(queries.getReturnVersionReason, params)
+  })
+}
+
+const _getReturnVersionReasonCache = _createReturnVersionReasonCache()
+
+module.exports = {
+  _createReturnVersionReasonCache,
+  _getReturnVersionReasonCache,
+  getFormats,
+  getFormatPurposes,
+  getFormatPoints,
+  getLogs,
+  getLines,
+  getLogLines,
+  isNilReturn,
+  getSplitDate,
+  getReturnVersionReason
+}

--- a/src/modules/return-logs/lib/transform-returns-helpers.js
+++ b/src/modules/return-logs/lib/transform-returns-helpers.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const moment = require('moment')
-
 const waterHelpers = require('@envage/water-abstraction-helpers')
 
 const { returns: { date: { getPeriodStart } } } = waterHelpers

--- a/src/modules/return-logs/lib/transform-returns.js
+++ b/src/modules/return-logs/lib/transform-returns.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const moment = require('moment')
-const queries = require('./lib/nald-queries/returns')
+const returnHelpers = require('./return-helpers.js')
 
-const helpers = require('./lib/transform-returns-helpers.js')
+const helpers = require('./transform-returns-helpers.js')
 
-const dueDate = require('./lib/due-date')
+const dueDate = require('./due-date')
 
 const { getReturnId } = require('@envage/water-abstraction-helpers').returns
 
@@ -15,14 +15,14 @@ const { getReturnId } = require('@envage/water-abstraction-helpers').returns
  * @return {Promise} resolves with array of formats
  */
 const getLicenceFormats = async (licenceNumber) => {
-  const splitDate = await queries.getSplitDate(licenceNumber)
+  const splitDate = await returnHelpers.getSplitDate(licenceNumber)
 
-  const formats = await queries.getFormats(licenceNumber)
+  const formats = await returnHelpers.getFormats(licenceNumber)
 
   // Load format data
   for (const format of formats) {
-    format.purposes = await queries.getFormatPurposes(format.ID, format.FGAC_REGION_CODE)
-    format.points = await queries.getFormatPoints(format.ID, format.FGAC_REGION_CODE)
+    format.purposes = await returnHelpers.getFormatPurposes(format.ID, format.FGAC_REGION_CODE)
+    format.points = await returnHelpers.getFormatPoints(format.ID, format.FGAC_REGION_CODE)
     format.cycles = helpers.getFormatCycles(format, splitDate)
   }
   return formats
@@ -51,7 +51,7 @@ const buildReturnsPacket = async (licenceNumber) => {
     // Get all the logs for the format here and filter later by cycle.
     // This saves having to make many requests to the database for
     // each format cycle.
-    const logs = await queries.getLogs(format.ID, format.FGAC_REGION_CODE)
+    const logs = await returnHelpers.getLogs(format.ID, format.FGAC_REGION_CODE)
 
     for (const cycle of format.cycles) {
       const { startDate, endDate, isCurrent } = cycle

--- a/src/modules/return-logs/plugin.js
+++ b/src/modules/return-logs/plugin.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const cron = require('node-cron')
+
+const QueueJob = require('./jobs/queue.js')
+const ImportJob = require('./jobs/import.js')
+
+const config = require('../../../config')
+
+async function register (server, _options) {
+  // Queue the licences for processing
+  await server.messageQueue.subscribe(QueueJob.JOB_NAME, () => {
+    return QueueJob.handler(server.messageQueue)
+  })
+  await server.messageQueue.onComplete(QueueJob.JOB_NAME, (executedJob) => {
+    return QueueJob.onComplete(executedJob)
+  })
+
+  // Register import return logs job
+  await server.messageQueue.subscribe(ImportJob.JOB_NAME, ImportJob.handler)
+  await server.messageQueue.onComplete(ImportJob.JOB_NAME, (executedJob) => {
+    return ImportJob.onComplete(executedJob)
+  })
+
+  // Schedule queue job using cron. The queue job will then queue the import job in its onComplete
+  cron.schedule(config.import.returnLogs.schedule, async () => {
+    if (!config.featureFlags.disableReturnsImports) {
+      await server.messageQueue.publish(QueueJob.createMessage())
+    }
+  })
+}
+
+module.exports = {
+  plugin: {
+    name: 'importReturnLogs',
+    dependencies: ['pgBoss'],
+    register
+  }
+}

--- a/src/modules/return-logs/plugin.js
+++ b/src/modules/return-logs/plugin.js
@@ -9,8 +9,8 @@ const config = require('../../../config')
 
 async function register (server, _options) {
   // Queue the licences for processing
-  await server.messageQueue.subscribe(QueueJob.JOB_NAME, () => {
-    return QueueJob.handler(server.messageQueue)
+  await server.messageQueue.subscribe(QueueJob.JOB_NAME, (executedJob) => {
+    return QueueJob.handler(server.messageQueue, executedJob)
   })
   await server.messageQueue.onComplete(QueueJob.JOB_NAME, (executedJob) => {
     return QueueJob.onComplete(executedJob)

--- a/src/modules/return-logs/routes.js
+++ b/src/modules/return-logs/routes.js
@@ -7,7 +7,32 @@ const routes = [
     method: 'post',
     handler: controller.importReturnLogs,
     path: '/import/return-logs'
-  }
+  },
+  {
+    method: 'post',
+    handler: controller.replicateReturnLogs,
+    path: '/replicate/return-logs'
+  },
+  {
+    method: 'get',
+    handler: controller.returnFormats,
+    path: '/import/1.0/nald/returns/formats'
+  },
+  {
+      method: 'get',
+      handler: controller.returnLogs,
+      path: '/import/1.0/nald/returns/logs'
+    },
+    {
+      method: 'get',
+      handler: controller.returnLogLines,
+      path: '/import/1.0/nald/returns/lines'
+    },
+  {
+    method: 'get',
+    handler: controller.returns,
+    path: '/import/1.0/nald/returns'
+  },
 ]
 
 module.exports = routes

--- a/src/modules/return-logs/routes.js
+++ b/src/modules/return-logs/routes.js
@@ -19,20 +19,20 @@ const routes = [
     path: '/import/1.0/nald/returns/formats'
   },
   {
-      method: 'get',
-      handler: controller.returnLogs,
-      path: '/import/1.0/nald/returns/logs'
-    },
-    {
-      method: 'get',
-      handler: controller.returnLogLines,
-      path: '/import/1.0/nald/returns/lines'
-    },
+    method: 'get',
+    handler: controller.returnLogs,
+    path: '/import/1.0/nald/returns/logs'
+  },
+  {
+    method: 'get',
+    handler: controller.returnLogLines,
+    path: '/import/1.0/nald/returns/lines'
+  },
   {
     method: 'get',
     handler: controller.returns,
     path: '/import/1.0/nald/returns'
-  },
+  }
 ]
 
 module.exports = routes

--- a/src/modules/return-logs/routes.js
+++ b/src/modules/return-logs/routes.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const controller = require('./controller')
+
+const routes = [
+  {
+    method: 'post',
+    handler: controller.importReturnLogs,
+    path: '/import/return-logs'
+  }
+]
+
+module.exports = routes

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ const jobSummaryRoutes = require('./modules/jobs/routes')
 const licenceImportRoutes = require('./modules/licence-import/routes')
 const naldImportRoutes = require('./modules/nald-import/routes')
 const returnsRoutes = require('./modules/returns/routes')
+const returnLogsRoutes = require('./modules/return-logs/routes')
 const returnVersionsRoutes = require('./modules/return-versions/routes.js')
 const modLogsRoutes = require('./modules/mod-logs/routes.js')
 const pointsRoutes = require('./modules/points/routes.js')
@@ -17,6 +18,7 @@ module.exports = [
   ...licenceImportRoutes,
   ...naldImportRoutes,
   ...returnsRoutes,
+  ...returnLogsRoutes,
   ...returnVersionsRoutes,
   ...modLogsRoutes,
   ...pointsRoutes

--- a/test/modules/nald-import/jobs/delete-removed-documents.test.js
+++ b/test/modules/nald-import/jobs/delete-removed-documents.test.js
@@ -15,8 +15,6 @@ const importService = require('../../../../src/lib/services/import')
 const DeleteRemovedDocumentsJob = require('../../../../src/modules/nald-import/jobs/delete-removed-documents')
 
 experiment('NALD Import: Delete Removed Documents job', () => {
-  const replicateReturns = false
-
   let notifierStub
 
   beforeEach(async () => {
@@ -36,16 +34,13 @@ experiment('NALD Import: Delete Removed Documents job', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = DeleteRemovedDocumentsJob.createMessage(replicateReturns)
+      const message = DeleteRemovedDocumentsJob.createMessage()
 
       expect(message).to.equal({
         name: 'nald-import.delete-removed-documents',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.delete-removed-documents'
-        },
-        data: {
-          replicateReturns: false
         }
       })
     })
@@ -105,7 +100,7 @@ experiment('NALD Import: Delete Removed Documents job', () => {
       beforeEach(async () => {
         job = {
           failed: false,
-          data: { request: { data: { replicateReturns: false } } }
+          data: { request: {} }
         }
       })
 

--- a/test/modules/nald-import/jobs/queue-licences.test.js
+++ b/test/modules/nald-import/jobs/queue-licences.test.js
@@ -16,8 +16,6 @@ const assertImportTablesExist = require('../../../../src/modules/nald-import/lib
 const QueueLicencesJob = require('../../../../src/modules/nald-import/jobs/queue-licences.js')
 
 experiment('NALD Import: Queue Licences job', () => {
-  const replicateReturns = false
-
   let notifierStub
 
   beforeEach(async () => {
@@ -41,16 +39,13 @@ experiment('NALD Import: Queue Licences job', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = QueueLicencesJob.createMessage(replicateReturns)
+      const message = QueueLicencesJob.createMessage()
 
       expect(message).to.equal({
         name: 'nald-import.queue-licences',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.queue-licences'
-        },
-        data: {
-          replicateReturns: false
         }
       })
     })
@@ -127,7 +122,7 @@ experiment('NALD Import: Queue Licences job', () => {
         job = {
           failed: false,
           data: {
-            request: { data: { replicateReturns: false } },
+            request: {},
             response: {
               licenceNumbers: [
                 'licence-1',
@@ -150,9 +145,7 @@ experiment('NALD Import: Queue Licences job', () => {
 
         const jobMessage = messageQueue.publish.firstCall.args[0]
 
-        expect(jobMessage.data).to.equal({
-          licenceNumber: 'licence-1', jobNumber: 1, numberOfJobs: 2, replicateReturns: false
-        })
+        expect(jobMessage.data).to.equal({ licenceNumber: 'licence-1', jobNumber: 1, numberOfJobs: 2 })
       })
 
       test('the import licence job is published to the queue for the second licence', async () => {
@@ -160,9 +153,7 @@ experiment('NALD Import: Queue Licences job', () => {
 
         const jobMessage = messageQueue.publish.lastCall.args[0]
 
-        expect(jobMessage.data).to.equal({
-          licenceNumber: 'licence-2', jobNumber: 2, numberOfJobs: 2, replicateReturns: false
-        })
+        expect(jobMessage.data).to.equal({ licenceNumber: 'licence-2', jobNumber: 2, numberOfJobs: 2 })
       })
 
       experiment('but an error is thrown', () => {

--- a/test/modules/nald-import/jobs/s3-download.test.js
+++ b/test/modules/nald-import/jobs/s3-download.test.js
@@ -48,8 +48,7 @@ experiment('NALD Import: S3 Download job', () => {
           singletonKey: 'nald-import.s3-download'
         },
         data: {
-          checkEtag: true,
-          replicateReturns: false
+          checkEtag: true
         }
       })
     })
@@ -309,7 +308,7 @@ experiment('NALD Import: S3 Download job', () => {
           job = {
             failed: false,
             data: {
-              request: { data: { replicateReturns: false } },
+              request: { data: {} },
               response: { isRequired: true }
             }
           }
@@ -360,7 +359,7 @@ experiment('NALD Import: S3 Download job', () => {
           job = {
             failed: false,
             data: {
-              request: { data: { replicateReturns: false } },
+              request: { data: {} },
               response: { isRequired: false }
             }
           }

--- a/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
+++ b/test/modules/nald-import/jobs/trigger-end-date-checks.test.js
@@ -15,8 +15,6 @@ const WaterSystemService = require('../../../../src/lib/services/water-system-se
 const TriggerEndDateCheckJob = require('../../../../src/modules/nald-import/jobs/trigger-end-date-check.js')
 
 experiment('NALD Import: Trigger End Date Check job', () => {
-  const replicateReturns = false
-
   let notifierStub
 
   beforeEach(async () => {
@@ -36,16 +34,13 @@ experiment('NALD Import: Trigger End Date Check job', () => {
 
   experiment('.createMessage', () => {
     test('formats a message for PG boss', async () => {
-      const message = TriggerEndDateCheckJob.createMessage(replicateReturns)
+      const message = TriggerEndDateCheckJob.createMessage()
 
       expect(message).to.equal({
         name: 'nald-import.trigger-end-date-check',
         options: {
           expireIn: '1 hours',
           singletonKey: 'nald-import.trigger-end-date-check'
-        },
-        data: {
-          replicateReturns: false
         }
       })
     })
@@ -105,7 +100,7 @@ experiment('NALD Import: Trigger End Date Check job', () => {
       beforeEach(async () => {
         job = {
           failed: false,
-          data: { request: { data: { replicateReturns: false } } }
+          data: { request: {} }
         }
       })
 

--- a/test/modules/return-logs/lib/due-date.test.js
+++ b/test/modules/return-logs/lib/due-date.test.js
@@ -4,10 +4,10 @@ const sandbox = require('sinon').createSandbox()
 const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-const dueDate = require('../../../../src/modules/nald-import/lib/due-date')
-const returnsQueries = require('../../../../src/modules/nald-import/lib/nald-queries/returns')
+const dueDate = require('../../../../src/modules/return-logs/lib/due-date.js')
+const returnHelpers = require('../../../../src/modules/return-logs/lib/return-helpers.js')
 
-experiment('modules/nald-import/lib/due-date', () => {
+experiment('modules/return-logs/lib/due-date', () => {
   experiment('getDueDate', () => {
     const formats = {
       nullEndDate: {
@@ -42,7 +42,7 @@ experiment('modules/nald-import/lib/due-date', () => {
       const endDate = '2019-01-01'
 
       beforeEach(async () => {
-        sandbox.stub(returnsQueries, 'getReturnVersionReason').resolves([])
+        sandbox.stub(returnHelpers, 'getReturnVersionReason').resolves([])
       })
 
       afterEach(async () => {
@@ -62,13 +62,13 @@ experiment('modules/nald-import/lib/due-date', () => {
       experiment('when the returns version end date equals the split end date', () => {
         test('the getReturnVersionReason query is called with licence ID, region, and the incremented return version number', async () => {
           await dueDate.getDueDate(endDate, formats.summerProductionMonth)
-          const { args } = returnsQueries.getReturnVersionReason.lastCall
+          const { args } = returnHelpers.getReturnVersionReason.lastCall
           expect(args).to.equal(['licence_id_1', 'region_1', 101])
         })
 
         experiment('and the mod log reason is in VARF, VARM, AMND, NAME, REDS, SPAC, SPAN, XCORR', () => {
           beforeEach(async () => {
-            returnsQueries.getReturnVersionReason.resolves([{
+            returnHelpers.getReturnVersionReason.resolves([{
               AMRE_CODE: 'VARF'
             }])
           })
@@ -86,7 +86,7 @@ experiment('modules/nald-import/lib/due-date', () => {
 
         experiment('and the mod log reason is not in VARF, VARM, AMND, NAME, REDS, SPAC, SPAN, XCORR', () => {
           beforeEach(async () => {
-            returnsQueries.getReturnVersionReason.resolves([{
+            returnHelpers.getReturnVersionReason.resolves([{
               AMRE_CODE: 'NO-MATCH'
             }])
           })

--- a/test/modules/return-logs/lib/persist-returns.test.js
+++ b/test/modules/return-logs/lib/persist-returns.test.js
@@ -6,9 +6,9 @@ const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi
 const { expect } = require('@hapi/code')
 const { v4: uuid } = require('uuid')
 
-const returnsApi = require('../../../../src/lib/connectors/returns')
-const db = require('../../../../src/modules/nald-import/lib/db')
-const persistReturns = require('../../../../src/modules/nald-import/lib/persist-returns')
+const returnsConnector = require('../../../../src/lib/connectors/returns.js')
+const db = require('../../../../src/lib/connectors/db.js')
+const persistReturns = require('../../../../src/modules/return-logs/lib/persist-returns.js')
 
 const naldReturn = {
   return_id: 'v1:123:456',
@@ -42,23 +42,23 @@ const digitalServiceReturn = {
   due_date: '2018-11-28'
 }
 
-experiment('test/modules/nald-import/lib/persist-returns', () => {
+experiment('modules/return-logs/lib/persist-returns', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery').resolves([{}])
+    sandbox.stub(db, 'query').resolves([{}])
 
-    sandbox.stub(returnsApi.returns, 'findOne')
-    sandbox.stub(returnsApi.returns, 'create')
-    sandbox.stub(returnsApi.returns, 'updateOne')
+    sandbox.stub(returnsConnector.returns, 'findOne')
+    sandbox.stub(returnsConnector.returns, 'create')
+    sandbox.stub(returnsConnector.returns, 'updateOne')
 
-    sandbox.stub(returnsApi.versions, 'create').resolves({
+    sandbox.stub(returnsConnector.versions, 'create').resolves({
       data: {
         version_id: uuid(),
         return_id: 'v1:234:789'
       }
     })
-    sandbox.stub(returnsApi.versions, 'updateOne')
+    sandbox.stub(returnsConnector.versions, 'updateOne')
 
-    sandbox.stub(returnsApi.lines, 'create')
+    sandbox.stub(returnsConnector.lines, 'create')
   })
 
   afterEach(async () => {
@@ -67,13 +67,13 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
 
   experiment('.returnExists', () => {
     test('returns true if return exists', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
+      returnsConnector.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
       const exists = await persistReturns.returnExists('01/123')
       expect(exists).to.equal(true)
     })
 
     test('returns false if return does not exist', async () => {
-      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
+      returnsConnector.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
       const exists = await persistReturns.returnExists('01/123')
       expect(exists).to.equal(false)
     })
@@ -101,22 +101,22 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
 
   experiment('.createOrUpdateReturn', () => {
     test('creates a row if the record is not present', async () => {
-      returnsApi.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
-      returnsApi.returns.create.resolves({ error: null })
+      returnsConnector.returns.findOne.resolves({ error: { name: 'NotFoundError' }, data: null })
+      returnsConnector.returns.create.resolves({ error: null })
 
       await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall.args[0]).to.equal(naldReturn)
-      expect(returnsApi.returns.updateOne.firstCall).to.equal(null)
+      expect(returnsConnector.returns.create.firstCall.args[0]).to.equal(naldReturn)
+      expect(returnsConnector.returns.updateOne.firstCall).to.equal(null)
     })
 
     test('updates a NALD return if the record is present', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: naldReturn })
-      returnsApi.returns.updateOne.resolves({ error: null })
+      returnsConnector.returns.findOne.resolves({ error: null, data: naldReturn })
+      returnsConnector.returns.updateOne.resolves({ error: null })
       await persistReturns.createOrUpdateReturn(naldReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall).to.equal(null)
-      expect(returnsApi.returns.updateOne.firstCall.args).to.equal([naldReturn.return_id, {
+      expect(returnsConnector.returns.create.firstCall).to.equal(null)
+      expect(returnsConnector.returns.updateOne.firstCall.args).to.equal([naldReturn.return_id, {
         metadata: naldReturn.metadata,
         status: naldReturn.status,
         received_date: naldReturn.received_date,
@@ -125,12 +125,12 @@ experiment('test/modules/nald-import/lib/persist-returns', () => {
     })
 
     test('updates a digital service return metadata only if the record is present', async () => {
-      returnsApi.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
-      returnsApi.returns.updateOne.resolves({ error: null })
+      returnsConnector.returns.findOne.resolves({ error: null, data: digitalServiceReturn })
+      returnsConnector.returns.updateOne.resolves({ error: null })
       await persistReturns.createOrUpdateReturn(digitalServiceReturn, '2018-01-01')
 
-      expect(returnsApi.returns.create.firstCall).to.equal(null)
-      expect(returnsApi.returns.updateOne.firstCall.args).to.equal([digitalServiceReturn.return_id, {
+      expect(returnsConnector.returns.create.firstCall).to.equal(null)
+      expect(returnsConnector.returns.updateOne.firstCall.args).to.equal([digitalServiceReturn.return_id, {
         metadata: digitalServiceReturn.metadata,
         due_date: digitalServiceReturn.due_date
       }])

--- a/test/modules/return-logs/lib/return-helpers.test.js
+++ b/test/modules/return-logs/lib/return-helpers.test.js
@@ -10,14 +10,14 @@ const {
 const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
 
-const returns = require('../../../../../src/modules/nald-import/lib/nald-queries/returns')
-const cache = require('../../../../../src/modules/nald-import/lib/nald-queries/cache')
-const db = require('../../../../../src/modules/nald-import/lib/db')
-const sql = require('../../../../../src/modules/nald-import/lib/nald-queries/sql/returns')
+const returnHelpers = require('../../../../src/modules/return-logs/lib/return-helpers.js')
+const cache = require('../../../../src/modules/return-logs/lib/cache.js')
+const db = require('../../../../src/lib/connectors/db.js')
+const queries = require('../../../../src/modules/return-logs/lib/queries.js')
 
-experiment('modules/nald-import/lib/queries/returns', () => {
+experiment('modules/return-logs/lib/return-helpers', () => {
   beforeEach(async () => {
-    sandbox.stub(db, 'dbQuery')
+    sandbox.stub(db, 'query')
     sandbox.stub(cache, 'createCachedQuery')
   })
 
@@ -27,64 +27,64 @@ experiment('modules/nald-import/lib/queries/returns', () => {
 
   experiment('.getFormats', () => {
     beforeEach(async () => {
-      await returns.getFormats('test-lic')
+      await returnHelpers.getFormats('test-lic')
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getFormats)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getFormats)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal(['test-lic'])
     })
   })
 
   experiment('.getFormatPurposes', () => {
     beforeEach(async () => {
-      await returns.getFormatPurposes('test-format', 'test-region')
+      await returnHelpers.getFormatPurposes('test-format', 'test-region')
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getFormatPurposes)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getFormatPurposes)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal(['test-format', 'test-region'])
     })
   })
 
   experiment('.getFormatPoints', () => {
     beforeEach(async () => {
-      await returns.getFormatPoints('test-format', 'test-region')
+      await returnHelpers.getFormatPoints('test-format', 'test-region')
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getFormatPoints)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getFormatPoints)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal(['test-format', 'test-region'])
     })
   })
 
   experiment('.getLogs', () => {
     beforeEach(async () => {
-      await returns.getLogs('test-format', 'test-region')
+      await returnHelpers.getLogs('test-format', 'test-region')
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getLogs)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getLogs)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal(['test-format', 'test-region'])
     })
   })
@@ -100,16 +100,16 @@ experiment('modules/nald-import/lib/queries/returns', () => {
       regionCode = 'test-region-code'
       dateFrom = 'test-date-from'
       dateTo = 'test-date-to'
-      await returns.getLines(formatId, regionCode, dateFrom, dateTo)
+      await returnHelpers.getLines(formatId, regionCode, dateFrom, dateTo)
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getLines)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getLines)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal([formatId, regionCode, dateFrom, dateTo])
     })
   })
@@ -124,16 +124,16 @@ experiment('modules/nald-import/lib/queries/returns', () => {
       regionCode = 'test-region-code'
       logDateFrom = '01/01/2000'
 
-      await returns.getLogLines(formatId, regionCode, logDateFrom)
+      await returnHelpers.getLogLines(formatId, regionCode, logDateFrom)
     })
 
     test('uses the correct query', async () => {
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getLogLines)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getLogLines)
     })
 
     test('passes the expected params to the database query', async () => {
-      const [, params] = db.dbQuery.lastCall.args
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal([
         formatId,
         regionCode,
@@ -154,30 +154,30 @@ experiment('modules/nald-import/lib/queries/returns', () => {
       dateFrom = 'test-date-from'
       dateTo = 'test-date-to'
 
-      db.dbQuery.resolves([{ total_qty: 0 }])
+      db.query.resolves([{ total_qty: 0 }])
     })
 
     test('uses the correct query', async () => {
-      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.isNilReturn)
+      await returnHelpers.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.isNilReturn)
     })
 
     test('passes the expected params to the database query', async () => {
-      await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
-      const [, params] = db.dbQuery.lastCall.args
+      await returnHelpers.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal([formatId, regionCode, dateFrom, dateTo])
     })
 
     test('returns true if the total quantity is zero', async () => {
-      db.dbQuery.resolves([{ total_qty: 0 }])
-      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      db.query.resolves([{ total_qty: 0 }])
+      const result = await returnHelpers.isNilReturn(formatId, regionCode, dateFrom, dateTo)
       expect(result).to.equal(true)
     })
 
     test('returns false if the total quantity is not zero', async () => {
-      db.dbQuery.resolves([{ total_qty: 1 }])
-      const result = await returns.isNilReturn(formatId, regionCode, dateFrom, dateTo)
+      db.query.resolves([{ total_qty: 1 }])
+      const result = await returnHelpers.isNilReturn(formatId, regionCode, dateFrom, dateTo)
       expect(result).to.equal(false)
     })
   })
@@ -188,30 +188,30 @@ experiment('modules/nald-import/lib/queries/returns', () => {
     beforeEach(async () => {
       licenceNumber = 'test-licence-number'
 
-      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }])
+      db.query.resolves([{ EFF_ST_DATE: '01/01/2000' }])
     })
 
     test('uses the correct query', async () => {
-      await returns.getSplitDate(licenceNumber)
-      const [query] = db.dbQuery.lastCall.args
-      expect(query).to.equal(sql.getSplitDate)
+      await returnHelpers.getSplitDate(licenceNumber)
+      const [query] = db.query.lastCall.args
+      expect(query).to.equal(queries.getSplitDate)
     })
 
     test('passes the expected params to the database query', async () => {
-      await returns.getSplitDate(licenceNumber)
-      const [, params] = db.dbQuery.lastCall.args
+      await returnHelpers.getSplitDate(licenceNumber)
+      const [, params] = db.query.lastCall.args
       expect(params).to.equal([licenceNumber])
     })
 
     test('returns the date if there are result rows', async () => {
-      db.dbQuery.resolves([{ EFF_ST_DATE: '01/01/2000' }])
-      const result = await returns.getSplitDate(licenceNumber)
+      db.query.resolves([{ EFF_ST_DATE: '01/01/2000' }])
+      const result = await returnHelpers.getSplitDate(licenceNumber)
       expect(result).to.equal('2000-01-01')
     })
 
     test('returns null if there are no result rows', async () => {
-      db.dbQuery.resolves([])
-      const result = await returns.getSplitDate(licenceNumber)
+      db.query.resolves([])
+      const result = await returnHelpers.getSplitDate(licenceNumber)
       expect(result).to.equal(null)
     })
   })
@@ -219,13 +219,13 @@ experiment('modules/nald-import/lib/queries/returns', () => {
   experiment('.getReturnVersionReason', () => {
     experiment('._createReturnVersionReasonCache', async () => {
       test('creates a cache with the expected method name', async () => {
-        returns._createReturnVersionReasonCache()
+        returnHelpers._createReturnVersionReasonCache()
         const [, methodName] = cache.createCachedQuery.lastCall.args
         expect(methodName).to.equal('getReturnVersionReason')
       })
 
       test('creates a cache with the required generate func', async () => {
-        returns._createReturnVersionReasonCache()
+        returnHelpers._createReturnVersionReasonCache()
         const [, , generate] = cache.createCachedQuery.lastCall.args
         const id = {
           licenceId: 'test-licence',
@@ -235,19 +235,19 @@ experiment('modules/nald-import/lib/queries/returns', () => {
 
         await generate(id)
 
-        const [query, params] = db.dbQuery.lastCall.args
+        const [query, params] = db.query.lastCall.args
 
-        expect(query).to.equal(sql.getReturnVersionReason)
+        expect(query).to.equal(queries.getReturnVersionReason)
         expect(params).to.equal(['test-licence', 'test-version', 'test-region'])
       })
     })
 
     test('passes the expected id object to the cache provider', async () => {
-      sandbox.stub(returns._getReturnVersionReasonCache, 'get')
+      sandbox.stub(returnHelpers._getReturnVersionReasonCache, 'get')
 
-      await returns.getReturnVersionReason('test-licence', 'test-region', 'test-version')
+      await returnHelpers.getReturnVersionReason('test-licence', 'test-region', 'test-version')
 
-      const [id] = returns._getReturnVersionReasonCache.get.lastCall.args
+      const [id] = returnHelpers._getReturnVersionReasonCache.get.lastCall.args
 
       expect(id.id).to.equal('returnVersionReason:licenceId:test-licence:regionCode:test-region:versionNumber:test-version')
       expect(id.licenceId).to.equal('test-licence')

--- a/test/modules/return-logs/lib/transform-returns-helpers.test.js
+++ b/test/modules/return-logs/lib/transform-returns-helpers.test.js
@@ -5,9 +5,9 @@ const { expect } = require('@hapi/code')
 const moment = require('moment')
 moment.locale('en-gb')
 
-const transformReturnHelpers = require('../../../../src/modules/nald-import/lib/transform-returns-helpers')
+const transformReturnHelpers = require('../../../../src/modules/return-logs/lib/transform-returns-helpers.js')
 
-experiment('modules/nald-import/lib/transform-return-helpers', () => {
+experiment('modules/return-logs/lib/transform-return-helpers', () => {
   experiment('.mapPeriod', () => {
     test('Test mapping of NALD returns periods codes', async () => {
       expect(transformReturnHelpers.mapPeriod('D')).to.equal('day')

--- a/test/modules/return-logs/lib/transform-returns.test.js
+++ b/test/modules/return-logs/lib/transform-returns.test.js
@@ -7,21 +7,21 @@ const sandbox = sinon.createSandbox()
 const moment = require('moment')
 moment.locale('en-gb')
 
-const { buildReturnsPacket, getLicenceFormats } = require('../../../src/modules/nald-import/transform-returns')
-const queries = require('../../../src/modules/nald-import/lib/nald-queries/returns')
-const helpers = require('../../../src/modules/nald-import/lib/transform-returns-helpers.js')
-const dueDate = require('../../../src/modules/nald-import/lib/due-date')
+const { buildReturnsPacket, getLicenceFormats } = require('../../../../src/modules/return-logs/lib/transform-returns.js')
+const returnHelpers = require('../../../../src/modules/return-logs/lib/return-helpers.js')
+const transformReturnHelpers = require('../../../../src/modules/return-logs/lib/transform-returns-helpers.js')
+const dueDate = require('../../../../src/modules/return-logs/lib/due-date.js')
 
-experiment('modules/nald-import/transform-returns', () => {
+experiment('modules/return-logs/lib/transform-returns', () => {
   experiment('getLicenceFormats', () => {
     beforeEach(() => {
       const formats = [{ name: 'format1' }]
 
-      sandbox.stub(queries, 'getSplitDate').returns()
-      sandbox.stub(queries, 'getFormats').returns(formats)
-      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes')
-      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints')
-      sandbox.stub(helpers, 'getFormatCycles').returns('formatCycles')
+      sandbox.stub(returnHelpers, 'getSplitDate').returns()
+      sandbox.stub(returnHelpers, 'getFormats').returns(formats)
+      sandbox.stub(returnHelpers, 'getFormatPurposes').returns('formatPurposes')
+      sandbox.stub(returnHelpers, 'getFormatPoints').returns('formatPoints')
+      sandbox.stub(transformReturnHelpers, 'getFormatCycles').returns('formatCycles')
     })
 
     afterEach(() => {
@@ -49,18 +49,18 @@ experiment('modules/nald-import/transform-returns', () => {
     }]
 
     beforeEach(() => {
-      sandbox.stub(queries, 'getSplitDate').returns()
-      sandbox.stub(queries, 'getFormats').returns(formats)
-      sandbox.stub(queries, 'getFormatPurposes').returns('formatPurposes')
-      sandbox.stub(queries, 'getFormatPoints').returns('formatPoints')
-      sandbox.stub(helpers, 'getFormatCycles').returns(cycle)
-      sandbox.stub(queries, 'getLogs').returns(logs)
-      sandbox.stub(helpers, 'mapReceivedDate').returns()
-      sandbox.stub(helpers, 'getStatus').returns()
+      sandbox.stub(returnHelpers, 'getSplitDate').returns()
+      sandbox.stub(returnHelpers, 'getFormats').returns(formats)
+      sandbox.stub(returnHelpers, 'getFormatPurposes').returns('formatPurposes')
+      sandbox.stub(returnHelpers, 'getFormatPoints').returns('formatPoints')
+      sandbox.stub(transformReturnHelpers, 'getFormatCycles').returns(cycle)
+      sandbox.stub(returnHelpers, 'getLogs').returns(logs)
+      sandbox.stub(transformReturnHelpers, 'mapReceivedDate').returns()
+      sandbox.stub(transformReturnHelpers, 'getStatus').returns()
       sandbox.stub(dueDate, 'getDueDate').returns('2019-04-28')
-      sandbox.stub(helpers, 'mapPeriod').returns('monthly')
-      sandbox.stub(helpers, 'formatReturnMetadata').returns({ version: 1 })
-      sandbox.stub(helpers, 'getFormatEndDate')
+      sandbox.stub(transformReturnHelpers, 'mapPeriod').returns('monthly')
+      sandbox.stub(transformReturnHelpers, 'formatReturnMetadata').returns({ version: 1 })
+      sandbox.stub(transformReturnHelpers, 'getFormatEndDate')
     })
 
     afterEach(() => {
@@ -78,14 +78,14 @@ experiment('modules/nald-import/transform-returns', () => {
     })
 
     test('isFinal flag returns true if endDate matches format end date', async () => {
-      helpers.getFormatEndDate.returns('2019-03-31')
+      transformReturnHelpers.getFormatEndDate.returns('2019-03-31')
       const { returns } = await buildReturnsPacket('123/xyz')
 
       expect(returns[0].metadata).to.include('"isFinal":true')
     })
 
     test('isFinal flag returns false if endDate does not match format end date', async () => {
-      helpers.getFormatEndDate.returns('2019-04-01')
+      transformReturnHelpers.getFormatEndDate.returns('2019-04-01')
       const { returns } = await buildReturnsPacket('123/xyz')
 
       expect(returns[0].metadata).to.include('"isFinal":false')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

We've realised NALD has return log data that we don't. Initially, we thought it was just the return lines for pre-2013 return logs. But after some digging, it appears there are not only the return submission lines but also some return logs we don't have that NALD does.

Putting aside the missing return logs, we need to get those missing return submission lines in. We have found that NALD structures the return logs and submission data _very_ differently from WRLS. Our plan to do something 'quick & dirty' with a SQL query is therefore not possible. That means we'll need to code a solution.

We intend to [stop all 'return leg' processes](https://github.com/DEFRA/water-abstraction-import/pull/1054) in the very near future, just as soon as WRLS takes over from NALD on all things 'returns' related. So, it makes no sense to start from scratch. This project understands how to interpret and create WRLS return logs and submission data based on what NALD holds. We could work with it and make the necessary changes to get this missing data in, including the missing return logs.

But that will be much easier if we can move the return logs logic into its own job. Currently, it is tightly coupled to the NALD licence import process, meaning you must run it to see what it is doing with the return logs.

This change splits it into its own 'job', which we can then trigger and amend going forward.