### PR TITLE
Fix non-awaited call in licence-data-import

### DIFF
--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -85,7 +85,7 @@ async function _processLicence (licence) {
     messages.push(processMessages)
 
     if (!config.featureFlags.disableReturnsImports) {
-      processMessages = LicenceReturnsImportProcess.go(licence, false)
+      processMessages = await LicenceReturnsImportProcess.go(licence, false)
       messages.push(processMessages)
     }
   } catch (err) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

We made a typo in [AWS import performance tuning](https://github.com/DEFRA/water-abstraction-import/pull/1083) and overlooked awaiting the call to `LicenceReturnsImportProcess`.

This change fixes that.