### PR TITLE
Add progress display back in during licence import

### DIFF
--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -31,9 +31,21 @@ async function go () {
   return step
 }
 
+function _displayProgress (licence) {
+  const { LIC_NO, row_index } = licence
+
+  if (row_index % 1000 === 0) {
+    global.GlobalNotifier.omg(
+      `import-job.${STEP_NAME}: progress (${row_index})`,
+      { lastLicence: LIC_NO }
+    )
+  }
+}
+
 async function _licences () {
   return db.query(`
     SELECT
+      row_number() over() AS row_index,
       nal.*
     FROM
       "import"."NALD_ABS_LICENCES" nal
@@ -88,6 +100,8 @@ async function _processLicence (licence) {
       processMessages = await LicenceReturnsImportProcess.go(licence, false)
       messages.push(processMessages)
     }
+
+    _displayProgress(licence)
   } catch (err) {
     global.GlobalNotifier.omg(`import-job.${STEP_NAME}: errored`, { licence, err })
     messages.push(err.message)

--- a/src/modules/import-job/lib/licence-data-import.js
+++ b/src/modules/import-job/lib/licence-data-import.js
@@ -32,11 +32,11 @@ async function go () {
 }
 
 function _displayProgress (licence) {
-  const { LIC_NO, row_index } = licence
+  const { LIC_NO, row_index: rowIndex } = licence
 
-  if (row_index % 1000 === 0) {
+  if (rowIndex % 1000 === 0) {
     global.GlobalNotifier.omg(
-      `import-job.${STEP_NAME}: progress (${row_index})`,
+      `import-job.${STEP_NAME}: progress (${rowIndex})`,
       { lastLicence: LIC_NO }
     )
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4855

> Part of the work to migrate management of return requirements from NALD to WRLS

In [Display progress during licence data import](https://github.com/DEFRA/water-abstraction-import/pull/1081), we added an indicator of progress during the licence data import. Our reasoning was

> We're testing getting all the missing returns data to import, which depends on the [Refactor all overnight jobs into one work](https://github.com/DEFRA/water-abstraction-import/pull/1063) we did.
>
> It works fine locally, but in our NALD environments, the logs seem to stop after the `licence-data-import` has started. So, more for debugging purposes, we're adding some progress logging.

Because of the changes we made in [AWS import performance tuning](https://github.com/DEFRA/water-abstraction-import/pull/1083) we lost the progress, even though we are now more confident it is completing.

However, to be sure, it would be nice to have the progress back. We've since had a brain wave, and this change is a way to display progress again, even though we are using p-map to run the work concurrently.