### PR TITLE
Fix "Build Status" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Water Abstraction Import
 
-![Build Status](https://github.com/DEFRA/water-abstraction-import/workflows/CI/badge.svg?branch=main)
+![Build Status](https://github.com/DEFRA/water-abstraction-import/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-import&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-import)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-import&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-import)
 [![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/water-abstraction-import/badge.svg)](https://snyk.io/test/github/DEFRA/water-abstraction-import)


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/135

The url used for GitHub's CI badges has changed, leading to our existing badge not displaying correctly. This PR fixes this.