### PR TITLE
Switch to using Snyk CLI action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,70 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-COOKIE-8163060:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:45:51.032Z
+        created: 2025-08-06T13:45:51.034Z
+  SNYK-JS-JSONWEBTOKEN-3180022:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:46:41.265Z
+        created: 2025-08-06T13:46:41.271Z
+  SNYK-JS-JSONWEBTOKEN-3180024:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:48:57.753Z
+        created: 2025-08-06T13:48:57.759Z
+  SNYK-JS-JSONWEBTOKEN-3180026:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:49:23.186Z
+        created: 2025-08-06T13:49:23.191Z
+  SNYK-JS-IP-7148531:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:49:47.057Z
+        created: 2025-08-06T13:49:47.063Z
+  SNYK-JS-PACRESOLVER-1564857:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T13:59:27.763Z
+        created: 2025-08-06T13:59:27.770Z
+  SNYK-JS-IP-6240864:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T14:01:16.800Z
+        created: 2025-08-06T14:01:16.806Z
+  SNYK-JS-NETMASK-1089716:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T14:01:47.740Z
+        created: 2025-08-06T14:01:47.747Z
+  SNYK-JS-NETMASK-6056519:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T14:02:17.086Z
+        created: 2025-08-06T14:02:17.092Z
+  SNYK-JS-FORMDATA-10841150:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T14:02:57.866Z
+        created: 2025-08-06T14:02:57.872Z
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T14:03:26.744Z
+        created: 2025-08-06T14:03:26.748Z
+  SNYK-JS-SEMVER-3247795:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T14:04:03.060Z
+        created: 2025-08-06T14:04:03.067Z
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T14:04:38.660Z
+        created: 2025-08-06T14:04:38.666Z
+patch: {}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/144

With the adoption of SSO in the Defra GitHub org, our current [Snyk](https://snyk.io) status checks have stopped working.

The team issue goes into more detail, but in essence, whilst the GitHub account that **Snyk** uses to connect has SSO enabled, it won't connect to GitHub to update the PR with the test result.

This change performs the same check without **Snyk** having to authenticate to GitHub. Instead, GitHub will authenticate with **Snyk** by using its CLI via a GitHub action.

It does mean **Snyk** will no longer be listed as a separate check; instead, it will just be a new step in our CI. So, the outcome (adding a package with a vulnerability will cause the PR to fail checks) will be the same.