### PR TITLE
Extract NALD data directly into import schema

### DIFF
--- a/src/modules/extract-nald-data/lib/schema.js
+++ b/src/modules/extract-nald-data/lib/schema.js
@@ -2,17 +2,11 @@
 
 const db = require('../../../lib/connectors/db.js')
 
-async function dropAndCreateSchema (schema) {
-  await db.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE;`)
-  await db.query(`CREATE SCHEMA IF NOT EXISTS ${schema};`)
-}
-
-const swapTemporarySchema = async () => {
-  await db.query('DROP SCHEMA IF EXISTS import CASCADE;')
-  await db.query('ALTER SCHEMA import_temp RENAME TO import;')
+async function dropAndCreateSchema () {
+  await db.query('DROP SCHEMA IF EXISTS "import" CASCADE;')
+  await db.query('CREATE SCHEMA IF NOT EXISTS "import";')
 }
 
 module.exports = {
-  dropAndCreateSchema,
-  swapTemporarySchema
+  dropAndCreateSchema
 }

--- a/src/modules/extract-nald-data/process.js
+++ b/src/modules/extract-nald-data/process.js
@@ -26,14 +26,11 @@ async function go (log = false) {
     // extracting files from zip
     await Zip.extract()
 
-    // create import_temp schema
-    await Schema.dropAndCreateSchema('import_temp')
+    // drop existing tables by dropping the schema and recreating it
+    await Schema.dropAndCreateSchema()
 
     // importing CSV files
-    await LoadCsv.importFiles('import_temp')
-
-    // swapping schema from import_temp to import
-    await Schema.swapTemporarySchema()
+    await LoadCsv.importFiles()
 
     // cleaning up local files
     await _prepare()

--- a/test/modules/extract-nald-data/lib/schema.test.js
+++ b/test/modules/extract-nald-data/lib/schema.test.js
@@ -15,8 +15,6 @@ const db = require('../../../../src/lib/connectors/db.js')
 const Schema = require('../../../../src/modules/extract-nald-data/lib/schema.js')
 
 experiment('modules/extract-nald-data/lib/schema.js', () => {
-  const schemaName = 'test_schema'
-
   let dbStub
 
   beforeEach(async () => {
@@ -29,37 +27,19 @@ experiment('modules/extract-nald-data/lib/schema.js', () => {
 
   experiment('.dropAndCreateSchema', () => {
     test('the schema is dropped', async () => {
-      await Schema.dropAndCreateSchema(schemaName)
+      await Schema.dropAndCreateSchema()
 
       const [query] = dbStub.firstCall.args
 
-      expect(query).to.equal(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE;`)
+      expect(query).to.equal('DROP SCHEMA IF EXISTS "import" CASCADE;')
     })
 
     test('the schema is re-created', async () => {
-      await Schema.dropAndCreateSchema(schemaName)
+      await Schema.dropAndCreateSchema()
 
       const [query] = dbStub.secondCall.args
 
-      expect(query).to.equal(`CREATE SCHEMA IF NOT EXISTS ${schemaName};`)
-    })
-  })
-
-  experiment('.swapTemporarySchema', () => {
-    test('the schema is dropped', async () => {
-      await Schema.swapTemporarySchema()
-
-      const [query] = dbStub.firstCall.args
-
-      expect(query).to.equal('DROP SCHEMA IF EXISTS import CASCADE;')
-    })
-
-    test('the schema is re-created', async () => {
-      await Schema.swapTemporarySchema()
-
-      const [query] = dbStub.secondCall.args
-
-      expect(query).to.equal('ALTER SCHEMA import_temp RENAME TO import;')
+      expect(query).to.equal('CREATE SCHEMA IF NOT EXISTS "import";')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

Whilst testing getting the missing returns data into our non-prod environments, we encountered an issue with the DB hitting its allocated size.

We realised one of the reasons we need to allocate more space than we actually use is that the extract nald data process first loads everything into `import_test`. Once loaded, it swaps the schemas.

But this means we are duplicating the import schema during the load, which is why we need too much extra allocation space. If we dropped the import schema and then loaded the extract CSV files straight in, we'd avoid duplicating anything and get that 'cushion' back.

We understand why it was done. Because of the decision to fetch returns data directly from the import schema when viewing them in the legacy UI, the previous team needed to add this precaution in case the import failed.

But as we are now moving to our new view return, which will be based solely on data in WRLS, this caution is no longer necessary.