### PR TITLE
Filter out submissions imported from NALD in API

### DIFF
--- a/src/modules/returns/lib/api-helpers.js
+++ b/src/modules/returns/lib/api-helpers.js
@@ -8,7 +8,8 @@ const getVersionFilter = (request) => {
   const { start, end } = request.query
   const filter = {
     current: true,
-    created_at: { $gte: start }
+    created_at: { $gte: start },
+    user_id: { $ne: 'imported@from.nald' }
   }
 
   if (end) {

--- a/test/modules/returns/lib/api-helpers.test.js
+++ b/test/modules/returns/lib/api-helpers.test.js
@@ -25,7 +25,7 @@ experiment('getVersionFilter', () => {
         $gte: '2018-04-01'
       },
       user_id: {
-        '$ne': 'imported@from.nald'
+        $ne: 'imported@from.nald'
       }
     })
   })
@@ -47,7 +47,7 @@ experiment('getVersionFilter', () => {
         $lte: '2018-05-12'
       },
       user_id: {
-        '$ne': 'imported@from.nald'
+        $ne: 'imported@from.nald'
       }
     })
   })

--- a/test/modules/returns/lib/api-helpers.test.js
+++ b/test/modules/returns/lib/api-helpers.test.js
@@ -19,7 +19,15 @@ experiment('getVersionFilter', () => {
 
     const data = getVersionFilter(request)
 
-    expect(data).to.equal({ current: true, created_at: { $gte: '2018-04-01' } })
+    expect(data).to.equal({
+      current: true,
+      created_at: {
+        $gte: '2018-04-01'
+      },
+      user_id: {
+        '$ne': 'imported@from.nald'
+      }
+    })
   })
 
   it('Should get version filter with end date specified', async () => {
@@ -32,7 +40,16 @@ experiment('getVersionFilter', () => {
 
     const filter = getVersionFilter(request)
 
-    expect(filter).to.equal({ current: true, created_at: { $gte: '2018-04-01', $lte: '2018-05-12' } })
+    expect(filter).to.equal({
+      current: true,
+      created_at: {
+        $gte: '2018-04-01',
+        $lte: '2018-05-12'
+      },
+      user_id: {
+        '$ne': 'imported@from.nald'
+      }
+    })
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5048

On Friday 9 May at 23:45 (22:45 UTC) the update NALD import job ran for the first time. (see WATER-4855 )

It now looks for return submission data that exists in NALD but not in WRLS, and imports it. When the job ran that night, we knew that'd be everything pre-2018!

The job completed fine and has been running each night successfully.

However, overnight, it meant we went from 99K submission records to 447K!

We thought the FME job would have no issues because of a misunderstanding of its date parameters. Each day at 7 AM, it pings WRLS using the previous day's date as a filter parameter. We believed this meant it only wanted to see submissions submitted for that day. In fact, it wants to see anything _created_ on that date.

Added to that, the WRLS service paginates its results (2000 per page). We've since learnt that the FME job doesn't have the logic to deal with pagination. An assumption was made that there would never be more than 2000 submissions in a day, so only the first page of results is processed.

So, even if the FME job could successfully process all the new submission records we've added, it would only process the first 2000.

Fortunately, the updated import job makes it easy to differentiate return submissions we've imported from NALD. Since NALD already knows about these records, the FME job is pointless in attempting to import them back into NALD.

With the addition of a new filter, we can ensure that the API endpoint the FME job is hitting excludes these records from the results. What remains is stuff NALD doesn't know about, and that FME does need to import back into NALD.