### PR TITLE
Display progress during licence data import

### DIFF
--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -90,10 +90,21 @@ async function _process () {
     messages.push('Skipped licence-returns-import because importing returns is disabled')
   }
 
+  let progress = 0
+
   for (const [index, licence] of licences.entries()) {
+    progress += 1
+
     const licenceMessages = await _processLicence(index, licence)
 
     messages.push(...licenceMessages)
+
+    if (progress % 1000 === 0) {
+      global.GlobalNotifier.omg(
+        `import-job.${STEP_NAME}: progress (${progress} of ${licences.length})`,
+        { lastLicence: licence.LIC_NO }
+      )
+    }
   }
 
   return messages


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

We're testing getting all the missing returns data to import, which depends on the [Refactor all overnight jobs into one work](https://github.com/DEFRA/water-abstraction-import/pull/1063) we did.

It works fine locally, but in our NALD environments, the logs seem to stop after the `licence-data-import` has started. So, more for debugging purposes, we're adding some progress logging.