### PR TITLE
Change user id for imported return submissions

### DIFF
--- a/src/modules/licence-submissions-import/lib/replicate-submissions.js
+++ b/src/modules/licence-submissions-import/lib/replicate-submissions.js
@@ -247,7 +247,7 @@ function _version (returnLog, nilReturn) {
     metadata: {},
     nil_return: nilReturn,
     return_id: returnLog.return_id,
-    user_id: 'imported@from.nald',
+    user_id: 'imported.from@nald.gov.uk',
     user_type: 'system',
     version_id: generateUUID(),
     version_number: returnLog.version_number

--- a/src/modules/returns/lib/api-helpers.js
+++ b/src/modules/returns/lib/api-helpers.js
@@ -9,7 +9,7 @@ const getVersionFilter = (request) => {
   const filter = {
     current: true,
     created_at: { $gte: start },
-    user_id: { $ne: 'imported@from.nald' }
+    user_id: { $ne: 'imported.from@nald.gov.uk' }
   }
 
   if (end) {

--- a/test/modules/returns/lib/api-helpers.test.js
+++ b/test/modules/returns/lib/api-helpers.test.js
@@ -25,7 +25,7 @@ experiment('getVersionFilter', () => {
         $gte: '2018-04-01'
       },
       user_id: {
-        $ne: 'imported@from.nald'
+        $ne: 'imported.from@nald.gov.uk'
       }
     })
   })
@@ -47,7 +47,7 @@ experiment('getVersionFilter', () => {
         $lte: '2018-05-12'
       },
       user_id: {
-        $ne: 'imported@from.nald'
+        $ne: 'imported.from@nald.gov.uk'
       }
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5053

Unfortunately, the email assigned to the historic NALD return submissions we import from NALD is causing problems for the legacy code that generates the return cycles report.

It believes that `imported@from.nald` is an invalid email address, so it is throwing an error when reading the submission records.

We've found that it is happy if we change the email to `imported.from@nald.gov.uk`, so this data fix does that for anything new we import.

A [change in water-abstraction-returns](https://github.com/DEFRA/water-abstraction-returns/pull/422) will fix the existing records.