### PR TITLE
Add node-cron back in for local scheduling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ S3_NALD_IMPORT_PATH=
 
 WATER_SERVICE_MAILBOX=
 
+# Use Cron type syntax to set timings for these background processes
+WRLS_CRON_NALD='15 23 * * *'
+
 # In preparation for switching management of the returns leg from NALD to WRLS we need the ability to disable
 # the import of return versions and return logs (and their connected data). On the day of go live the env var will be
 # set to 'true'. Assuming all is well, we'll then remove the jobs completely. If not, we can revert with a simple env

--- a/config.js
+++ b/config.js
@@ -67,6 +67,7 @@ module.exports = {
   proxy: process.env.PROXY,
 
   import: {
+    schedule: process.env.WRLS_CRON_NALD,
     nald: {
       zipPassword: process.env.NALD_ZIP_PASSWORD,
       path: process.env.S3_NALD_IMPORT_PATH || 'wal_nald_data_release'

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "hapi-pino": "^11.0.1",
         "mkdir": "0.0.2",
         "moment": "^2.30.1",
+        "node-cron": "^3.0.3",
         "notifications-node-client": "^8.2.1",
         "p-map": "^7.0.3",
         "pg": "^8.12.0",
@@ -5598,6 +5599,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -8572,6 +8585,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hapi-pino": "^11.0.1",
     "mkdir": "0.0.2",
     "moment": "^2.30.1",
+    "node-cron": "^3.0.3",
     "notifications-node-client": "^8.2.1",
     "p-map": "^7.0.3",
     "pg": "^8.12.0",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

In our [big refactor of the app](https://github.com/DEFRA/water-abstraction-import/pull/1063), we removed [node-cron](https://www.npmjs.com/package/node-cron) as we didn't believe it was needed anymore.

We could trigger the job like we trigger those in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system): with a `curl` request fired from a Jenkins job.

The only issue would be that we'd need an alternate mechanism to trigger it locally. Running the import nightly in our local dev environments helps keep them in a state that means we can work with fewer surprises.

We figured that locally, we could use a standard [cron job](https://en.wikipedia.org/wiki/Cron).

Very quickly, we were reminded that

- setting up cron programmatically is a pain
- doing it in a docker container is a nightmare 😱

Much simpler is just to put **node-cron** back 😬.