### PR TITLE
Add one-off missing 0 return submission lines step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@hapi/joi": "^15.1.1",
         "aws-sdk": "^2.1657.0",
         "bluebird": "^3.7.2",
+        "csv-parse": "^6.2.1",
         "csv-stringify": "^5.5.0",
         "dotenv": "^8.2.0",
         "firstline": "^2.0.2",
@@ -2461,6 +2462,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "5.6.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@hapi/joi": "^15.1.1",
     "aws-sdk": "^2.1657.0",
     "bluebird": "^3.7.2",
+    "csv-parse": "^6.2.1",
     "csv-stringify": "^5.5.0",
     "dotenv": "^8.2.0",
     "firstline": "^2.0.2",

--- a/src/controller.js
+++ b/src/controller.js
@@ -26,6 +26,7 @@ const LicencesImportProcess = require('./modules/licences-import/process.js')
 const LinkToModLogsProcess = require('./modules/link-to-mod-logs/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
+const ZeroReturnLinesProcess = require('./modules/zero-return-lines/process.js')
 
 async function clean (_request, h) {
   CleanProcess.go(true)
@@ -189,6 +190,12 @@ function status (_request, _h) {
   return { status: 'alive' }
 }
 
+async function zeroReturnLines (_request, h) {
+  ZeroReturnLinesProcess.go(true)
+
+  return h.response().code(204)
+}
+
 async function _tagReference () {
   try {
     const { stdout, stderr } = await exec('git describe --always --tags')
@@ -230,5 +237,6 @@ module.exports = {
   linkToModLogs,
   partyCrmV2Import,
   referenceDataImport,
-  status
+  status,
+  zeroReturnLines
 }

--- a/src/modules/extract-old-lines/process.js
+++ b/src/modules/extract-old-lines/process.js
@@ -161,12 +161,11 @@ async function _loadOldLinesTable (extractLocalPath) {
 
 async function _oldLinesFileExists () {
   try {
-    console.log('Hello')
     await s3.getHead(OLD_LINES_ZIP_FILE)
 
     return true
   } catch (error) {
-    if (error.name === 'NoSuchKey') {
+    if (['NotFound', 'NoSuchKey'].includes(error.name)) {
       return false // File does not exist
     }
 

--- a/src/modules/import-job/lib/zero-return-lines.js
+++ b/src/modules/import-job/lib/zero-return-lines.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const ZeroReturnLinesProcess = require('../../zero-return-lines/process.js')
+
+const STEP_NAME = 'zero-return-lines'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await ZeroReturnLinesProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -13,6 +13,7 @@ const LicencesImportStep = require('./lib/licences-import.js')
 const LinkToModLogsStep = require('./lib/link-to-mod-logs.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
 const ReferenceDataImportStep = require('./lib/reference-data-import.js')
+const ZeroReturnLinesStep = require('./lib/zero-return-lines.js')
 
 async function go () {
   try {
@@ -54,6 +55,9 @@ async function go () {
     steps.push(step)
 
     step = await EndDateTriggerStep.go()
+    steps.push(step)
+
+    step = await ZeroReturnLinesStep.go()
     steps.push(step)
 
     await CompletionEmail.go(steps)

--- a/src/modules/zero-return-lines/lib/convert-to-json.js
+++ b/src/modules/zero-return-lines/lib/convert-to-json.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const fs = require('node:fs')
+const { parse } = require('csv-parse/sync')
+
+function go (path, filename) {
+  const fileData = fs.readFileSync(`${path}/${filename}`)
+
+  const csvData = _parseDataToCsv(fileData)
+
+  const unzippedData = _unzip(csvData)
+
+  return _rows(unzippedData, filename)
+}
+
+function _convertToBoolean(value) {
+  if (!value || value.toLowerCase() === 'n') {
+    return false
+  }
+
+  return true
+}
+
+function _convertToNumber(value) {
+  if (!value) {
+    return null
+  }
+
+  return Number(value)
+}
+
+function _parseDataToCsv(csvData) {
+  const cleaned = csvData.toString().replace(/^\uFEFF/, '') // Remove BOM
+
+  return parse(cleaned, {
+    skip_lines_with_empty_values: true,
+    skip_empty_lines: true,
+    trim: true
+  })
+}
+
+function _rows(unzippedData, filename) {
+  const rows = []
+
+  const headerLine = unzippedData[0]
+
+  for (let i = 1; i < unzippedData.length; i++) {
+    const line = unzippedData[i]
+    const rowObject = {
+      filename,
+      process: false,
+      licenceRef: line[0],
+      returnRef: line[1],
+      siteDescription: line[2],
+      purpose: line[3],
+      nilReturn: _convertToBoolean(line[4]),
+      useMeter: _convertToBoolean(line[5]),
+      meterMake: line[6],
+      meterNumber: line[7],
+      returnId: line[line.length - 1],
+      lines: []
+    }
+
+    for (let j = 8; j < line.length - 1; j++) {
+      rowObject.lines.push({
+        endDate: new Date(headerLine[j]),
+        quantity: _convertToNumber(line[j])
+      })
+    }
+
+    rowObject.process = rowObject.lines.some((line) => {
+      return line.quantity === 0
+    })
+
+    rows.push(rowObject)
+  }
+
+  return rows
+}
+
+function _unzip(csvData) {
+  if (csvData.length === 0) {
+    return []
+  }
+
+  const noOfLicences = csvData[0].length
+
+  return Array.from({ length: noOfLicences }, (_, index) => {
+    return csvData.map((row) => row[index])
+  })
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/zero-return-lines/lib/convert-to-json.js
+++ b/src/modules/zero-return-lines/lib/convert-to-json.js
@@ -13,7 +13,7 @@ function go (path, filename) {
   return _rows(unzippedData, filename)
 }
 
-function _convertToBoolean(value) {
+function _convertToBoolean (value) {
   if (!value || value.toLowerCase() === 'n') {
     return false
   }
@@ -21,7 +21,7 @@ function _convertToBoolean(value) {
   return true
 }
 
-function _convertToNumber(value) {
+function _convertToNumber (value) {
   if (!value) {
     return null
   }
@@ -29,7 +29,7 @@ function _convertToNumber(value) {
   return Number(value)
 }
 
-function _parseDataToCsv(csvData) {
+function _parseDataToCsv (csvData) {
   const cleaned = csvData.toString().replace(/^\uFEFF/, '') // Remove BOM
 
   return parse(cleaned, {
@@ -39,7 +39,7 @@ function _parseDataToCsv(csvData) {
   })
 }
 
-function _rows(unzippedData, filename) {
+function _rows (unzippedData, filename) {
   const rows = []
 
   const headerLine = unzippedData[0]
@@ -74,7 +74,7 @@ function _rows(unzippedData, filename) {
 
     // There are some funnies in the file where we have a licence and reference, but no return ID. Fortunately they are
     // never populated but just to be sure we only want to process rows where we have a return ID _and_ zero qty lines.
-    rowObject.process = hasZeroQuantityLines && rowObject.returnId ? true : false
+    rowObject.process = hasZeroQuantityLines && !!rowObject.returnId
 
     rows.push(rowObject)
   }
@@ -82,7 +82,7 @@ function _rows(unzippedData, filename) {
   return rows
 }
 
-function _unzip(csvData) {
+function _unzip (csvData) {
   if (csvData.length === 0) {
     return []
   }

--- a/src/modules/zero-return-lines/lib/convert-to-json.js
+++ b/src/modules/zero-return-lines/lib/convert-to-json.js
@@ -68,9 +68,13 @@ function _rows(unzippedData, filename) {
       })
     }
 
-    rowObject.process = rowObject.lines.some((line) => {
+    const hasZeroQuantityLines = rowObject.lines.some((line) => {
       return line.quantity === 0
     })
+
+    // There are some funnies in the file where we have a licence and reference, but no return ID. Fortunately they are
+    // never populated but just to be sure we only want to process rows where we have a return ID _and_ zero qty lines.
+    rowObject.process = hasZeroQuantityLines && rowObject.returnId ? true : false
 
     rows.push(rowObject)
   }

--- a/src/modules/zero-return-lines/lib/file-manager.js
+++ b/src/modules/zero-return-lines/lib/file-manager.js
@@ -8,8 +8,6 @@ const processHelper = require('@envage/water-abstraction-helpers').process
 
 const s3 = require('../../../lib/services/s3.js')
 
-const config = require('../../../../config.js')
-
 const ZERO_RETURN_LINES_ZIP_FILE = 'zero-return-lines.zip'
 
 async function checkFileExists () {
@@ -58,10 +56,10 @@ async function extractFile (downloadLocalPath) {
   return localPath
 }
 
-function files(extractLocalPath) {
+function files (extractLocalPath) {
   return fs.readdirSync(extractLocalPath).filter((file) => {
-      return file.endsWith('.csv')
-    }).sort()
+    return file.endsWith('.csv')
+  }).sort()
 }
 
 async function uploadFile (filename, data) {

--- a/src/modules/zero-return-lines/lib/file-manager.js
+++ b/src/modules/zero-return-lines/lib/file-manager.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const processHelper = require('@envage/water-abstraction-helpers').process
+
+const s3 = require('../../../lib/services/s3.js')
+
+const config = require('../../../../config.js')
+
+const ZERO_RETURN_LINES_ZIP_FILE = 'zero-return-lines.zip'
+
+async function checkFileExists () {
+  try {
+    await s3.getHead(ZERO_RETURN_LINES_ZIP_FILE)
+
+    return true
+  } catch (error) {
+    if (['NotFound', 'NoSuchKey'].includes(error.name)) {
+      return false // File does not exist
+    }
+
+    throw error // Handle other errors
+  }
+}
+
+function cleanUpFiles (downloadLocalPath, extractLocalPath) {
+  // Delete the files we created. Force true means if it doesn't exist don't error (saves us checking first)
+  fs.rmSync(downloadLocalPath, { force: true })
+  fs.rmSync(extractLocalPath, { force: true, recursive: true })
+}
+
+async function downloadFile () {
+  const temporaryFilePath = os.tmpdir()
+  const localPath = path.join(temporaryFilePath, ZERO_RETURN_LINES_ZIP_FILE)
+
+  // Delete any existing copy of the file. Force true means if it doesn't exist don't error (saves us checking first)
+  fs.rmSync(localPath, { force: true })
+
+  await s3.download(ZERO_RETURN_LINES_ZIP_FILE, localPath)
+
+  return localPath
+}
+
+async function extractFile (downloadLocalPath) {
+  const temporaryFilePath = os.tmpdir()
+  const localPath = path.join(temporaryFilePath, 'zero-return-lines')
+
+  // Delete any existing files. Force true means if it doesn't exist don't error (saves us checking first)
+  fs.rmSync(localPath, { force: true, recursive: true })
+
+  const command = `7z x ${downloadLocalPath} -o${localPath}`
+
+  await processHelper.execCommand(command)
+
+  return localPath
+}
+
+function files(extractLocalPath) {
+  return fs.readdirSync(extractLocalPath).filter((file) => {
+      return file.endsWith('.csv')
+    }).sort()
+}
+
+async function uploadFile (filename, data) {
+  await s3.upload(filename, Buffer.from(data))
+}
+
+module.exports = {
+  checkFileExists,
+  cleanUpFiles,
+  downloadFile,
+  extractFile,
+  files,
+  uploadFile
+}

--- a/src/modules/zero-return-lines/lib/process-submission.js
+++ b/src/modules/zero-return-lines/lib/process-submission.js
@@ -14,19 +14,7 @@ async function go (submission, timestamp) {
   }
 }
 
-async function _processSubmission(submission, timestamp) {
-  const { lines, returnId } = submission
-
-  const zeroQtyLines = lines.filter((line) => {
-    return line.quantity === 0
-  })
-
-  for (const line of zeroQtyLines) {
-    await _updateLine(line, returnId, timestamp)
-  }
-}
-
-async function _updateLine(line, returnId, timestamp) {
+async function _updateLine (line, returnId, timestamp) {
   const params = [returnId, line.quantity, timestamp, line.endDate]
 
   const query = `WITH first_return_submission AS (

--- a/src/modules/zero-return-lines/lib/process-submission.js
+++ b/src/modules/zero-return-lines/lib/process-submission.js
@@ -2,17 +2,15 @@
 
 const db = require('../../../lib/connectors/db.js')
 
-async function go (submissions, timestamp) {
-  const toBeProcessed = submissions.filter((submission) => {
-    return submission.process
+async function go (submission, timestamp) {
+  const { lines, returnId } = submission
+
+  const zeroQtyLines = lines.filter((line) => {
+    return line.quantity === 0
   })
 
-  if (toBeProcessed.length === 0) {
-    return
-  }
-
-  for (const submission of toBeProcessed) {
-    await _processSubmission(submission, timestamp)
+  for (const line of zeroQtyLines) {
+    await _updateLine(line, returnId, timestamp)
   }
 }
 

--- a/src/modules/zero-return-lines/lib/process-submissions.js
+++ b/src/modules/zero-return-lines/lib/process-submissions.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go (submissions, timestamp) {
+  const toBeProcessed = submissions.filter((submission) => {
+    return submission.process
+  })
+
+  if (toBeProcessed.length === 0) {
+    return
+  }
+
+  for (const submission of toBeProcessed) {
+    await _processSubmission(submission, timestamp)
+  }
+}
+
+async function _processSubmission(submission, timestamp) {
+  const { lines, returnId } = submission
+
+  const zeroQtyLines = lines.filter((line) => {
+    return line.quantity === 0
+  })
+
+  for (const line of zeroQtyLines) {
+    await _updateLine(line, returnId, timestamp)
+  }
+}
+
+async function _updateLine(line, returnId, timestamp) {
+  const params = [returnId, line.quantity, timestamp, line.endDate]
+
+  const query = `WITH first_return_submission AS (
+  SELECT DISTINCT ON (v.return_id)
+    v.return_id,
+    v.version_id
+  FROM
+    "returns".versions v
+  WHERE
+    v.return_id = $1
+  ORDER BY
+    v.return_id ASC,
+    v.version_number ASC
+)
+UPDATE "returns".lines l
+SET
+  quantity = $2,
+  updated_at = $3
+FROM first_return_submission frs
+WHERE
+  l.version_id = frs.version_id
+  AND l.quantity IS NULL
+  AND l.end_date = $4;
+`
+
+  await db.query(query, params)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -52,14 +52,14 @@ async function go (log = false) {
 
 async function _logResults (extractLocalPath, logs, timestamp) {
   const logData = logs.map((log) => {
-    return `${log.filename},${log.returnId},${log.process},${log.error || ''}`
+    return `${log.filename},${log.returnId},${log.process},${log.error || ''},`
   }).join('\n')
 
   await uploadFile(`zero-return-lines-log-${Date.parse(timestamp)}.csv`, logData)
 }
 
 async function _processSubmissionFile (extractLocalPath, submissionFile, timestamp) {
-  const logs = []
+  const results = []
   const submissions = ConvertToJson.go(extractLocalPath, submissionFile)
 
   for (const submission of submissions) {
@@ -75,10 +75,10 @@ async function _processSubmissionFile (extractLocalPath, submissionFile, timesta
       }
     }
 
-    logs.push(log)
+    results.push(log)
   }
 
-  return logs
+  return results
 }
 
 function _setMessages (processResults, messages) {

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -1,12 +1,9 @@
 'use strict'
 
-const fs = require('node:fs')
-
 const ConvertToJson = require('./lib/convert-to-json.js')
 const ProcessSubmission = require('./lib/process-submission.js')
+const { checkFileExists, cleanUpFiles, downloadFile, extractFile, files, uploadFile } = require('./lib/file-manager.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
-
-const LOCATION_OF_FILES = '/home/tmp/water-5481'
 
 /**
  * This is a temporary script
@@ -16,23 +13,33 @@ async function go(log = false) {
   const processResults = []
   const timestamp = timestampForPostgres()
 
+  let fileExists
+
   try {
     const startTime = currentTimeInNanoseconds()
 
-    const files = _returnFiles()
+    fileExists = await checkFileExists()
 
-    for (const file of files) {
-      const results = await _processFile(file, timestamp, messages)
+    if (fileExists) {
+      const downloadLocalPath = await downloadFile()
+      const extractLocalPath = await extractFile(downloadLocalPath)
+      const submissionFiles = files(extractLocalPath)
 
-      processResults.push(...results)
+      for (const submissionFile of submissionFiles) {
+        const results = await _processSubmissionFile(extractLocalPath, submissionFile, timestamp)
+
+        processResults.push(...results)
+      }
+
+      await _logResults(extractLocalPath, processResults, timestamp)
+
+      cleanUpFiles(downloadLocalPath, extractLocalPath)
     }
 
     _setMessages(processResults, messages)
 
-    _logResults(processResults, timestamp)
-
     if (log) {
-      calculateAndLogTimeTaken(startTime, 'zero-return-lines: complete')
+      calculateAndLogTimeTaken(startTime, 'zero-return-lines: complete', { messages })
     }
   } catch (error) {
     global.GlobalNotifier.omfg('zero-return-lines: errored', {}, error)
@@ -43,17 +50,17 @@ async function go(log = false) {
   return messages
 }
 
-function _logResults (logs, timestamp) {
+async function _logResults (extractLocalPath, logs, timestamp) {
   const logData = logs.map((log) => {
     return `${log.filename},${log.returnId},${log.process},${log.error || ''}`
   }).join('\n')
 
-  fs.writeFileSync(`${LOCATION_OF_FILES}/zero-return-lines-${timestamp}.csv`, logData)
+  await uploadFile(`zero-return-lines-log-${Date.parse(timestamp)}.csv`, logData)
 }
 
-async function _processFile (file, timestamp) {
+async function _processSubmissionFile (extractLocalPath, submissionFile, timestamp) {
   const logs = []
-  const submissions = ConvertToJson.go(LOCATION_OF_FILES, file)
+  const submissions = ConvertToJson.go(extractLocalPath, submissionFile)
 
   for (const submission of submissions) {
     const { filename, process, returnId } = submission
@@ -72,12 +79,6 @@ async function _processFile (file, timestamp) {
   }
 
   return logs
-}
-
-function _returnFiles() {
-  return fs.readdirSync(LOCATION_OF_FILES).filter((file) => {
-      return file.endsWith('.csv')
-    }).sort()
 }
 
 function _setMessages(processResults, messages) {

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const fs = require('node:fs')
+
+const ConvertToJson = require('./lib/convert-to-json.js')
+const db = require('../../lib/connectors/db.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+const LOCATION_OF_FILES = '/home/tmp/water-5481'
+
+/**
+ * This is a temporary script
+ */
+async function go(log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    const files = _returnFiles()
+
+    const submissions = ConvertToJson.go(LOCATION_OF_FILES, files[0])
+    console.log(submissions[0])
+    console.log(submissions[11])
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'zero-return-lines: complete')
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('zero-return-lines: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+function _returnFiles() {
+  return fs.readdirSync(LOCATION_OF_FILES).filter((file) => {
+      return file.endsWith('.csv')
+    }).sort()
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -3,8 +3,8 @@
 const fs = require('node:fs')
 
 const ConvertToJson = require('./lib/convert-to-json.js')
-const db = require('../../lib/connectors/db.js')
-const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+const ProcessSubmissions = require('./lib/process-submissions.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
 
 const LOCATION_OF_FILES = '/home/tmp/water-5481'
 
@@ -13,6 +13,7 @@ const LOCATION_OF_FILES = '/home/tmp/water-5481'
  */
 async function go(log = false) {
   const messages = []
+  const timestamp = timestampForPostgres()
 
   try {
     const startTime = currentTimeInNanoseconds()
@@ -20,8 +21,8 @@ async function go(log = false) {
     const files = _returnFiles()
 
     const submissions = ConvertToJson.go(LOCATION_OF_FILES, files[0])
-    console.log(submissions[0])
-    console.log(submissions[11])
+
+    await ProcessSubmissions.go(submissions, timestamp)
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'zero-return-lines: complete')

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -8,7 +8,7 @@ const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres
 /**
  * This is a temporary script
  */
-async function go(log = false) {
+async function go (log = false) {
   const messages = []
   const processResults = []
   const timestamp = timestampForPostgres()
@@ -81,7 +81,7 @@ async function _processSubmissionFile (extractLocalPath, submissionFile, timesta
   return logs
 }
 
-function _setMessages(processResults, messages) {
+function _setMessages (processResults, messages) {
   const total = processResults.length
 
   const processedCount = processResults.filter((logEntry) => {

--- a/src/modules/zero-return-lines/process.js
+++ b/src/modules/zero-return-lines/process.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs')
 
 const ConvertToJson = require('./lib/convert-to-json.js')
-const ProcessSubmissions = require('./lib/process-submissions.js')
+const ProcessSubmission = require('./lib/process-submission.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
 
 const LOCATION_OF_FILES = '/home/tmp/water-5481'
@@ -13,6 +13,7 @@ const LOCATION_OF_FILES = '/home/tmp/water-5481'
  */
 async function go(log = false) {
   const messages = []
+  const processResults = []
   const timestamp = timestampForPostgres()
 
   try {
@@ -20,9 +21,15 @@ async function go(log = false) {
 
     const files = _returnFiles()
 
-    const submissions = ConvertToJson.go(LOCATION_OF_FILES, files[0])
+    for (const file of files) {
+      const results = await _processFile(file, timestamp, messages)
 
-    await ProcessSubmissions.go(submissions, timestamp)
+      processResults.push(...results)
+    }
+
+    _setMessages(processResults, messages)
+
+    _logResults(processResults, timestamp)
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'zero-return-lines: complete')
@@ -36,10 +43,55 @@ async function go(log = false) {
   return messages
 }
 
+function _logResults (logs, timestamp) {
+  const logData = logs.map((log) => {
+    return `${log.filename},${log.returnId},${log.process},${log.error || ''}`
+  }).join('\n')
+
+  fs.writeFileSync(`${LOCATION_OF_FILES}/zero-return-lines-${timestamp}.csv`, logData)
+}
+
+async function _processFile (file, timestamp) {
+  const logs = []
+  const submissions = ConvertToJson.go(LOCATION_OF_FILES, file)
+
+  for (const submission of submissions) {
+    const { filename, process, returnId } = submission
+
+    const log = { filename, process, returnId }
+
+    if (submission.process) {
+      try {
+        await ProcessSubmission.go(submission, timestamp)
+      } catch (error) {
+        log.error = error.message
+      }
+    }
+
+    logs.push(log)
+  }
+
+  return logs
+}
+
 function _returnFiles() {
   return fs.readdirSync(LOCATION_OF_FILES).filter((file) => {
       return file.endsWith('.csv')
     }).sort()
+}
+
+function _setMessages(processResults, messages) {
+  const total = processResults.length
+
+  const processedCount = processResults.filter((logEntry) => {
+    return logEntry.process
+  }).length
+
+  const failedCount = processResults.filter((logEntry) => {
+    return logEntry.error
+  }).length
+
+  messages.push(`${total} return submissions checked. ${processedCount} processed. ${failedCount} failed.`)
 }
 
 module.exports = {

--- a/src/routes.js
+++ b/src/routes.js
@@ -189,5 +189,13 @@ module.exports = [
     config: {
       auth: false
     }
+  },
+  {
+    method: 'POST',
+    path: '/process/zero-return-lines',
+    handler: Controller.zeroReturnLines,
+    config: {
+      auth: false
+    }
   }
 ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5481

Last year, a long-standing issue with return submission values was found.

The issue was where a value had been calculated, because the submission was not in cubic metres. The calculation resulted in a [floating-point error](https://en.wikipedia.org/wiki/Floating-point_error_mitigation) in some quantities.

It's not something that affects the overall values. It just results in values like `8433.000000000000002`, which, when rounded, would disappear. But these values could be seen when a user opted to download a return, or when reporting on them in Power BI.

So, we agreed to round all calculations to 6 decimal places. We also updated the existing data to match.

Unfortunately, one of those changes introduced a bug to the external bulk upload process. Any 0 values in the lines were dropped, and NULL was recorded instead.

It matters to the business whether a licensee entered 0 or left it blank, so we need to populate the missing 0 values. There had only been one round of quarterly submissions before we spotted the bug and fixed it. Fortunately, the service retains copies of the submitted returns for a period.

So, this change adds a step to the import process that will look through all the files and determine which contain 0-value submissions. When it finds them, it then ensures that the 0 value is recorded in the database, rather than NULL.

It's a one-off step; once run, we can remove it from the import. But because of our change control process, this is the easiest and least disruptive way to apply the fix. It also means we can use the computer's power to review and determine which return logs need fixing.