### PR TITLE
Fix NALD received only rtns in WRLS for last cycle

### DIFF
--- a/src/modules/clean/process.js
+++ b/src/modules/clean/process.js
@@ -22,7 +22,7 @@ async function go (cleanLicences = false, skipReturnData = false, log = false) {
 
     if (skipReturnData) {
       global.GlobalNotifier.omg('clean: skipped return version data')
-      messages.push('Skipped because importing returns is disabled')
+      messages.push('Skipped cleaning return version data because importing NALD returns-leg is disabled')
 
       return messages
     }

--- a/src/modules/invalid-returns-cleanup/lib/clean-received-only.js
+++ b/src/modules/invalid-returns-cleanup/lib/clean-received-only.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+/**
+ * Cleans up returns that have been imported as nil returns but should have been received only
+ *
+ * > Currently only applies to return logs since 2024-04-01. There are many more older ones in the same state but it is
+ * > still being decided what to do with those.
+ *
+ * In NALD, the form logs are generated at the start of the cycle. Like WRLS, you can apply a received date but not add
+ * any quantities. However, in WRLS, we have a separate 'status' field that is set to 'received' at the same time. NALD
+ * doesn't have this.
+ *
+ * When testing the historic NALD submission data in NALD, we found that we weren't correctly handling NALD lines with
+ * zero and null quantities. Essentially, we were ignoring them when we needed to include them.
+ *
+ * But by doing so, it cannot differentiate between
+ *
+ * - A NALD form log where a user wants to record a received date
+ * - A NALD form log that has been submitted, but where no values were provided
+ *
+ * So, it has interpreted these records as 'nil returns' in WRLS and set them to `COMPLETE`.
+ *
+ * This module cleans up any records that have been imported as nil returns but should have been received only
+ */
+async function go () {
+  await _cleanReturns()
+}
+
+/**
+ * We've used a temporary table here to allow us to ensure we that when we update the data, nothing becomes messed up
+ * because one step fails. It also allows us to make this as performant as possible.
+ */
+async function _cleanReturns () {
+  const query = `
+    BEGIN;
+
+    -- Create a table containing all the version and return IDs that should be received-only
+    CREATE TEMP TABLE received_only_returns(
+      return_id VARCHAR,
+      version_id VARCHAR
+    ) ON COMMIT DROP;
+
+    INSERT INTO received_only_returns
+    SELECT
+      r.return_id,
+      v.version_id
+    FROM
+      "returns"."returns" r
+    INNER JOIN
+      "returns".versions v ON v.return_id = r.return_id
+    WHERE
+      r.received_date IS NOT NULL
+      AND r.start_date >= '2024-04-01'
+      AND v.nil_return = TRUE
+      AND v.user_type = 'system'
+    AND NOT EXISTS (
+      SELECT 1 FROM "returns".lines l WHERE l.quantity IS NOT NULL AND l.version_id = v.version_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM "returns".versions v2 WHERE v2.version_number <> 1 AND v2.return_id = v.return_id
+    );
+
+    DELETE FROM "returns".lines l WHERE l.version_id IN (
+      SELECT ror.version_id FROM received_only_returns ror
+    );
+
+    DELETE FROM "returns".versions v WHERE v.version_id IN (
+      SELECT ror.version_id FROM received_only_returns ror
+    );
+
+    UPDATE "returns"."returns" SET
+      "status" = 'received'
+    WHERE
+      return_id IN (
+        SELECT ror.return_id FROM received_only_returns ror
+      );
+
+    COMMIT;
+  `
+
+  await db.query(query)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/invalid-returns-cleanup/process.js
+++ b/src/modules/invalid-returns-cleanup/process.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CleanNoRequirements = require('./lib/clean-no-requirement.js')
+const CleanReceivedOnly = require('./lib/clean-received-only.js')
 const CleanSummer = require('./lib/clean-summer.js')
 const CleanWinter = require('./lib/clean-winter.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
@@ -11,6 +12,7 @@ async function go (log = false) {
   try {
     const startTime = currentTimeInNanoseconds()
 
+    await CleanReceivedOnly.go()
     await CleanSummer.go()
     await CleanWinter.go()
     await CleanNoRequirements.go()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5055

In NALD, the form logs are generated at the start of the cycle. Like WRLS, you can apply a received date but not add any quantities. However, in WRLS, we have a separate 'status' field that is set to 'received' at the same time. NALD doesn't have this.

When testing the historic NALD submission data in NALD, we found that we weren't correctly handling NALD lines with zero and null quantities. Essentially, we were ignoring them when we needed to include them.

But by doing so, it cannot differentiate between

- A NALD form log where a user wants to record a received date
- A NALD form log that has been submitted, but where no values were provided

So, it has interpreted these records as 'nil returns' in WRLS and set them to `COMPLETE`.

We've agreed that NALD records with a received date and all null quantities should be interpreted as 'received only'. But when we checked, there are more than 9K of them from as far back as 1994!

We're going to consider what we do with some of these very old returns. But in the meantime, we'd like to clean up those from the last returns cycle at least (2024-04-01 onwards).

We must develop a query that 'corrects' those we've already imported as 'nil' returns. We then need to stop it from happening to any more.

On that last point, we're not expecting any more. The ones they flagged in NALD as received-only were done before the email reminders were generated on 1 April as a one-off exercise. Plus, we intend to switch off this import in the very near future.

So, we're going to 'hack' this! We won't touch the code that generates the return submissions. It'll continue to create nil returns and mark the return log as `COMPLETE`. Instead, we'll just let the step needed to clean up those we've already imported handle any future ones created as well.

Simples!