### PR TITLE
Remove forgotten test limit in licence data import

### DIFF
--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -64,7 +64,7 @@ async function _licences () {
         nalv."AABL_ID" = nal."ID"
         AND nalv."FGAC_REGION_CODE" = nal."FGAC_REGION_CODE"
         AND nalv."STATUS" <> 'DRAFT'
-    ) AND nal."LIC_NO" IN ('6/33/03/*G/0041', 'AN/033/0053/044R01', 'NW/068/0005/004', 'WA/055/0008/012', '6/33/03/*G/0012');
+    );
   `)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

Whilst working on the [big refactor of the app](https://github.com/DEFRA/water-abstraction-import/pull/1063), we would limit the number of records some of the queries would return whilst testing.

We've managed to leave one of them in when we merged the change! 😬🤦