### PR TITLE
Fix return cycles for those end on start of cycle

### DIFF
--- a/src/modules/licence-returns-import/lib/persist-returns.js
+++ b/src/modules/licence-returns-import/lib/persist-returns.js
@@ -96,9 +96,14 @@ async function _create (row) {
 
 async function _createOrUpdateReturn (row, oldLinesExist, returnCycles) {
   const returnDataExists = await _returnDataExists(row.return_id)
-  const { return_cycle_id: returnCycleId } = ReturnCycleHelpers.match(returnCycles, row)
 
-  row.returnCycleId = returnCycleId
+  try {
+    const { return_cycle_id: returnCycleId } = ReturnCycleHelpers.match(returnCycles, row)
+
+    row.returnCycleId = returnCycleId
+  } catch (error) {
+    global.GlobalNotifier.omg('licence-returns-import: errored', { row, error: error.message })
+  }
 
   // Conditional update
   if (returnDataExists.return_log_exists) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5015

In [Reduce return cycle queries to just one](https://github.com/DEFRA/water-abstraction-import/pull/1091), we avoided querying the DB to find a matching return cycle for each return log generated by the legacy import engine.

This means we went from 500K plus DB hits to just one!

Local testing proved successful, but it was predicated on the assumption that the start and end dates of each return log being processed were valid. Since all missing return cycles have now been added, there should be no reason why the appropriate return log cannot be found.

However, when we did a full run, we got errors. When we dug in, we found the new code could not find a matching return cycle for some return logs.

Huh!? 🤔

We were able to find the cause. The return logs that were failing had end dates that were actually the start dates of the next return cycle.

- 2018-05-23 to 2018-11-01
- 2022-11-01 to 2023-11-01
- 2024-04-01 to **2025-04-01**

<img width="969" alt="Screenshot 2025-04-29 at 18 32 24" src="https://github.com/user-attachments/assets/1ef3e87f-27bd-4179-94e1-25ed2cc38656" />

What all the licences affected by this had in common was that they all had something 'end' on the 1 April or 11 November. For example, the licence was revoked on that date, or return version was ended (new return version starts 2 April).

For example, suppose we have a licence with a return version (and just one return requirement) that starts on 2017-12-17 and ends on 2025-04-01. The licence has not ended.

|Start date      |End date        |Reason      |
|----------------|----------------|------------|
|2 April 2025    |                |Major change|
|17 December 2017|1 April 2025    |Major change|
|1 April 2008    |16 December 2017|Minor change|

The logic in the legacy code determines 'return cycles' for the period of time when the return version applied. However, they are not return cycles as we know them. They are the 'return periods' used to generate the WRLS return logs.

It starts by working out the return cycle (this time, we mean return cycle!!) start dates that might apply throughout the period.

> For some unknown reason, it started with an invalid date: just the current year, e.g. 2025. This got passed to `getPeriodStart()` in [water-abstraction-helpers](https://github.com/DEFRA/water-abstraction-helpers), which, because it is invalid, instead defaults to the Epoch date (1970-01-01). Then, it would test every year against the return period (1971-04-01, 1972-04-01, 1973-04-01, etc.). In almost all cases, you only need to start testing from the late 90s onwards. In fact, taking the start date and subtracting a year results in dropping millions of pointless loops!

These get ignored until it finally gets to one that is ['between'](https://momentjscom.readthedocs.io/en/latest/moment/05-query/06-is-between/) the start and end date for the period. Those who were within the period are captured and stored for further processing. Note the 'between', though. The problem was that the check was 'exclusive' rather than 'inclusive'.

Continuing our example, 2024-04-01 would be added, but 2025-04-01 wouldn't. After some further processing, the final 'return periods' would be as follows:

- 2017-12-17 to 2018-03-31 (note the return version start date kicks off the first return period)
- 2018-04-01 to 2019-03-31
- 2019-04-01 to 2020-03-31
- 2020-04-01 to 2021-03-31
- 2021-04-01 to 2022-03-31
- 2022-04-01 to 2023-03-31
- 2023-04-01 to 2024-03-31
- 2024-04-01 to 2025-04-01 (note its end date is used for the last return period)

If we update the check to be 'inclusive', the result is

- 2017-12-17 to 2018-03-31
- 2018-04-01 to 2019-03-31
- ...
- 2023-04-01 to 2024-03-31
- 2024-04-01 to 2025-03-31
- 2025-04-01 to 2025-04-01 (end date is still used for the last return cycle, but now it's valid, even if only covering a day)

We found approximately 10 summer and almost 500 winter return logs affected by this issue. Fortunately, fixing the logic will cause the import to self-correct. It will create the correct return logs while voiding the invalid ones.