### PR TITLE
Fix not importing 0 qty NALD lines to WRLS

### DIFF
--- a/src/modules/licence-submissions-import/lib/replicate-submissions.js
+++ b/src/modules/licence-submissions-import/lib/replicate-submissions.js
@@ -91,7 +91,6 @@ async function _naldLinesCurrent (returnLog) {
         nrl."RET_QTY" IS NOT NULL
         AND nrl."RET_QTY" <> 'null'
         AND nrl."RET_QTY" <> ''
-        AND nrl."RET_QTY" <> '0'
         AND nrl."ARFL_ARTY_ID"=$1
         AND nrl."FGAC_REGION_CODE"=$2
         AND to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') >= to_date($3, 'YYYY-MM-DD')
@@ -135,7 +134,6 @@ async function _naldLinesOld (returnLog) {
         nrl."RET_QTY" IS NOT NULL
         AND nrl."RET_QTY" <> 'null'
         AND nrl."RET_QTY" <> ''
-        AND nrl."RET_QTY" <> '0'
         AND nrl."ARFL_ARTY_ID" = $1
         AND nrl."FGAC_REGION_CODE" = $2
         AND to_date(nrl."RET_DATE", 'DD/MM/YYYY') >= to_date($3, 'YYYY-MM-DD')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5035

We've significantly changed the overnight import process to include missing return submission data from NALD.

Billing & Data have been reviewing the results and have found an issue. It appears that where NALD has recorded a `0`, we are importing it as `NULL`. On the face of it, they may appear to mean the same thing, but they are, in fact, different.

`0` means the customer has explicitly told us that no water was abstracted at that time. `NULL` means no value has been submitted.

After investigating, we spotted that the query that extracts the NALD lines for import ignores those with a quantity of `0`. This means that, because nothing matches the generated WRLS line, we leave its quantity as `NULL`.

Simply removing the clause in the NALD lines queries resolves the issue!