### PR TITLE
Fix issue with getMinDate() & getMaxDate()

### DIFF
--- a/src/lib/date-helpers.js
+++ b/src/lib/date-helpers.js
@@ -80,10 +80,10 @@ function _sortDates (arr) {
   })
 
   mappedArray.sort(function (startDate1, startDate2) {
-    if ((startDate1.unix > startDate2.unix)) {
-      return -1
-    } else {
+    if ((startDate1.unix() > startDate2.unix())) {
       return 1
+    } else {
+      return -1
     }
   })
 

--- a/test/modules/party-crm-v2-import/lib/transformer.test.js
+++ b/test/modules/party-crm-v2-import/lib/transformer.test.js
@@ -65,7 +65,7 @@ experiment('modules/party-crm-v2-import/lib/transformer.js', () => {
         roleAddresses: [
           {
             role: 'licenceHolder',
-            startDate: moment('2015-08-13'),
+            startDate: moment('2015-04-01'),
             endDate: null,
             address: {
               address1: 'BIG MANOR FARM',
@@ -155,7 +155,7 @@ experiment('modules/party-crm-v2-import/lib/transformer.js', () => {
         roleAddresses: [
           {
             role: 'licenceHolder',
-            startDate: moment('2015-08-13'),
+            startDate: moment('2015-04-01'),
             endDate: null,
             address: {
               address1: 'BIG MANOR FARM',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5084

The billing & data team have spotted an issue with some licences. They are displaying multiple licence holders in their 'Contact details' tab in the view licence summary. Plus, when they go to add a new charge version, the incorrect licence holder is typically the one offered for selection.

Initially, we thought it was the same issue as WATER-4696 and WATER-4833 . However, it has nothing to do with data being deleted from NALD that gets left behind in WRLS. It _should_ now be that the data clean-up in the import job is enabled, this won't happen.

After debugging, we tracked the cause down to the wrong end date being assigned to the `crm_v2.document_roles` records, and a fault in the import refactoring.

😱😰☠️

Actually, there is no need to panic. We've confirmed that after correcting the mistake, the records self-heal. So, once a 'fixed' version of the import runs, the licences display as expected, and the correct account can be selected when setting up new charge versions.