### PR TITLE
Remove disable returns and enable clean flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,15 +34,5 @@ WATER_SERVICE_MAILBOX=
 # Use Cron type syntax to set timings for these background processes
 WRLS_CRON_NALD='15 23 * * *'
 
-# In preparation for switching management of the returns leg from NALD to WRLS we need the ability to disable
-# the import of return versions and return logs (and their connected data). On the day of go live the env var will be
-# set to 'true'. Assuming all is well, we'll then remove the jobs completely. If not, we can revert with a simple env
-# var change.
-DISABLE_RETURNS_IMPORTS=false
-
-# Whether to enable the extra steps in the clean process that will delete licence data from WRLS that no longer exists
-# in NALD.
-CLEAN_LICENCE_IMPORTS=false
-
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -70,11 +70,6 @@ module.exports = {
     nald: {
       zipPassword: process.env.NALD_ZIP_PASSWORD,
       path: process.env.S3_NALD_IMPORT_PATH || 'wal_nald_data_release'
-    },
-    licences: {
-      // Note: If the `isCleanLicenceImportsEnabled` flag is set to `true` the licence data that no longer exists in
-      // NALD but is in the WRLS DB will be removed from the WRLS DB
-      isCleanLicenceImportsEnabled: (process.env.CLEAN_LICENCE_IMPORTS === 'true') || false
     }
   },
 
@@ -82,11 +77,5 @@ module.exports = {
     apiKey: process.env.NOTIFY_API_KEY,
     mailbox: process.env.WATER_SERVICE_MAILBOX,
     templateId: '46eeaa9c-7346-4898-a4ad-4e26d239d4ef'
-  },
-
-  // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
-  // converting the env var to a boolean
-  featureFlags: {
-    disableReturnsImports: String(process.env.DISABLE_RETURNS_IMPORTS) === 'true' || false
   }
 }

--- a/src/controller.js
+++ b/src/controller.js
@@ -26,10 +26,8 @@ const LinkToModLogsProcess = require('./modules/link-to-mod-logs/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
 
-const config = require('../config.js')
-
 async function clean (_request, h) {
-  CleanProcess.go(config.import.licences.isCleanLicenceImportsEnabled, true)
+  CleanProcess.go(true)
 
   return h.response().code(204)
 }

--- a/src/modules/clean/process.js
+++ b/src/modules/clean/process.js
@@ -5,19 +5,14 @@ const DeletedLicenceData = require('./lib/deleted-licence-data.js')
 
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
-async function go (cleanLicences = false, log = false) {
+async function go (log = false) {
   const messages = []
 
   try {
     const startTime = currentTimeInNanoseconds()
 
-    if (cleanLicences) {
-      await DeletedLicences.go()
-      await DeletedLicenceData.go()
-    } else {
-      global.GlobalNotifier.omg('clean: skipped licences')
-      messages.push('Skipped cleaning licences as not enabled')
-    }
+    await DeletedLicences.go()
+    await DeletedLicenceData.go()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'clean: complete')

--- a/src/modules/import-job/lib/clean.js
+++ b/src/modules/import-job/lib/clean.js
@@ -3,8 +3,6 @@
 const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
 const CleanProcess = require('../../clean/process.js')
 
-const config = require('../../../../config.js')
-
 const STEP_NAME = 'clean'
 
 async function go () {
@@ -14,7 +12,7 @@ async function go () {
 
   const startTime = currentTimeInNanoseconds()
 
-  step.messages = await CleanProcess.go(config.import.licences.isCleanLicenceImportsEnabled, false)
+  step.messages = await CleanProcess.go(false)
 
   const { timeTakenSs } = durations(startTime)
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/143

> See our Team issue for an expanded explanation

This change removes the two feature flags the import has

- `DISABLE_RETURNS_IMPORTS` - Since we switched from NALD to WRLS on [June 11](https://github.com/DEFRA/water-abstraction-import/releases/tag/v2.35.1), this has been disabled and now will never be re-enabled. This means we can remove it altogether.
- `CLEAN_LICENCE_IMPORTS` - We argued that for the switch from NALD to WRLS to be successful, the changes we'd implemented many months ago, but which were waiting to go live, needed to be enabled. Again, cleaning of the licence data during the import will never be disabled, so we can remove the flag