### PR TITLE
Bring omfg() in sync with water-abstraction-system

### DIFF
--- a/src/lib/notifiers/base-notifier.lib.js
+++ b/src/lib/notifiers/base-notifier.lib.js
@@ -40,9 +40,9 @@ class BaseNotifierLib {
    *
    * The message will be added as an `INFO` level log message.
    *
-   * @param {string} message Message to add to the log (INFO)
-   * @param {Object} [data={}] An object containing any values to be logged, for example, a bill run ID to be included with
-   *  the log message. Defaults to an empty object
+   * @param {string} message - Message to add to the log (INFO)
+   * @param {object} [data={}] - An object containing any values to be logged, for example, a bill run ID to be included
+   * with the log message. Defaults to an empty object
    */
   omg (message, data = {}) {
     this._logger.info(this._formatLogPacket(data), message)
@@ -74,13 +74,13 @@ class BaseNotifierLib {
    * notifier.omfg('Bill run failed to generate.', { id: billRun.id })
    * ```
    *
-   * @param {string} message Message to add to the log (ERROR)
-   * @param {Error} [error=null] An instance of the error to be logged and sent to Errbit. If no error is provided one
-   *  will be created using `message` as the error message
-   * @param {Object} [data={}] An object containing any values to be logged and sent in the notification to Errbit, for
-   *  example, a bill run ID. Defaults to an empty object
+   * @param {string} message - Message to add to the log (ERROR)
+   * @param {object} [data={}] - An object containing any values to be logged and sent in the notification to Errbit,
+   * for example, a bill run ID. Defaults to an empty object
+   * @param {Error} [error=null] - An instance of the error to be logged and sent to Errbit. If no error is provided one
+   * will be created using `message` as the error message
    */
-  omfg (message, error = null, data = {}) {
+  omfg (message, data = {}, error = null) {
     // This deals with anyone calling omfg() with `omfg('It broke', null, error)` which would cause things to break
     if (!data) {
       data = {}
@@ -94,7 +94,8 @@ class BaseNotifierLib {
 
     this._logger.error(this._formatLogPacket(data, error), message)
 
-    this._notifier.notify(this._formatNotifyPacket(data, error, message))
+    this._notifier
+      .notify(this._formatNotifyPacket(data, error, message))
       // This section is a 'just in case' anything goes wrong when trying to send the notification to Errbit. It will
       // either fail (cannot connect) or blow up entirely. If it does we log the error directly (no calls to the
       // formatter)
@@ -103,7 +104,7 @@ class BaseNotifierLib {
           this._logger.error(notice.error, `${this.constructor.name} - Airbrake failed`)
         }
       })
-      .catch(err => {
+      .catch((err) => {
         this._logger.error(err, `${this.constructor.name} - Airbrake errored`)
       })
   }
@@ -135,6 +136,8 @@ class BaseNotifierLib {
    *
    * By doing it this way we can _still_ pass a `data` arg to `omfg()` and include those values in our log entry along
    * with the error.
+   *
+   * @private
    */
   _formatLogPacket (data, error) {
     const packet = {
@@ -160,6 +163,8 @@ class BaseNotifierLib {
    * But this means Airbrake's `message:` property becomes ignored. Errbit will set the issue title using the error's
    * `message` instead. In order to see our message when a 'proper' error is passed in we include our `message` as a
    * property of `session:`.
+   *
+   * @private
    */
   _formatNotifyPacket (data, error, message) {
     return {
@@ -177,8 +182,10 @@ class BaseNotifierLib {
    * Returns an instance of {@link https://github.com/pinojs/pino|Pino} the logger our dependency Hapi-pino brings in.
    * We can then call `info()` and `error()` on it in order to create our log entries.
    *
-   * @param {Object} [logger] An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the method will
+   * @param {object} [logger] - An instance of {@link https://github.com/pinojs/pino|pino}. If 'null' the method will
    * create a new instance.
+   *
+   * @private
    */
   _setLogger (logger) {
     if (logger) {
@@ -194,8 +201,10 @@ class BaseNotifierLib {
    * Returns an instance of {@link https://github.com/airbrake/airbrake-js|airbrake-js} `Notifier` which when called
    * with `notify()` will record errors in our Errbit instance.
    *
-   * @param {Object} [notifier] An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js}
+   * @param {object} [notifier] - An instance of the {@link https://github.com/airbrake/airbrake-js|airbrake-js}
    * `Notifier`. If 'null' the class will create a new instance instead.
+   *
+   * @private
    */
   _setNotifier (notifier) {
     if (notifier) {

--- a/src/modules/bill-runs-import/process.js
+++ b/src/modules/bill-runs-import/process.js
@@ -22,7 +22,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'bill-runs-import: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('bill-runs-import: errored', error)
+    global.GlobalNotifier.omfg('bill-runs-import: errored', {}, error)
   }
 }
 

--- a/src/modules/charge-versions-import/process.js
+++ b/src/modules/charge-versions-import/process.js
@@ -41,7 +41,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'charge-versions-import: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('charge-versions-import: errored', error)
+    global.GlobalNotifier.omfg('charge-versions-import: errored', {}, error)
   }
 }
 
@@ -51,7 +51,7 @@ async function _importChargeVersionMetadataForLicence (licence) {
 
     await MetadataImport.go(licenceData)
   } catch (error) {
-    global.GlobalNotifier.omfg('charge-versions-import: errored', error, { licence })
+    global.GlobalNotifier.omfg('charge-versions-import: errored', { licence }, error)
   }
 }
 

--- a/src/modules/clean/process.js
+++ b/src/modules/clean/process.js
@@ -33,7 +33,7 @@ async function go (cleanLicences = false, skipReturnData = false, log = false) {
       calculateAndLogTimeTaken(startTime, 'clean: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('clean: errored', error)
+    global.GlobalNotifier.omfg('clean: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/completion-email/process.js
+++ b/src/modules/completion-email/process.js
@@ -17,7 +17,7 @@ async function go (steps) {
 
     calculateAndLogTimeTaken(startTime, 'completion-email: complete')
   } catch (error) {
-    global.GlobalNotifier.omfg('completion-email: errored', error)
+    global.GlobalNotifier.omfg('completion-email: errored', {}, error)
   }
 }
 

--- a/src/modules/end-date-check/process.js
+++ b/src/modules/end-date-check/process.js
@@ -15,7 +15,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'end-date-check: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('end-date-check: errored', error)
+    global.GlobalNotifier.omfg('end-date-check: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/end-date-trigger/process.js
+++ b/src/modules/end-date-trigger/process.js
@@ -15,7 +15,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'end-date-trigger: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('end-date-trigger: errored', error)
+    global.GlobalNotifier.omfg('end-date-trigger: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/extract-nald-data/process.js
+++ b/src/modules/extract-nald-data/process.js
@@ -42,7 +42,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'extract-nald-data: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('extract-nald-data: errored', error)
+    global.GlobalNotifier.omfg('extract-nald-data: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/extract-old-lines/process.js
+++ b/src/modules/extract-old-lines/process.js
@@ -58,7 +58,7 @@ async function go (skip = false, log = false) {
       calculateAndLogTimeTaken(startTime, 'extract-old-lines: complete', { oldLinesExist })
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('extract-old-lines: errored', error)
+    global.GlobalNotifier.omfg('extract-old-lines: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/flag-deleted-documents/process.js
+++ b/src/modules/flag-deleted-documents/process.js
@@ -16,7 +16,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'flag-deleted-documents: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('flag-deleted-documents: errored', error)
+    global.GlobalNotifier.omfg('flag-deleted-documents: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -64,7 +64,7 @@ async function go () {
 
     calculateAndLogTimeTaken(startTime, 'import-job completed')
   } catch (error) {
-    global.GlobalNotifier.omfg('import-job errored', error)
+    global.GlobalNotifier.omfg('import-job errored', {}, error)
   }
 }
 

--- a/src/modules/licence-crm-import/process.js
+++ b/src/modules/licence-crm-import/process.js
@@ -25,7 +25,7 @@ async function go (permitJson, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `licence-crm-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licence-crm-import: errored', error, { licenceRef: permitJson?.LIC_NO, index })
+    global.GlobalNotifier.omfg('licence-crm-import: errored', { licenceRef: permitJson?.LIC_NO, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/licence-crm-v2-import/process.js
+++ b/src/modules/licence-crm-v2-import/process.js
@@ -28,7 +28,7 @@ async function go (permitJson, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `licence-crm-v2-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licence-crm-v2-import: errored', error, { licenceRef: permitJson?.LIC_NO, index })
+    global.GlobalNotifier.omfg('licence-crm-v2-import: errored', { licenceRef: permitJson?.LIC_NO, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/licence-no-start-date-import/process.js
+++ b/src/modules/licence-no-start-date-import/process.js
@@ -48,7 +48,7 @@ async function go (permitJson, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `licence-no-start-date-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licence-no-start-date-import: errored', error, { licenceRef: permitJson?.LIC_NO, index })
+    global.GlobalNotifier.omfg('licence-no-start-date-import: errored', { licenceRef: permitJson?.LIC_NO, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/licence-permit-import/process.js
+++ b/src/modules/licence-permit-import/process.js
@@ -22,7 +22,7 @@ async function go (permitJson, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `licence-permit-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licence-permit-import: errored', error, { licenceRef: permitJson?.LIC_NO, index })
+    global.GlobalNotifier.omfg('licence-permit-import: errored', { licenceRef: permitJson?.LIC_NO, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/licence-returns-import/process.js
+++ b/src/modules/licence-returns-import/process.js
@@ -28,7 +28,7 @@ async function go (licence, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `licence-returns-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licence-returns-import: errored', error, { licence, index })
+    global.GlobalNotifier.omfg('licence-returns-import: errored', { licence, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/licences-import/process.js
+++ b/src/modules/licences-import/process.js
@@ -23,7 +23,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'licences-import: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('licences-import: errored', error)
+    global.GlobalNotifier.omfg('licences-import: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/link-to-mod-logs/process.js
+++ b/src/modules/link-to-mod-logs/process.js
@@ -17,7 +17,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'link-to-mod-logs: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('link-to-mod-logs: errored', error)
+    global.GlobalNotifier.omfg('link-to-mod-logs: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/party-crm-v2-import/process.js
+++ b/src/modules/party-crm-v2-import/process.js
@@ -25,7 +25,7 @@ async function go (party, index = 0, log = false) {
       calculateAndLogTimeTaken(startTime, `party-crm-v2-import: complete (${index})`)
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('party-crm-v2-import: errored', error, { party, index })
+    global.GlobalNotifier.omfg('party-crm-v2-import: errored', { party, index }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/reference-data-import/process.js
+++ b/src/modules/reference-data-import/process.js
@@ -17,7 +17,7 @@ async function go (log = false) {
       calculateAndLogTimeTaken(startTime, 'reference-data-import: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('reference-data-import: errored', error)
+    global.GlobalNotifier.omfg('reference-data-import: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/src/modules/return-versions-import/process.js
+++ b/src/modules/return-versions-import/process.js
@@ -37,7 +37,7 @@ async function go (skip = false, log = false) {
       calculateAndLogTimeTaken(startTime, 'return-versions-import: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('return-versions-import: errored', error)
+    global.GlobalNotifier.omfg('return-versions-import: errored', {}, error)
 
     messages.push(error.message)
   }

--- a/test/lib/notifiers/base-notifier.lib.test.js
+++ b/test/lib/notifiers/base-notifier.lib.test.js
@@ -103,7 +103,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message and some data is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, null, { id })
+          testNotifier.omfg(message, { id }, null)
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -115,7 +115,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, null, { id })
+          testNotifier.omfg(message, { id }, null)
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 
@@ -128,7 +128,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message, some data and an error is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, testError, { id })
+          testNotifier.omfg(message, { id }, testError)
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -140,7 +140,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, testError, { id })
+          testNotifier.omfg(message, { id }, testError)
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 
@@ -153,7 +153,7 @@ experiment('BaseNotifierLib class', () => {
       experiment('and a message, no data but an error is to be logged', () => {
         test("logs a correctly formatted 'error' level entry", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, testError, null)
+          testNotifier.omfg(message, null, testError)
 
           const logPacketArgs = pinoFake.error.args[0]
 
@@ -164,7 +164,7 @@ experiment('BaseNotifierLib class', () => {
 
         test("sends the expected notification to 'Errbit'", () => {
           const testNotifier = new BaseNotifierLib()
-          testNotifier.omfg(message, testError, null)
+          testNotifier.omfg(message, null, testError)
 
           const { error, session } = airbrakeFake.notify.args[0][0]
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

While working on the import service, we spotted that the base notifier in this repo is out of sync with the one we copied it from in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). Most notably, the order of arguments to `omfg()` is out of sync.

This updates it to be in sync.