### PR TITLE
Amend return-logs import to exclude fortnightly

### DIFF
--- a/src/modules/return-logs/lib/replicate-returns.js
+++ b/src/modules/return-logs/lib/replicate-returns.js
@@ -19,8 +19,8 @@ const { daysFromPeriod, weeksFromPeriod, monthsFromPeriod } = require('./return-
  * replicating NALD submission data
  */
 async function go (row, oldLinesExist) {
-  // TODO: Support old NALD quarterly and yearly returns
-  if (row.returns_frequency === 'quarter' || row.returns_frequency === 'year') {
+  // TODO: Support old NALD fortnightly, quarterly and yearly returns
+  if (row.returns_frequency === 'quarter' || row.returns_frequency === 'year' || row.returns_frequency === 'fortnight') {
     return
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4856

> Part of the work to migrate management of return requirements from NALD to WRLS

As part of getting ready for WRLS to take over the management of returns from NALD, we looked into whether there were any discrepancies in the returns data.

We found two things.

- What was initially just thought to be missing line data for returns older than 2013-01-01 turned out to be nearly all submission data older than 2018-10-31
- There are 338 NALD form logs (return logs) linked to return formats (return requirements) that don't exist in WRLS

The last set of changes to this app supported the first issue and the aim of getting the missing submission data in. This change relates to the second.

We have found that in nearly all cases, there is a valid reason why the 338 were not imported. In essence, the licence has ended, and where the end date falls, the form logs no longer intersect with valid return periods.

For example, licence `01/123` has a return format which starts on 1998-11-16. The licence was revoked on 1999-03-01. `src/modules/return-logs/lib/transform-returns.js` determines just one return period, which is based on the winter or summer return cycles, the start and end times of the format, and finally, the licence.

```javascript
  cycles: [
    { startDate: '1998-11-16', endDate: '1999-03-31', isCurrent: true }
  ]
```

The licence has several form logs, but the first starts on 1999-04-01. It, nor the rest, intersects with the return period the import engine has calculated, so they do not get imported.

The one exception is a licence with a return format where the reporting frequency has been set to `fortnightly`. WRLS does not recognise this frequency in its `returns.returns` table, so this licence was erroring on import.

This change is to handle the error better.