### PR TITLE
Add missing billing step to clean process

### DIFF
--- a/src/modules/clean/lib/deleted-licences.js
+++ b/src/modules/clean/lib/deleted-licences.js
@@ -23,7 +23,7 @@ async function go () {
   await _licences()
 }
 
-async function _billingBatchChargeVersionYears() {
+async function _billingBatchChargeVersionYears () {
   // Delete any billing batch charge version years linked to charge versions linked to deleted NALD licences
   await db.query(`
     WITH licences_to_remove AS (
@@ -43,7 +43,7 @@ async function _billingBatchChargeVersionYears() {
   `)
 }
 
-async function _billingVolumes() {
+async function _billingVolumes () {
   // Delete any billing volumes linked to charge elements linked to deleted NALD licences
   await db.query(`
     WITH licences_to_remove AS (


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4662

As part of preparing for WRLS to take over returns management from NALD, we needed to ensure that the return version information from NALD was being imported.

When we dug in, we realised there was data in WRLS that no longer existed in NALD. This is because NALD, unlike WRLS, allows users to delete records. We cleaned all that up (see WATER-4654 ), but that led us to examine the licence data, where we found the same problem.

We added the 'clean' job in [clean up deleted licence data](https://github.com/DEFRA/water-abstraction-import/pull/1047) and thought this was running perfectly when finally deployed. That was until we realised that we had dropped some steps as part of a [refactor](https://github.com/DEFRA/water-abstraction-import/pull/1063).

We [added them back in](https://github.com/DEFRA/water-abstraction-import/pull/1120), but then saw that the 'clean' process, when run in pre-prod against real data, errored.

The issue was `water.billing_batch_charge_version_years`. The legacy bill run process creates these records when generating a bill run, even if it turns out to be empty or errors. In pre-prod, there were records linked to charge versions we were trying to delete because the licence had been deleted in NALD. Foreign key constraints caused the `_chargeVersions() step to fail, which prevented the process from finishing.

Therefore, we add a new step to handle those records. This reminded us that the legacy bill run process also creates `water.billing_volumes` records, which link to `water.charge_elements` records. The same constraint doesn't exist, and this was an opportune time to ensure that the table gets cleaned as well.