### PR TITLE
Fix licence-crm-import

### DIFF
--- a/src/modules/licence-crm-import/lib/persist-crm.js
+++ b/src/modules/licence-crm-import/lib/persist-crm.js
@@ -4,7 +4,12 @@ const db = require('../../../lib/connectors/db.js')
 const { generateUUID } = require('../../../lib/general.js')
 
 async function go (crmData) {
-  const params = [generateUUID(), crmData.system_external_id, crmData.metadata]
+  const params = [
+    crmData.system_external_id,
+    generateUUID(),
+    crmData.system_external_id,
+    crmData.metadata
+  ]
   const query = `
     INSERT INTO crm.document_header (
       regime_entity_id,
@@ -18,19 +23,16 @@ async function go (crmData) {
     VALUES (
       '0434dc31-a34e-7158-5775-4694af7a60cf',
       'permit-repo',
-      (SELECT l.licence_id FROM permit.licence l WHERE l.licence_ref = $2 LIMIT 1),
-      $1,
+      (SELECT l.licence_id FROM permit.licence l WHERE l.licence_ref = $1 LIMIT 1),
       $2,
       $3,
+      $4,
       now()
     )
     ON CONFLICT (
-      system_id,
-      system_internal_id,
-      regime_entity_id
+      system_external_id
     )
     DO UPDATE SET
-      system_external_id = EXCLUDED.system_external_id,
       metadata = EXCLUDED.metadata,
       date_updated = EXCLUDED.date_updated;
   `


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

After [refactoring the import into a single job](https://github.com/DEFRA/water-abstraction-import/pull/1063), when we tested it in `tst` and `pre`, we found the licence-drm-import failed for many records.

Looking into the error, it seems folks have gone a bit crazy with the indexes and constraints on this table. Though it worked fine locally, our UPSERT was failing when a document header record had a verification ID.

Switching the constraint to `system_external_id` appears to make it work in all environments.

Go figure!

We also spotted that we were reusing a numbered param. Handily, it is working fine. But normally we repeat value not the param (e.g. $2) so we corrected that as well.