### PR TITLE
Ignore draft licence versions in PermitJson

### DIFF
--- a/src/lib/permit-json/fetch-versions.js
+++ b/src/lib/permit-json/fetch-versions.js
@@ -38,6 +38,7 @@ async function _licenceVersions (id, regionCode) {
     WHERE
       "AABL_ID" = $1
       AND "FGAC_REGION_CODE" = $2
+      AND "STATUS" <> 'DRAFT'
     ORDER BY "EFF_ST_DATE" ASC;
   `
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

When we did our [Refactor all overnight jobs into one](https://github.com/DEFRA/water-abstraction-import/pull/1063), we knew that NALD licences with draft licence versions are a common cause of errors during the import.

That is why we updated the query that pulls the licences to import to discount those with only 'DRAFT' licence versions. However, what we hadn't spotted is that `src/lib/permit-json/permit-json.js` still fetches draft licence versions. So, a licence can have a valid licence version and a draft one.

It was when we saw this error in the logs that we realised the problem.

```text
{
  "level": 50,
  "time": 1743392463087,
  "pid": 3527,
  "hostname": "PREWALBESSRV002",
  "licenceRef": "18/54/01/???",
  "index": 25822,
  "err": {
    "type": "DatabaseError",
    "message": "new row for relation \"document_roles\" violates check constraint \"company_or_invoice_account\"",
    "stack": "error: new row for relation \"document_roles\" violates check constraint \"company_or_invoice_account\"\n    at /srv/app/node/water-abstraction-import/releases/20250330_154347/node_modules/pg-pool/index.js:45:11\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Object.query (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/lib/connectors/db.js:17:27)\n    at async _persistDocumentRole (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/modules/licence-crm-v2-import/process.js:130:3)\n    at async Object.go (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/modules/licence-crm-v2-import/process.js:24:7)\n    at async Promise.allSettled (index 1)\n    at async _process (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/modules/import-job/lib/licence-data-import.js:96:21)\n    at async Object.go (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/modules/import-job/lib/licence-data-import.js:23:19)\n    at async Object.go (/srv/app/node/water-abstraction-import/releases/20250330_154347/src/modules/import-job/process.js:51:12)",
    "length": 478,
    "name": "error",
    "severity": "ERROR",
    "code": "23514",
    "detail": "Failing row contains (80f04098-433d-453f-92ec-16ed39de1f90, 7cd2413c-14d5-4df7-9436-5c71a0a916e5, 60cd6c29-f546-4016-ba77-6682b6bd7351, null, null, 15836db1-dd49-45e1-a75f-d10990d7e0a1, 2025-03-19, null, 2025-03-31 03:41:03.085092, 2025-03-31 03:41:03.085092, null, f).",
    "schema": "crm_v2",
    "table": "document_roles",
    "constraint": "company_or_invoice_account",
    "file": "execMain.c",
    "line": "2028",
    "routine": "ExecConstraints"
  },
  "msg": "licence-crm-v2-import: errored"
}
```

It had pulled in a draft licence version with the same details as the previous and was trying to create `crm_v2.document_role` records based on it.

So, this change adds a filter to `src/lib/permit-json/fetch-versions.js` to exclude draft licence versions.