### PR TITLE
Import NALD sent date for return logs

### DIFF
--- a/src/modules/licence-returns-import/lib/persist-returns.js
+++ b/src/modules/licence-returns-import/lib/persist-returns.js
@@ -55,6 +55,7 @@ async function _create (row, returnCycleId) {
     row.return_id,
     row.return_requirement,
     row.returns_frequency,
+    row.sent_date,
     row.source,
     row.start_date,
     row.status,
@@ -73,6 +74,7 @@ async function _create (row, returnCycleId) {
       return_id,
       return_requirement,
       returns_frequency,
+      sent_date,
       "source",
       start_date,
       status,
@@ -80,7 +82,7 @@ async function _create (row, returnCycleId) {
       created_at,
       updated_at
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now(), now());
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now(), now());
   `
 
   await db.query(query, params)
@@ -176,7 +178,7 @@ async function _returnDataExists (returnId) {
 }
 
 async function _update (row) {
-  const params = [row.due_date, row.metadata, row.received_date, row.returns_frequency, row.status, row.return_id]
+  const params = [row.due_date, row.metadata, row.received_date, row.returns_frequency, row.sent_date, row.status, row.return_id]
 
   const query = `
     UPDATE "returns"."returns" SET
@@ -184,9 +186,10 @@ async function _update (row) {
       metadata = $2,
       received_date = $3,
       returns_frequency = $4,
-      status = $5,
+      sent_date = $5,
+      status = $6,
       updated_at = now()
-    WHERE return_id=$6;
+    WHERE return_id=$7;
   `
 
   await db.query(query, params)

--- a/src/modules/licence-returns-import/lib/transform-returns-helpers.js
+++ b/src/modules/licence-returns-import/lib/transform-returns-helpers.js
@@ -248,6 +248,23 @@ const mapReceivedDate = (logs) => {
   return logs[logs.length - 1].received_date
 }
 
+
+const mapSentDate = (logs) => {
+  if (logs.length === 0) {
+    return null
+  }
+
+  const unsentLog = logs.some((log) => {
+    return !log.sent_date
+  })
+
+  if (unsentLog) {
+    return null
+  }
+
+  return logs[logs.length - 1].sent_date
+}
+
 /**
  * A sort comparator that will sort moment dates in ascending order
  *
@@ -323,5 +340,6 @@ module.exports = {
   getStatus,
   mapPeriod,
   mapProductionMonth,
-  mapReceivedDate
+  mapReceivedDate,
+  mapSentDate
 }

--- a/src/modules/licence-returns-import/lib/transform-returns-helpers.js
+++ b/src/modules/licence-returns-import/lib/transform-returns-helpers.js
@@ -248,7 +248,6 @@ const mapReceivedDate = (logs) => {
   return logs[logs.length - 1].received_date
 }
 
-
 const mapSentDate = (logs) => {
   if (logs.length === 0) {
     return null

--- a/src/modules/licence-returns-import/lib/transform-returns.js
+++ b/src/modules/licence-returns-import/lib/transform-returns.js
@@ -96,7 +96,11 @@ async function _naldLogs (formatId, regionCode) {
       (CASE
         WHEN l."RECD_DATE" = 'null' THEN NULL
         ELSE to_date(l."RECD_DATE", 'DD/MM/YYYY')
-      END) AS received_date
+      END) AS received_date,
+      (CASE
+        WHEN l."SENT_DATE" = 'null' THEN NULL
+        ELSE to_date(l."SENT_DATE", 'DD/MM/YYYY')
+      END) AS sent_date
     FROM
       "import"."NALD_RET_FORM_LOGS" l
     WHERE
@@ -188,24 +192,26 @@ async function _returnLog (cycle, naldLogs, licenceRef, format) {
 
   const returnId = getReturnId(format.FGAC_REGION_CODE, licenceRef, format.ID, startDate, endDate)
   const receivedDate = helpers.mapReceivedDate(naldLogs)
+  const sentDate = helpers.mapSentDate(naldLogs)
   const status = helpers.getStatus(receivedDate)
   const dueDate = await DueDate.go(endDate, format)
   const metadata = await _metadata(cycle, format)
 
   return {
-    return_id: returnId,
-    regime: 'water',
-    licence_type: 'abstraction',
-    licence_ref: licenceRef,
-    start_date: startDate,
-    end_date: endDate,
     due_date: dueDate,
-    returns_frequency: helpers.mapPeriod(format.ARTC_REC_FREQ_CODE),
-    status,
-    source: 'NALD',
+    end_date: endDate,
+    licence_ref: licenceRef,
+    licence_type: 'abstraction',
     metadata,
     received_date: receivedDate,
-    return_requirement: format.ID
+    regime: 'water',
+    return_id: returnId,
+    return_requirement: format.ID,
+    returns_frequency: helpers.mapPeriod(format.ARTC_REC_FREQ_CODE),
+    sent_date: sentDate,
+    source: 'NALD',
+    start_date: startDate,
+    status
   }
 }
 

--- a/test/modules/licence-returns-import/lib/persist-returns.test.js
+++ b/test/modules/licence-returns-import/lib/persist-returns.test.js
@@ -16,19 +16,20 @@ const PersistReturns = require('../../../../src/modules/licence-returns-import/l
 
 experiment('modules/licence-returns-import/lib/persist-returns', () => {
   const naldReturn = {
-    return_id: 'v1:123:456',
-    regime: 'water',
-    licence_type: 'abstraction',
-    licence_ref: '01/234/567',
-    start_date: '2016-11-01',
+    due_date: '2017-11-28',
     end_date: '2017-10-31',
-    returns_frequency: 'month',
-    status: 'completed',
-    source: 'NALD',
+    licence_ref: '01/234/567',
+    licence_type: 'abstraction',
     metadata: JSON.stringify({ param: 'value', version: '1' }),
     received_date: '2017-11-24',
+    regime: 'water',
+    return_id: 'v1:123:456',
     return_requirement: '012345',
-    due_date: '2017-11-28'
+    returns_frequency: 'month',
+    sent_date: '2017-11-01',
+    source: 'NALD',
+    start_date: '2016-11-01',
+    status: 'completed'
   }
 
   afterEach(() => {
@@ -60,6 +61,7 @@ experiment('modules/licence-returns-import/lib/persist-returns', () => {
         'v1:123:456',
         '012345',
         'month',
+        '2017-11-01',
         'NALD',
         '2016-11-01',
         'completed',
@@ -75,7 +77,7 @@ experiment('modules/licence-returns-import/lib/persist-returns', () => {
         .onSecondCall().resolves()
     })
 
-    test("updates the return log's 'due_date', 'metadata', 'received_date', 'returns_frequency', and 'status'", async () => {
+    test("updates the return log's 'due_date', 'metadata', 'received_date', 'returns_frequency', 'sent_date', and 'status'", async () => {
       await PersistReturns.go([naldReturn], false)
 
       const params = db.query.secondCall.args[1]
@@ -86,6 +88,7 @@ experiment('modules/licence-returns-import/lib/persist-returns', () => {
         '{"param":"value","version":"1"}',
         '2017-11-24',
         'month',
+        '2017-11-01',
         'completed',
         'v1:123:456'
       ])

--- a/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
+++ b/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
@@ -14,7 +14,7 @@ moment.locale('en-gb')
 // Thing under test
 const TransformReturnsHelpers = require('../../../../src/modules/licence-returns-import/lib/transform-returns-helpers.js')
 
-experiment.only('modules/licence-returns-import/lib/transform-returns-helpers', () => {
+experiment('modules/licence-returns-import/lib/transform-returns-helpers', () => {
   experiment('.addDate', () => {
     test('add a date if within range', async () => {
       expect(TransformReturnsHelpers.addDate([], '2018-12-01', '2018-01-01', '2018-12-31')).to.equal(['2018-12-01'])

--- a/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
+++ b/test/modules/licence-returns-import/lib/transform-returns-helpers.test.js
@@ -14,7 +14,7 @@ moment.locale('en-gb')
 // Thing under test
 const TransformReturnsHelpers = require('../../../../src/modules/licence-returns-import/lib/transform-returns-helpers.js')
 
-experiment('modules/licence-returns-import/lib/transform-returns-helpers', () => {
+experiment.only('modules/licence-returns-import/lib/transform-returns-helpers', () => {
   experiment('.addDate', () => {
     test('add a date if within range', async () => {
       expect(TransformReturnsHelpers.addDate([], '2018-12-01', '2018-01-01', '2018-12-31')).to.equal(['2018-12-01'])
@@ -713,6 +713,23 @@ experiment('modules/licence-returns-import/lib/transform-returns-helpers', () =>
     test('with valid dates', async () => {
       const logs = [{ received_date: '04/01/2017' }, { received_date: '25/12/2017' }]
       expect(TransformReturnsHelpers.mapReceivedDate(logs)).to.equal('25/12/2017')
+    })
+  })
+
+  experiment('.mapSentDate', () => {
+    test('with no logs', async () => {
+      const logs = []
+      expect(TransformReturnsHelpers.mapSentDate(logs)).to.equal(null)
+    })
+
+    test('with a null value', async () => {
+      const logs = [{ sent_date: '01/01/2017' }, { sent_date: null }]
+      expect(TransformReturnsHelpers.mapSentDate(logs)).to.equal(null)
+    })
+
+    test('with valid dates', async () => {
+      const logs = [{ sent_date: '04/01/2017' }, { sent_date: '25/12/2017' }]
+      expect(TransformReturnsHelpers.mapSentDate(logs)).to.equal('25/12/2017')
     })
   })
 })

--- a/test/modules/licence-returns-import/lib/transform-returns.test.js
+++ b/test/modules/licence-returns-import/lib/transform-returns.test.js
@@ -95,7 +95,7 @@ experiment('modules/licence-returns-import/lib/transform-returns.js', () => {
       beforeEach(() => {
         // Stubbing call to _naldLogs()
         dbStub.onCall(2).resolves([
-          { start_date: '2023-08-01', end_date: '2024-03-31', received_date: null }
+          { start_date: '2023-08-01', end_date: '2024-03-31', received_date: null, sent_date: '2024-04-01' }
         ])
       })
 
@@ -104,19 +104,20 @@ experiment('modules/licence-returns-import/lib/transform-returns.js', () => {
 
         expect(results).to.equal([
           {
-            return_id: 'v1:3:01/123:10061242:2023-08-17:2024-03-31',
-            regime: 'water',
-            licence_type: 'abstraction',
-            licence_ref: '01/123',
-            start_date: '2023-08-17',
-            end_date: '2024-03-31',
             due_date: '2024-04-28',
-            returns_frequency: 'month',
-            status: 'due',
-            source: 'NALD',
+            end_date: '2024-03-31',
+            licence_ref: '01/123',
+            licence_type: 'abstraction',
             metadata: '{"version":1,"description":"CATCH-PIT AT PLACE, TOWN, COUNTY","purposes":[{"primary":{"code":"C","description":"Crown And Government"},"secondary":{"code":"CRW","description":"Crown - Other"},"tertiary":{"code":"320","description":"Pollution Remediation"}}],"points":[{"ngr1":"NY 766 450","ngr2":null,"ngr3":null,"ngr4":null,"name":"CATCH-PIT AT NENT HAGGS ADIT, NENTSBERRY, CUMBRIA"}],"nald":{"regionCode":3,"areaCode":"NAREA","formatId":10061242,"periodStartDay":"1","periodStartMonth":"1","periodEndDay":"31","periodEndMonth":"12"},"isTwoPartTariff":false,"isSummer":false,"isUpload":false,"isCurrent":true,"isFinal":false}',
             received_date: null,
-            return_requirement: '10061242'
+            regime: 'water',
+            return_id: 'v1:3:01/123:10061242:2023-08-17:2024-03-31',
+            return_requirement: '10061242',
+            returns_frequency: 'month',
+            sent_date: '2024-04-01',
+            source: 'NALD',
+            start_date: '2023-08-17',
+            status: 'due'
           }
         ])
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5018

WRLS is taking over management of the 'returns leg' from NALD. Contingent on that is the ability to continue reporting on returns.

Our work with RDP is behind the service changes, but we must switch soon to support the first quarterly return submissions in July. So, we will ensure we can generate the same reports by building ad hoc queries.

We've spotted that the existing BOXI reports include `send_date`, which the job does not currently import from NALD.

This change updates the `licence-returns-import` process to grab the sent date from NALD and apply it to the WRLS return log.

---

**IMPORTANT!**

This won't be a one-to-one mapping because of how the process was implemented (admittedly, as per requirements). When the billing & data team took over managing return submissions, they also adopted the 'return cycles' concept. So, a return log's start and end dates would align with a cycle, for example, 2008-04-01 to 2018-03-31 (winter and all year).

Later NALD form logs align with this, but older ones were generated on schedules determined by the area teams. The WRLS return log implementation cannot handle this, so the import generates return logs based on the NALD return format (return requirements), not NALD form logs.

Our recent changes to include the missing submission data match NALD return lines to WRLS return logs by date.

We have highlighted this because it is possible for a WRLS return log to be assigned submission data from multiple NALD form logs, each with its own `sent_date`.

**NALD**

- ID FL1 - 2002-01-01 to 2002-12-31
- ID FL2 - 2003-01-01 to 2003-12-31

**WRLS**

- ID RL1 - 2001-04-01 to 2002-03-31
  - NALD FL1
- ID RL2 - 2002-04-01 to 2003-03-31
  - NALD FL1
  - NALD FL2
- ID RL3 - 2003-04-01 to 2004-03-31
  - NALD FL2

Without re-engineering WRLS, the only option we have is to take the latest date where a WRLS return log matches to multiple NALD form logs.

This issue also applies to NALD received dates, and this solution is _exactly_ how the previous team resolved the problem, and is how WRLS received dates have been imported from the very start.