### PR TITLE
Handle importing non-WRLS frequency rtns from NALD

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ process
     // If there are no in-flight requests Hapi will immediately stop. If there are they get 25 seconds to finish
     // before Hapi terminates them
     await server.stop(options)
-    await server.messageQueue.stop()
 
     // Log we're shut down using the same log format as the rest of our log output
     server.logger.info("That's all folks!")

--- a/src/modules/completion-email/process.js
+++ b/src/modules/completion-email/process.js
@@ -7,8 +7,6 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken, formatLongDateTime }
 const config = require('../../../config.js')
 
 async function go (steps) {
-  console.dir(steps, { depth: null, colors: true })
-
   try {
     const startTime = currentTimeInNanoseconds()
 

--- a/src/modules/licence-returns-import/lib/persist-returns.js
+++ b/src/modules/licence-returns-import/lib/persist-returns.js
@@ -176,16 +176,17 @@ async function _returnDataExists (returnId) {
 }
 
 async function _update (row) {
-  const params = [row.due_date, row.metadata, row.received_date, row.status, row.return_id]
+  const params = [row.due_date, row.metadata, row.received_date, row.returns_frequency, row.status, row.return_id]
 
   const query = `
     UPDATE "returns"."returns" SET
       due_date = $1,
       metadata = $2,
       received_date = $3,
-      status = $4,
+      returns_frequency = $4,
+      status = $5,
       updated_at = now()
-    WHERE return_id=$5;
+    WHERE return_id=$6;
   `
 
   await db.query(query, params)

--- a/src/modules/licence-returns-import/lib/replicate-returns.js
+++ b/src/modules/licence-returns-import/lib/replicate-returns.js
@@ -72,7 +72,11 @@ async function _addOldNaldLines (naldLines, row, naldLinesParams) {
         to_date("RET_DATE", 'DD/MM/YYYY') AS end_date
       FROM public."NALD_RET_LINES" nrl
       WHERE
-        nrl."ARFL_ARTY_ID" = $1
+        nrl."RET_QTY" IS NOT NULL
+        AND nrl."RET_QTY" <> 'null'
+        AND nrl."RET_QTY" <> ''
+        AND nrl."RET_QTY" <> '0'
+        AND nrl."ARFL_ARTY_ID" = $1
         AND nrl."FGAC_REGION_CODE" = $2
         AND to_date(nrl."RET_DATE", 'DD/MM/YYYY') >= to_date($3, 'YYYY-MM-DD')
         AND to_date(nrl."RET_DATE", 'DD/MM/YYYY') <= to_date($4, 'YYYY-MM-DD')
@@ -114,6 +118,7 @@ async function _naldLines (naldLinesParams) {
     FROM "import"."NALD_RET_LINES" nrl
     WHERE
       nrl."RET_QTY" IS NOT NULL
+      AND nrl."RET_QTY" <> 'null'
       AND nrl."RET_QTY" <> ''
       AND nrl."RET_QTY" <> '0'
       AND nrl."ARFL_ARTY_ID"=$1

--- a/src/modules/licence-returns-import/lib/replicate-returns.js
+++ b/src/modules/licence-returns-import/lib/replicate-returns.js
@@ -19,11 +19,6 @@ const { daysFromPeriod, weeksFromPeriod, monthsFromPeriod } = require('./return-
  * replicating NALD submission data
  */
 async function go (row, oldLinesExist) {
-  // TODO: Support old NALD fortnightly, quarterly and yearly returns
-  if (row.returns_frequency === 'quarter' || row.returns_frequency === 'year' || row.returns_frequency === 'fortnight') {
-    return
-  }
-
   if (row.status !== 'completed') {
     return
   }

--- a/src/modules/licence-returns-import/lib/replicate-returns.js
+++ b/src/modules/licence-returns-import/lib/replicate-returns.js
@@ -69,7 +69,8 @@ async function _addOldNaldLines (naldLines, row, naldLinesParams) {
         nrl."RET_QTY",
         nrl."RET_QTY_USABILITY",
         nrl."UNIT_RET_FLAG",
-        to_date("RET_DATE", 'DD/MM/YYYY') AS end_date
+        to_date("RET_DATE", 'DD/MM/YYYY') AS end_date,
+        (false) AS matched
       FROM public."NALD_RET_LINES" nrl
       WHERE
         nrl."RET_QTY" IS NOT NULL
@@ -114,7 +115,8 @@ async function _naldLines (naldLinesParams) {
       nrl."RET_QTY",
       nrl."RET_QTY_USABILITY",
       nrl."UNIT_RET_FLAG",
-      to_date("RET_DATE", 'YYYYMMDDHH24MISS') AS end_date
+      to_date("RET_DATE", 'YYYYMMDDHH24MISS') AS end_date,
+      (false) AS matched
     FROM "import"."NALD_RET_LINES" nrl
     WHERE
       nrl."RET_QTY" IS NOT NULL

--- a/src/modules/licence-returns-import/lib/transform-returns-helpers.js
+++ b/src/modules/licence-returns-import/lib/transform-returns-helpers.js
@@ -185,9 +185,6 @@ const getReturnCycles = (startDate, endDate, splitDate, isSummer = false) => {
 const getStatus = receivedDate => receivedDate === null ? 'due' : 'completed'
 
 /**
- * TODO: See connected note in src/modules/licence-returns-import/lib/transform-returns.js. When we can convert
- * fortnightly, quarterly, and yearly returns into weekly and monthly, then this comment will apply.
- *
  * These are the actual translations. However, we WRLS only supports daily, weekly, and monthly returns, which
  * is why we translate fortnightly, quarterly, and annually to something else.
  *
@@ -204,10 +201,10 @@ function mapPeriod (str) {
   const periods = {
     D: 'day',
     W: 'week',
-    F: 'fortnight',
+    F: 'week',
     M: 'month',
-    Q: 'quarter',
-    A: 'year'
+    Q: 'month',
+    A: 'month'
   }
   return periods[str]
 }

--- a/src/modules/licence-returns-import/lib/transform-returns.js
+++ b/src/modules/licence-returns-import/lib/transform-returns.js
@@ -14,24 +14,6 @@ async function go (licenceRef) {
   const allReturnsLogs = []
 
   for (const format of formats) {
-    // TODO: The returns.returns table does not support a returns_frequency of fortnightly.
-    //
-    // We _were_ importing return logs for quarterly and yearly but _only_ the return logs; the submission data was part
-    // of the old return lines so not being imported.
-    //
-    // We need to bring them all in, which means converting them (fortnight to weekly, quarter and year to month). But
-    // its not a straight conversion. For example, in NALD the quarter will be 1 line, but when converted to WRLS that
-    // will become 3 (1 per month). Our current logic matches WRLS lines to NALD based on the period, so we'd get the
-    // same qty assigned 3 times.
-    if (['F', 'Q', 'A'].includes(format.ARTC_REC_FREQ_CODE)) {
-      global.GlobalNotifier.omg(
-        'licence-returns-import: unsupported frequency',
-        { formatId: format.ID, frequency: format.ARTC_REC_FREQ_CODE, licenceRef }
-      )
-
-      continue
-    }
-
     const splitDate = await _splitDate(licenceRef)
 
     const returnLogs = await _returnLogs(licenceRef, splitDate, format)

--- a/test/modules/licence-returns-import/lib/persist-returns.test.js
+++ b/test/modules/licence-returns-import/lib/persist-returns.test.js
@@ -75,7 +75,7 @@ experiment('modules/licence-returns-import/lib/persist-returns', () => {
         .onSecondCall().resolves()
     })
 
-    test("updates the return log's 'due_date', 'metadata', 'received_date' and 'status'", async () => {
+    test("updates the return log's 'due_date', 'metadata', 'received_date', 'returns_frequency', and 'status'", async () => {
       await PersistReturns.go([naldReturn], false)
 
       const params = db.query.secondCall.args[1]
@@ -85,6 +85,7 @@ experiment('modules/licence-returns-import/lib/persist-returns', () => {
         '2017-11-28',
         '{"param":"value","version":"1"}',
         '2017-11-24',
+        'month',
         'completed',
         'v1:123:456'
       ])

--- a/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
+++ b/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
@@ -559,9 +559,10 @@ experiment('modules/licence-returns-import/lib/transform-returns-helpers', () =>
     test('Test mapping of NALD returns periods codes', async () => {
       expect(TransformReturnsHelpers.mapPeriod('D')).to.equal('day')
       expect(TransformReturnsHelpers.mapPeriod('W')).to.equal('week')
+      expect(TransformReturnsHelpers.mapPeriod('F')).to.equal('week')
       expect(TransformReturnsHelpers.mapPeriod('M')).to.equal('month')
-      expect(TransformReturnsHelpers.mapPeriod('Q')).to.equal('quarter')
-      expect(TransformReturnsHelpers.mapPeriod('A')).to.equal('year')
+      expect(TransformReturnsHelpers.mapPeriod('Q')).to.equal('month')
+      expect(TransformReturnsHelpers.mapPeriod('A')).to.equal('month')
       expect(TransformReturnsHelpers.mapPeriod('x')).to.equal(undefined)
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

In the following changes, we updated the legacy import process's handling of returns to ensure the missing submission data was being imported ready for WRLS to take over.

- [Stop 'return leg' processes with feature flag](https://github.com/DEFRA/water-abstraction-import/pull/1054)
- [Move import of return logs into their own job](https://github.com/DEFRA/water-abstraction-import/pull/1055)
- [Refactor new return-logs import job to use DB](https://github.com/DEFRA/water-abstraction-import/pull/1056)
- [Replace faulty replicate returns logic](https://github.com/DEFRA/water-abstraction-import/pull/1057)
- [Always replicate rtn submission data when missing](https://github.com/DEFRA/water-abstraction-import/pull/1058)
- [Include old return lines in return logs import](https://github.com/DEFRA/water-abstraction-import/pull/1059)
- [Download, extract and load old NALD return lines](https://github.com/DEFRA/water-abstraction-import/pull/1060)
- [Amend return-logs import to exclude fortnightly](https://github.com/DEFRA/water-abstraction-import/pull/1061)

Mostly!

When we realised this was going to slow down the import too much, we also made [a big change](https://github.com/DEFRA/water-abstraction-import/pull/1063) to address a number of long-standing issues with the app.

While doing that, we spotted that NALD supports return frequencies that WRLS doesn't: fortnightly, quarterly, and yearly. To get things moving and focus on the refactor, we had the returns import process ignore submissions for these.

Now it is time to get these last remaining returns importing.

The weirdness in NALD with these lines is that they have funny periods, for example, `2004-03-01 to 2004-06-30` (there doesn't appear to be any consistency or correlation with the idea of fortnightly, quarterly or yearly 🤯 😩 ).

In our existing engine, the line would match to multiple WRLS lines we'd generated, leading to a duplication in quantities applied.

We realised we could solve this by adding a `matched` flag to the NALD lines we retrieve. If `replicate-returns.js` matches the NALD line to a WRLS blank, it flags the NALD line as matched. This means it won't be used again when determining the total for other WRLS lines. Now, the quantity is only applied once.

