### PR TITLE
Support use of proxy with Notify client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "firstline": "^2.0.2",
         "hapi-auth-jwt2": "^8.8.1",
         "hapi-pino": "^11.0.1",
+        "hpagent": "^1.2.0",
         "mkdir": "0.0.2",
         "moment": "^2.30.1",
         "node-cron": "^3.0.3",
@@ -4377,6 +4378,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "firstline": "^2.0.2",
     "hapi-auth-jwt2": "^8.8.1",
     "hapi-pino": "^11.0.1",
+    "hpagent": "^1.2.0",
     "mkdir": "0.0.2",
     "moment": "^2.30.1",
     "node-cron": "^3.0.3",

--- a/src/modules/completion-email/process.js
+++ b/src/modules/completion-email/process.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const axios = require ('axios')
+const axios = require('axios')
 const { HttpsProxyAgent } = require('hpagent')
 const { NotifyClient } = require('notifications-node-client')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken, formatLongDateTime } = require('../../lib/general.js')
@@ -100,7 +100,7 @@ function _notifyClient () {
   const proxy = config.proxy
 
   if (proxy) {
-    const agent = new HttpsProxyAgent({ proxy: proxy })
+    const agent = new HttpsProxyAgent({ proxy })
     const axiosInstance = axios.create({
       proxy: false,
       httpsAgent: agent

--- a/src/modules/completion-email/process.js
+++ b/src/modules/completion-email/process.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const axios = require ('axios')
+// const { HttpsProxyAgent } = require('hpagent')
+const proxyAgent = require('proxy-agent')
 const { NotifyClient } = require('notifications-node-client')
 
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken, formatLongDateTime } = require('../../lib/general.js')
@@ -61,6 +64,49 @@ function _emailOptions (steps) {
   }
 }
 
+/**
+ * Returns an instance of {@link https://github.com/alphagov/notifications-node-client | notifications-node-client}
+ * configured to work in environments with and without proxy servers.
+ *
+ * Running locally just instantiating the NotifyClient was all we had to do. But when deployed to our AWS environments
+ * which use the {@link https://www.squid-cache.org/ | Squid proxy server} it failed.
+ *
+ * Initially, we followed the
+ * {@link https://docs.notifications.service.gov.uk/node.html#connect-through-a-proxy-optional | Notify documentation}
+ * but all we saw was the following returned by **Squid**.
+ *
+ * ```text
+ * This proxy and the remote host failed to negotiate a mutually acceptable security settings for handling your request.
+ * It is possible that the remote host does not support secure connections, or the proxy is not satisfied with the host
+ * security credentials.
+ * ```
+ *
+ * It appears this is a {@link https://github.com/axios/axios/issues/6320 | known issue with Axios} and how it sends
+ * data via the proxy. Most workarounds suggest that you in fact need to tell Axios to disable its proxy, and specify
+ * its httpsAgent instead.
+ *
+ *
+ *
+ * @private
+ */
+function _notifyClient () {
+  const notifyClient = new NotifyClient(config.notify.apiKey)
+  const proxy = config.proxy
+
+  if (proxy) {
+    // const agent = new HttpsProxyAgent({ proxy: proxy })
+    const agent = proxyAgent(proxy)
+    const axiosInstance = axios.create({
+      proxy: false,
+      httpsAgent: agent
+    })
+
+    notifyClient.setClient(axiosInstance)
+  }
+
+  return notifyClient
+}
+
 function _summary (steps) {
   const summary = []
 
@@ -74,7 +120,7 @@ function _summary (steps) {
 }
 
 async function _sendEmail (options) {
-  const client = new NotifyClient(config.notify.apiKey)
+  const client = _notifyClient()
 
   await client.sendEmail(config.notify.templateId, config.notify.mailbox, options)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

As part of the [Refactor all overnight jobs into one](https://github.com/DEFRA/water-abstraction-import/pull/1063), we switched from asking [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) to send them, to just calling [GOV.UK Notify](https://www.notifications.service.gov.uk/) directly (less code and far less hassle!)

It works fine locally but fails in our AWS environments. Other than the versions used, we could find no difference between what we've done and how the email is being sent in **water-abstraction-service**.

The only difference is that **water-abstraction-service** is way behind on v4, while we've used the latest v8. Initially, we saw the current documentation for Notify states you need to use `setProxy()` on the Notify client instance. As we cannot see the same call in **water-abstraction-service**, we can only assume v4 didn't require this.

It turns out it has more to do with the version of [Axios](https://github.com/axios/axios) being used behind the scenes. When we set the `proxy` config, the [Squid proxy server](https://www.squid-cache.org/) we're behind returned this error.

```text
This proxy and the remote host failed to negotiate a mutually acceptable security settings for handling your request. It is possible that the remote host does not support secure connections, or the proxy is not satisfied with the host security credentials.
```

Doing some digging on that led us to [Security: Axios sends HTTPS data in cleartext to a proxy (regression)](https://github.com/axios/axios/issues/6320). That matched the behaviour we were seeing. Fortunately, we also came across [Axios proxy is not working.](https://github.com/axios/axios/issues/2072) and [Proxy support does not work properly with CONNECT on https requests](https://github.com/axios/axios/issues/4531).

They suggested configuring **Axios** with a `httpsAgent`, which we've had to do on [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/53) to get it working behind the proxy.

We tried using [proxy-agent](https://www.npmjs.com/package/proxy-agent), which is already part of this app. But **Axios** didn't like it. **hpagent** however, works like a charm!
