### PR TITLE
Replace faulty replicate returns logic

### DIFF
--- a/src/modules/return-logs/controller.js
+++ b/src/modules/return-logs/controller.js
@@ -3,6 +3,7 @@
 const Boom = require('@hapi/boom')
 
 const QueueJob = require('./jobs/queue.js')
+const ImportJob = require('./jobs/import.js')
 const { getFormats, getLogLines, getLogs } = require('./lib/return-helpers.js')
 const { buildReturnsPacket } = require('./lib/transform-returns.js')
 
@@ -10,6 +11,7 @@ async function importReturnLogs (request, h) {
   const licenceRef = request.payload?.licenceRef ?? null
 
   await request.messageQueue.deleteQueue(QueueJob.JOB_NAME)
+  await request.messageQueue.deleteQueue(ImportJob.JOB_NAME)
   await request.messageQueue.publish(QueueJob.createMessage(false, licenceRef))
 
   return h.response().code(204)

--- a/src/modules/return-logs/lib/persist-returns.js
+++ b/src/modules/return-logs/lib/persist-returns.js
@@ -9,7 +9,7 @@ const moment = require('moment')
 const helpers = require('@envage/water-abstraction-helpers')
 
 const db = require('../../../lib/connectors/db.js')
-const ReplicateReturnsDataFromNaldForNonProductionEnvironments = require('./replicate-returns.js')
+const ReplicateReturns = require('./replicate-returns.js')
 
 /**
  * Updates matching return logs or creates missing ones based on those determined by the import from NALD data
@@ -95,7 +95,7 @@ async function _createOrUpdateReturn (row, replicateReturns) {
     // held in NALD. You can only set `replicateReturnLogs` by manually triggering the `/replicate/return-logs`
     // endpoint.
     if (replicateReturns) {
-      await ReplicateReturnsDataFromNaldForNonProductionEnvironments.go(row)
+      await ReplicateReturns.go(row)
     }
   }
 }

--- a/src/modules/return-logs/lib/replicate-returns.js
+++ b/src/modules/return-logs/lib/replicate-returns.js
@@ -20,9 +20,12 @@ async function go (row) {
   const naldLineData = _naldLineData(naldLines)
 
   const version = _version(row)
-  const blankLines = _blankLines(row)
+  const wrlsLines = _blankLines(row)
 
-  _populateBlankLines(row, version, blankLines, naldLineData)
+  _populateBlankLines(row, version, wrlsLines, naldLineData)
+
+  await _saveVersion(version)
+  await _saveLines(wrlsLines)
 }
 
 function _blankLines (row) {
@@ -149,6 +152,70 @@ function _version (row) {
     user_type: 'system',
     version_id: uuid(),
     version_number: parsedMetadata.version
+  }
+}
+
+async function _saveVersion (version) {
+  const params = [
+    version.current,
+    version.metadata,
+    version.nil_return,
+    version.return_id,
+    version.user_id,
+    version.user_type,
+    version.version_id,
+    version.version_number
+  ]
+
+  const query = `
+    INSERT INTO "returns"."versions" (
+      current,
+      metadata,
+      nil_return,
+      return_id,
+      user_id,
+      user_type,
+      version_id,
+      version_number,
+      created_at,
+      updated_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), now())
+  `
+
+  await db.query(query, params)
+}
+
+async function _saveLines (lines) {
+  const query = `
+    INSERT INTO "returns".lines (
+      end_date,
+      line_id,
+      metadata,
+      quantity,
+      reading_type,
+      start_date,
+      time_period,
+      user_unit,
+      version_id,
+      created_at,
+      updated_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), now())
+  `
+
+  for (const line of lines) {
+    const params = [
+      line.end_date,
+      line.line_id,
+      line.metadata,
+      line.quantity,
+      line.reading_type,
+      line.start_date,
+      line.time_period,
+      line.user_unit,
+      line.version_id
+    ]
+
+    await db.query(query, params)
   }
 }
 

--- a/src/modules/return-logs/lib/replicate-returns.js
+++ b/src/modules/return-logs/lib/replicate-returns.js
@@ -1,125 +1,157 @@
 'use strict'
 
-const moment = require('moment')
 const { v4: uuid } = require('uuid')
+const { returns: returnsHelpers } = require('@envage/water-abstraction-helpers')
 
 const db = require('../../../lib/connectors/db.js')
-const { versions, lines } = require('../../../lib/connectors/returns.js')
+const { daysFromPeriod, weeksFromPeriod, monthsFromPeriod } = require('./return-helpers.js')
 
-const DB_DATE_FORMAT = 'YYYY-MM-DD'
-
-/* MAIN FUNC */
-const go = async thisReturn => {
-  const { metadata } = thisReturn
-  // create returns.versions
-  const version = await versions.create({
-    metadata,
-    version_id: uuid(),
-    return_id: thisReturn.return_id,
-    user_id: 'imported@from.nald',
-    user_type: 'system',
-    version_number: JSON.parse(metadata).version,
-    nil_return: false,
-    current: JSON.parse(metadata).isCurrent
-  })
-
-  const naldReturnFormatQuery = await db.query('SELECT * FROM import."NALD_RET_FORMATS" WHERE "ID" = $1', [thisReturn.return_requirement])
-  const naldReturnFormat = naldReturnFormatQuery[0]
-
-  const naldLinesFromNaldReturnFormLogs = await db.query(`
-        SELECT * FROM import."NALD_RET_FORM_LOGS"
-        WHERE "ARTY_ID" = $1
-        AND "FGAC_REGION_CODE" = $2
-        AND "DATE_FROM" = $3
-        ORDER BY to_date("DATE_FROM", 'DD/MM/YYYY')`,
-  [
-    thisReturn.return_requirement,
-    naldReturnFormat.FGAC_REGION_CODE,
-      `${padDateComponent(naldReturnFormat.ABS_PERIOD_ST_DAY)}/${padDateComponent(naldReturnFormat.ABS_PERIOD_ST_MONTH)}/${moment(thisReturn.start_date).format('YYYY')}`
-  ])
-
-  const returnLinesFromNaldReturnLines = await db.query(`
-            SELECT * FROM import."NALD_RET_LINES" WHERE
-            "ARFL_ARTY_ID" = $1
-            AND "FGAC_REGION_CODE" = $2
-            AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')>=to_date($3, $5)
-            AND to_date("RET_DATE", 'YYYYMMDDHH24MISS')<=to_date($4, $5)
-            ORDER BY "RET_DATE";
-        `,
-  [
-    thisReturn.return_requirement,
-    naldReturnFormat.FGAC_REGION_CODE,
-      `${moment(thisReturn.start_date).format('YYYY')}-${padDateComponent(naldReturnFormat.ABS_PERIOD_ST_MONTH)}-${padDateComponent(naldReturnFormat.ABS_PERIOD_ST_DAY)}`,
-      `${moment(thisReturn.start_date).add(naldReturnFormat.ABS_PERIOD_END_MONTH < naldReturnFormat.ABS_PERIOD_ST_MONTH ? 1 : 0, 'year').format('YYYY')}-${padDateComponent(naldReturnFormat.ABS_PERIOD_END_MONTH)}-${padDateComponent(naldReturnFormat.ABS_PERIOD_END_DAY)}`,
-      DB_DATE_FORMAT
-  ])
-
-  // Two db queries have been run
-  // Now we check if they have pulled any data from the db
-  // If they have, set qtyKey to be the name of the column we will be summing up
-  // Set iterable to the data set we will be summing
-  let qtyKey
-  let iterable
-
-  if (returnLinesFromNaldReturnLines.length > 0) {
-    qtyKey = 'RET_QTY'
-    iterable = returnLinesFromNaldReturnLines
-  } else if (naldLinesFromNaldReturnFormLogs.length > 0) {
-    qtyKey = 'MONTHLY_RET_QTY'
-    iterable = naldLinesFromNaldReturnFormLogs
-  } else {
-    iterable = []
+async function go (row) {
+  // TODO: Support old NALD quarterly and yearly returns
+  if (row.returns_frequency === 'quarter' || row.returns_frequency === 'year') {
+    return
   }
 
-  const sumOfLines = iterable
-    .map((item) => parseFloat(item[qtyKey]))
-    .filter((value) => ![null, undefined, NaN].includes(value))
-    .reduce((acc, num) => acc + num, 0)
+  if (row.status !== 'completed') {
+    return
+  }
 
-  if (sumOfLines === 0) {
-    await versions.updateOne(version.data.version_id, { nil_return: true }, ['nil_return'])
-  } else {
-    iterable.forEach(line => {
-      let startDate
-      let endDate
+  const naldLines = await _naldLines(row.return_id)
+  const naldLineData = _naldLineData(naldLines)
 
-      if (returnLinesFromNaldReturnLines.length > 0) {
-        startDate = moment(line.RET_DATE, 'YYYYMMDD000000').format(DB_DATE_FORMAT)
-        endDate = moment(line.RET_DATE, 'YYYYMMDD000000').format(DB_DATE_FORMAT)
-      } else {
-        startDate = moment(line.FORM_PROD_ST_DATE, 'DD/MM/YYYY').format(DB_DATE_FORMAT)
-        endDate = moment(line.FORM_PROD_ST_DATE, 'DD/MM/YYYY').format(DB_DATE_FORMAT)
-      }
+  const version = _version (row)
+  const blankLines = _blankLines(row)
 
-      createLine(version.data.version_id, startDate, endDate, naldReturnFormat.ARTC_REC_FREQ_CODE, line, qtyKey)
-    })
+  _populateBlankLines(row, version, blankLines, naldLineData)
+}
+
+function _blankLines (row) {
+  const frequency = row.returns_frequency
+  const startDate = new Date(row.start_date)
+  const endDate = new Date(row.end_date)
+
+  if (frequency === 'day') {
+    return daysFromPeriod(startDate, endDate)
+  }
+
+  if (frequency === 'week') {
+    return weeksFromPeriod(startDate, endDate)
+  }
+
+  return monthsFromPeriod(startDate, endDate)
+}
+
+function _populateBlankLines (row, version, blankLines, naldLineData) {
+  let nilReturn = true
+
+  for (const line of blankLines) {
+    line.line_id = uuid()
+    line.version_id = version.version_id
+    line.time_period = row.returns_frequency
+    line.metadata = {}
+    line.user_unit = returnsHelpers.mappers.mapUnit(naldLineData.userUnit)
+    line.reading_type = returnsHelpers.mappers.mapUsability(naldLineData.readingType)
+    line.quantity = _totalLineQuantity(line, naldLineData.lines)
+
+    if (line.quantity !== null) {
+      nilReturn = false
+    }
+  }
+
+  version.nil_return = nilReturn
+}
+
+function _naldLineData (naldLines) {
+  const { RET_QTY_USABILITY: readingType, UNIT_RET_FLAG: userUnit } = naldLines[0]
+
+  const lines = naldLines.filter((naldLine) => {
+    const { RET_QTY: qty } = naldLine
+
+    // We need to consider a line with a qty 0 as populated, hence the more convoluted check
+    return qty !== null && qty !== undefined && qty !== 'null' && qty !== ''
+  })
+
+  return {
+    lines,
+    readingType,
+    userUnit
   }
 }
 
-/* UTILS */
-const plainEnglishFrequency = (val = 'M') => ({
-  D: 'day',
-  W: 'week',
-  M: 'month',
-  Y: 'year'
-}[val])
+async function _naldLines (returnId) {
+  // The row generated by the import contains all things but the region code. Its embedded in the return id and the
+  // abstraction-helpers has a function that will parse a return ID back out into its constituent parts. As the query
+  // was built to work with the values extracted from it, we just go ahead and use them all!
+  const { regionCode, formatId, startDate, endDate } = returnsHelpers.parseReturnId(returnId)
 
-const padDateComponent = (val = '1') => val.length === 1 ? `0${val}` : val
+  const params = [formatId, regionCode, startDate, endDate]
+  const query = `
+    SELECT
+      nrl."ARFL_ARTY_ID",
+      nrl."ARFL_DATE_FROM",
+      nrl."RET_DATE",
+      nrl."RET_QTY",
+      nrl."RET_QTY_USABILITY",
+      nrl."UNIT_RET_FLAG",
+      to_date("RET_DATE", 'YYYYMMDDHH24MISS') AS end_date
+    FROM "import"."NALD_RET_LINES" nrl
+    WHERE
+      nrl."ARFL_ARTY_ID"=$1
+      AND nrl."FGAC_REGION_CODE"=$2
+      AND to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') >= to_date($3, 'YYYY-MM-DD')
+      AND to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') <= to_date($4, 'YYYY-MM-DD')
+    ORDER BY "RET_DATE";
+  `
 
-const createLine = (versionId, startDate, endDate, frequency, line, qtyKey) => parseFloat(line[qtyKey]) > 0 &&
-  lines.create({
-    line_id: uuid(),
+  return db.query(query, params)
+}
+
+function _totalLineQuantity (blankLine, naldPopulatedLines) {
+  let match = false
+  let totalQuantity = 0
+
+  for (const naldLine of naldPopulatedLines) {
+    // Even though we cast RET_DATE to a Date as `end_date` in the query, the DB connection the
+    // water-abstraction-helpers makes always returns them it as a string.
+    const naldLineEndDate = new Date(naldLine.end_date)
+
+    // We have gone past the last line that could possibly match so stop looking
+    if (naldLineEndDate > blankLine.end_date) {
+      break
+    }
+
+    // The nald line ends before the blank line starts so continue to the next line
+    if (naldLineEndDate < blankLine.start_date) {
+      continue
+    }
+
+    // We have found a match!
+    match = true
+    totalQuantity += parseFloat(naldLine.RET_QTY)
+  }
+
+  if (match) {
+    return totalQuantity
+  }
+
+  return null
+}
+
+function _version (row) {
+  const versionId = uuid()
+  const parsedMetadata = row.metadata instanceof Object ? row.metadata : JSON.parse(row.metadata)
+
+  return {
+    current: parsedMetadata.isCurrent,
+    metadata: parsedMetadata,
+    nil_return: false,
+    return_id: row.return_id,
+    user_id: 'imported@from.nald',
+    user_type: 'system',
     version_id: versionId,
-    substance: 'water',
-    quantity: parseFloat(line[qtyKey]),
-    unit: 'm³',
-    user_unit: 'm³',
-    start_date: startDate,
-    end_date: endDate,
-    time_period: plainEnglishFrequency(frequency),
-    metadata: JSON.stringify(line),
-    reading_type: 'measured'
-  })
+    version_number: parsedMetadata.version
+  }
+}
 
 module.exports = {
   go

--- a/src/modules/return-logs/lib/replicate-returns.js
+++ b/src/modules/return-logs/lib/replicate-returns.js
@@ -138,17 +138,16 @@ function _totalLineQuantity (blankLine, naldPopulatedLines) {
 }
 
 function _version (row) {
-  const versionId = uuid()
   const parsedMetadata = row.metadata instanceof Object ? row.metadata : JSON.parse(row.metadata)
 
   return {
     current: parsedMetadata.isCurrent,
-    metadata: parsedMetadata,
+    metadata: {},
     nil_return: false,
     return_id: row.return_id,
     user_id: 'imported@from.nald',
     user_type: 'system',
-    version_id: versionId,
+    version_id: uuid(),
     version_number: parsedMetadata.version
   }
 }

--- a/src/modules/return-logs/lib/replicate-returns.js
+++ b/src/modules/return-logs/lib/replicate-returns.js
@@ -19,7 +19,7 @@ async function go (row) {
   const naldLines = await _naldLines(row.return_id)
   const naldLineData = _naldLineData(naldLines)
 
-  const version = _version (row)
+  const version = _version(row)
   const blankLines = _blankLines(row)
 
   _populateBlankLines(row, version, blankLines, naldLineData)

--- a/src/modules/return-logs/lib/return-helpers.js
+++ b/src/modules/return-logs/lib/return-helpers.js
@@ -11,9 +11,9 @@ function daysFromPeriod (periodStartDate, periodEndDate) {
   const days = []
 
   // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
-  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
 
-  while (clonedPeriodStartDate <= periodEndDate) {
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
     // Clone the date again for the same reason above
     const startDate = _cloneDate(clonedPeriodStartDate)
 
@@ -31,9 +31,9 @@ function weeksFromPeriod (periodStartDate, periodEndDate) {
   const weeks = []
 
   // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
-  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
 
-  while (clonedPeriodStartDate <= periodEndDate) {
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
     // Is the date a Saturday?
     if (clonedPeriodStartDate.getDay() === 6) {
       // Yes! Clone the date again for the same reason above
@@ -61,9 +61,9 @@ function monthsFromPeriod (periodStartDate, periodEndDate) {
   const months = []
 
   // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
-  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
 
-  while (clonedPeriodStartDate <= periodEndDate) {
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
     // Bump the returnLogStartDate to the next month, for example 2013-04-15 becomes 2013-05-15
     clonedPeriodStartDate.setMonth(clonedPeriodStartDate.getMonth() + 1)
 

--- a/src/modules/return-logs/lib/return-helpers.js
+++ b/src/modules/return-logs/lib/return-helpers.js
@@ -7,6 +7,84 @@ const db = require('../../../lib/connectors/db.js')
 const cache = require('./cache.js')
 const queries = require('./queries.js')
 
+function daysFromPeriod (periodStartDate, periodEndDate) {
+  const days = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) {
+    // Clone the date again for the same reason above
+    const startDate = _cloneDate(clonedPeriodStartDate)
+
+    // No jiggery-pokery needed. Simply add it to the days array as both the start and end date
+    days.push({ start_date: startDate, end_date: startDate })
+
+    // Move the date to the next day, and round we go again!
+    clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 1)
+  }
+
+  return days
+}
+
+function weeksFromPeriod (periodStartDate, periodEndDate) {
+  const weeks = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) {
+    // Is the date a Saturday?
+    if (clonedPeriodStartDate.getDay() === 6) {
+      // Yes! Clone the date again for the same reason above
+      const endDate = _cloneDate(clonedPeriodStartDate)
+      const startDate = _cloneDate(clonedPeriodStartDate)
+
+      // Set the start date back to 6 days, which makes it the previous Sunday
+      startDate.setDate(startDate.getDate() - 6)
+
+      weeks.push({ start_date: startDate, end_date: endDate })
+
+      // Now we have found our first week, we can just move the date forward by 6 days to the next Saturday, thus saving
+      // a bunch of loop iterations
+      clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 6)
+    } else {
+      // Move the date to the next day, and try again!
+      clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 1)
+    }
+  }
+
+  return weeks
+}
+
+function monthsFromPeriod (periodStartDate, periodEndDate) {
+  const months = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  let clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) {
+    // Bump the returnLogStartDate to the next month, for example 2013-04-15 becomes 2013-05-15
+    clonedPeriodStartDate.setMonth(clonedPeriodStartDate.getMonth() + 1)
+
+    // Then clone that for our end date. "But we want the last day in April!?" we hear you scream :-)
+    const endDate = _cloneDate(clonedPeriodStartDate)
+
+    // We use some JavaScript magic to move endDate back to the last of the month. By setting the date (the 01, 02, 03
+    // etc part) to 0, it's the equivalent of setting it to the 1st, then asking JavaScript to minus 1 day. That's
+    // how we get to 2013-04-30. It also means we don't need to worry about which months have 30 vs 31 days, or whether
+    // we are in a leap year!
+    endDate.setDate(0)
+
+    // Set start date to first of the month. Passing it in as a string to new Date() helps keep it UTC rather than local
+    const startDate = new Date(`${endDate.getFullYear()}-${endDate.getMonth() + 1}-01`)
+
+    months.push({ start_date: startDate, end_date: endDate })
+  }
+
+  return months
+}
+
 /**
  * Gets form logs for specified licence number
  * @param {String} licenceNumber
@@ -124,6 +202,14 @@ const _createReturnVersionReasonCache = () => {
   })
 }
 
+function _cloneDate (dateToClone) {
+  const year = dateToClone.getFullYear()
+  const month = dateToClone.getMonth() + 1
+  const day = dateToClone.getDate()
+
+  return new Date(`${year}-${month}-${day}`)
+}
+
 const _getReturnVersionReasonCache = _createReturnVersionReasonCache()
 
 module.exports = {
@@ -137,5 +223,8 @@ module.exports = {
   getLogLines,
   isNilReturn,
   getSplitDate,
-  getReturnVersionReason
+  getReturnVersionReason,
+  daysFromPeriod,
+  weeksFromPeriod,
+  monthsFromPeriod
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

We've realised NALD has return log data that we don't. Initially, we thought it was just the return lines for pre-2013 return logs. But after some digging, it appears there are not only the return submission lines but also some return logs we don't have that NALD does.

Putting aside the missing return logs, we need to get those missing return submission lines in. We have found that NALD structures the return logs and submission data very differently from WRLS. Our plan to do something 'quick & dirty' with a SQL query is therefore not possible. That means we'll need to code a solution.

We intend to stop all 'return leg' processes in the very near future, just as soon as WRLS takes over from NALD on all things 'returns' related. So, it makes no sense to start from scratch.

Or it didn't when we thought this project understood how to interpret and create WRLS return logs and submission data based on what NALD holds.

Turns out it doesn't!

We have found the replicate returns logic is faulty. There are instances of returns where

- 0 quantity lines have been ignored. They should be migrated as this is a customer actively recording that no water was abstracted
- weekly returns where lines are missing, for example, a 2013-04-01 to 2014-03-31 return log will only have lines for the weeks in 2013

We might have opted to start from scratch if we knew that when we started!

However, no one has complained about its handling of return logs. Plus, we recently learned that when displaying a return that ends before 2018-10-31, the legacy UI will query the `import` schema in the DB directly, even if there is data in the `returns` schema. 😩🤦

After some digging, we found it much more successful at interpreting NALD data than what was built in this project. So, having come this far, the next step is to update the faulty replicate returns engine with the logic from [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service).

Having proven it with the data we have in non-production environments, the next steps will be integrating it as part of the normal import process where we are missing submission data and getting it to look at the missing NALD line data we've obtained. But that's for later! For now, we have a crappy engine to replace 😀💪