### PR TITLE
Fix logging errors when using omg()

### DIFF
--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -130,9 +130,9 @@ async function _processLicence (index, licence) {
     const crmMessages = await LicenceCrmImportProcess.go(permitJson, index, false)
 
     messages.push(...crmMessages)
-  } catch (error) {
-    global.GlobalNotifier.omg(`import-job.${STEP_NAME}: errored`, { licence, error })
-    messages.push(error.message)
+  } catch (err) {
+    global.GlobalNotifier.omg(`import-job.${STEP_NAME}: errored`, { licence, err })
+    messages.push(err.message)
   }
 
   return messages


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

With the import dealing with so many transactions, we sometimes don't want to send every one to Errbit. It is enough that some indication will be registered in the email, and the actual error will be logged.

That is, if it is logged!

During some testing, we spotted an error thrown, but what we saw in the logs was just an empty object.

```text
0|import  | [16:16:01.938] INFO (2407): import-job.licence-data-import: errored
0|import  |     licence: {
0|import  |       "ID": "21",
0|import  |       "LIC_NO": "6/33/03/*S/0033",
0|import  |       "AREP_SUC_CODE": "ARSUC",
0|import  |       "AREP_AREA_CODE": "ARCA",
0|import  |       "SUSP_FROM_BILLING": "N",
0|import  |       "AREP_LEAP_CODE": "C4",
0|import  |       "EXPIRY_DATE": "null",
0|import  |       "ORIG_EFF_DATE": "01/11/1966",
0|import  |       "ORIG_SIG_DATE": "null",
0|import  |       "ORIG_APP_NO": "null",
0|import  |       "ORIG_LIC_NO": "null",
0|import  |       "NOTES": "null",
0|import  |       "REV_DATE": "01/09/1972",
0|import  |       "LAPSED_DATE": "null",
0|import  |       "SUSP_FROM_RETURNS": "N",
0|import  |       "AREP_CAMS_CODE": "ACC01",
0|import  |       "X_REG_IND": "N",
0|import  |       "PREV_LIC_NO": "null",
0|import  |       "FOLL_LIC_NO": "null",
0|import  |       "AREP_EIUC_CODE": "ANOTH",
0|import  |       "FGAC_REGION_CODE": "1",
0|import  |       "SOURCE_CODE": "null",
0|import  |       "BATCH_RUN_DATE\r": "31/03/2025 22:22:00"
0|import  |     }
0|import  |     error: {}
```

Huh!

After some testing, it is how Pino deals with the error instance. It works in `omfg()` because when we have an error instance, we add it to the log packet as `{ err: error }`. It seems to get Pino to detail the error; you have to add it to the log packet as `err:`.

So, this change updates how we pass in the data to `omg()` to cater for this.