### PR TITLE
Add new step to import missing void return logs 

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -24,6 +24,7 @@ const LicenceNoStartDateImportProcess = require('./modules/licence-no-start-date
 const LicencePermitImportProcess = require('./modules/licence-permit-import/process.js')
 const LicencesImportProcess = require('./modules/licences-import/process.js')
 const LinkToModLogsProcess = require('./modules/link-to-mod-logs/process.js')
+const MissingVoidReturnsProcess = require('./modules/missing-void-returns/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
 
@@ -166,6 +167,12 @@ async function linkToModLogs (_request, h) {
   return h.response().code(204)
 }
 
+async function missingVoidReturns (_request, h) {
+  MissingVoidReturnsProcess.go(true)
+
+  return h.response().code(204)
+}
+
 async function partyCrmV2Import (request, h) {
   const { partyId, regionCode } = request.payload
   const results = await db.query(
@@ -228,6 +235,7 @@ module.exports = {
   licencePermitImport,
   licencesImport,
   linkToModLogs,
+  missingVoidReturns,
   partyCrmV2Import,
   referenceDataImport,
   status

--- a/src/lib/date-helpers.js
+++ b/src/lib/date-helpers.js
@@ -25,6 +25,22 @@ function compareDates (dateA, dateB) {
 }
 
 /**
+ * Format the provided date in ISO format.
+ *
+ * @param {Date | string } date - a date object to be formatted
+ * @returns {Date | null} - the date formatted in YYYY-MM-DD.
+ */
+function formatDateObjectToISO(date) {
+  if (!date) {
+    return null
+  }
+
+  const localDate = new Date(date)
+
+  return localDate.toISOString().split('T')[0]
+}
+
+/**
  * Gets the end date for a company address from licence version data
  * @param {Object} row - from NALD licence/licence version data
  * @param {String,Null} currentEnd - the current value of the end date in the accumulator
@@ -111,6 +127,7 @@ function _sortDates (arr) {
 
 module.exports = {
   compareDates,
+  formatDateObjectToISO,
   getEndDate,
   getMinDate,
   getMaxDate,

--- a/src/lib/date-helpers.js
+++ b/src/lib/date-helpers.js
@@ -30,7 +30,7 @@ function compareDates (dateA, dateB) {
  * @param {Date | string } date - a date object to be formatted
  * @returns {Date | null} - the date formatted in YYYY-MM-DD.
  */
-function formatDateObjectToISO(date) {
+function formatDateObjectToISO (date) {
   if (!date) {
     return null
   }

--- a/src/lib/return-helpers.js
+++ b/src/lib/return-helpers.js
@@ -1,0 +1,93 @@
+'use strict'
+
+function daysFromPeriod (periodStartDate, periodEndDate) {
+  const days = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
+    // Clone the date again for the same reason above
+    const startDate = _cloneDate(clonedPeriodStartDate)
+
+    // No jiggery-pokery needed. Simply add it to the days array as both the start and end date
+    days.push({ start_date: startDate, end_date: startDate })
+
+    // Move the date to the next day, and round we go again!
+    clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 1)
+  }
+
+  return days
+}
+
+function weeksFromPeriod (periodStartDate, periodEndDate) {
+  const weeks = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
+    // Is the date a Saturday?
+    if (clonedPeriodStartDate.getDay() === 6) {
+      // Yes! Clone the date again for the same reason above
+      const endDate = _cloneDate(clonedPeriodStartDate)
+      const startDate = _cloneDate(clonedPeriodStartDate)
+
+      // Set the start date back to 6 days, which makes it the previous Sunday
+      startDate.setDate(startDate.getDate() - 6)
+
+      weeks.push({ start_date: startDate, end_date: endDate })
+
+      // Now we have found our first week, we can just move the date forward by 6 days to the next Saturday, thus saving
+      // a bunch of loop iterations
+      clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 6)
+    } else {
+      // Move the date to the next day, and try again!
+      clonedPeriodStartDate.setDate(clonedPeriodStartDate.getDate() + 1)
+    }
+  }
+
+  return weeks
+}
+
+function monthsFromPeriod (periodStartDate, periodEndDate) {
+  const months = []
+
+  // We have to clone the date, else as we increment in the loop we'd be incrementing the param passed in!
+  const clonedPeriodStartDate = _cloneDate(periodStartDate)
+
+  while (clonedPeriodStartDate <= periodEndDate) { // eslint-disable-line
+    // Bump the returnLogStartDate to the next month, for example 2013-04-15 becomes 2013-05-15
+    clonedPeriodStartDate.setMonth(clonedPeriodStartDate.getMonth() + 1)
+
+    // Then clone that for our end date. "But we want the last day in April!?" we hear you scream :-)
+    const endDate = _cloneDate(clonedPeriodStartDate)
+
+    // We use some JavaScript magic to move endDate back to the last of the month. By setting the date (the 01, 02, 03
+    // etc part) to 0, it's the equivalent of setting it to the 1st, then asking JavaScript to minus 1 day. That's
+    // how we get to 2013-04-30. It also means we don't need to worry about which months have 30 vs 31 days, or whether
+    // we are in a leap year!
+    endDate.setDate(0)
+
+    // Set start date to first of the month. Passing it in as a string to new Date() helps keep it UTC rather than local
+    const startDate = new Date(`${endDate.getFullYear()}-${endDate.getMonth() + 1}-01`)
+
+    months.push({ start_date: startDate, end_date: endDate })
+  }
+
+  return months
+}
+
+function _cloneDate (dateToClone) {
+  const year = dateToClone.getFullYear()
+  const month = dateToClone.getMonth() + 1
+  const day = dateToClone.getDate()
+
+  return new Date(`${year}-${month}-${day}`)
+}
+
+module.exports = {
+  daysFromPeriod,
+  weeksFromPeriod,
+  monthsFromPeriod
+}

--- a/src/modules/import-job/lib/missing-void-returns.js
+++ b/src/modules/import-job/lib/missing-void-returns.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const MissingVoidReturnsProcess = require('../../missing-void-returns/process.js')
+
+const STEP_NAME = 'missing-void-returns'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await MissingVoidReturnsProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -11,6 +11,7 @@ const FlagDeletedDocumentsStep = require('./lib/flag-deleted-documents.js')
 const LicenceDataImportStep = require('./lib/licence-data-import.js')
 const LicencesImportStep = require('./lib/licences-import.js')
 const LinkToModLogsStep = require('./lib/link-to-mod-logs.js')
+const MissingVoidReturnsStep = require('./lib/missing-void-returns.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
 const ReferenceDataImportStep = require('./lib/reference-data-import.js')
 
@@ -54,6 +55,9 @@ async function go () {
     steps.push(step)
 
     step = await EndDateTriggerStep.go()
+    steps.push(step)
+
+    step = await MissingVoidReturnsStep.go()
     steps.push(step)
 
     await CompletionEmail.go(steps)

--- a/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
@@ -38,7 +38,6 @@ function _processLines (missingVoidReturnLines) {
 
   for (const missingVoidReturnLine of missingVoidReturnLines) {
     if (missingReturns[missingVoidReturnLine.id]) {
-
       missingReturns[missingVoidReturnLine.id].naldLines.push({
         returnDate: new Date(missingVoidReturnLine.return_date),
         qty: Number(missingVoidReturnLine.return_qty)
@@ -80,7 +79,7 @@ function _processLines (missingVoidReturnLines) {
         id: missingVoidReturnLine.return_cycle_id,
         startDate,
         endDate,
-        dueDate,
+        dueDate
       },
       returnLog: {
         id: missingVoidReturnLine.return_log_id,

--- a/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
@@ -40,8 +40,8 @@ function _processLines (missingVoidReturnLines) {
     if (missingReturns[missingVoidReturnLine.id]) {
 
       missingReturns[missingVoidReturnLine.id].naldLines.push({
-        returnDate: missingVoidReturnLine.return_date,
-        qty: missingVoidReturnLine.return_qty
+        returnDate: new Date(missingVoidReturnLine.return_date),
+        qty: Number(missingVoidReturnLine.return_qty)
       })
 
       continue

--- a/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
@@ -1,0 +1,109 @@
+'use strict'
+
+const { daysFromPeriod, weeksFromPeriod, monthsFromPeriod } = require('../../../lib/return-helpers.js')
+
+function go (missingVoidReturnLines) {
+  const missingReturns = _processLines(missingVoidReturnLines)
+
+  _assignNaldLines(missingReturns)
+
+  return Object.values(missingReturns)
+}
+
+function _assignNaldLines (missingReturns) {
+  for (const missingReturn of Object.values(missingReturns)) {
+    const { naldLines } = missingReturn
+
+    for (const naldLine of naldLines) {
+      const line = missingReturn.lines.find((line) => {
+        const onOrAfterStartDate = line.start_date <= naldLine.returnDate
+        const onOrBeforeEndDate = line.end_date >= naldLine.returnDate
+
+        return onOrAfterStartDate && onOrBeforeEndDate
+      })
+
+      if (line) {
+        if (line.qty) {
+          line.qty += naldLine.qty
+        } else {
+          line.qty = naldLine.qty
+        }
+      }
+    }
+  }
+}
+
+function _processLines (missingVoidReturnLines) {
+  const missingReturns = {}
+
+  for (const missingVoidReturnLine of missingVoidReturnLines) {
+    if (missingReturns[missingVoidReturnLine.id]) {
+
+      missingReturns[missingVoidReturnLine.id].naldLines.push({
+        returnDate: missingVoidReturnLine.return_date,
+        qty: missingVoidReturnLine.return_qty
+      })
+
+      continue
+    }
+
+    const startDate = new Date(missingVoidReturnLine.return_cycle_start_date)
+    const endDate = new Date(missingVoidReturnLine.return_cycle_end_date)
+    const dueDate = new Date(missingVoidReturnLine.return_cycle_due_date)
+
+    missingReturns[missingVoidReturnLine.id] = {
+      licenceRef: missingVoidReturnLine.licence_ref,
+      lines: _lines(missingVoidReturnLine.reporting_frequency, startDate, endDate),
+      naldLines: [{
+        returnDate: new Date(missingVoidReturnLine.return_date),
+        qty: Number(missingVoidReturnLine.return_qty)
+      }],
+      returnRequirement: {
+        abstractionPeriod: {
+          startDay: missingVoidReturnLine.abstraction_period_start_day,
+          startMonth: missingVoidReturnLine.abstraction_period_start_month,
+          endDay: missingVoidReturnLine.abstraction_period_end_day,
+          endMonth: missingVoidReturnLine.abstraction_period_end_month
+        },
+        areaCode: missingVoidReturnLine.area_code,
+        id: missingVoidReturnLine.return_requirement_id,
+        multipleUpload: missingVoidReturnLine.water_undertaker,
+        reference: missingVoidReturnLine.format_id,
+        reportingFrequency: missingVoidReturnLine.reporting_frequency,
+        returnVersionId: missingVoidReturnLine.return_version_id,
+        siteDescription: missingVoidReturnLine.site_description,
+        summer: missingVoidReturnLine.summer,
+        twoPartTariff: missingVoidReturnLine.two_part_tariff
+      },
+      regionId: missingVoidReturnLine.region_id,
+      returnCycle: {
+        id: missingVoidReturnLine.return_cycle_id,
+        startDate,
+        endDate,
+        dueDate,
+      },
+      returnLog: {
+        id: missingVoidReturnLine.return_log_id,
+        returnId: missingVoidReturnLine.return_id
+      }
+    }
+  }
+
+  return missingReturns
+}
+
+function _lines (reportingFrequency, startDate, endDate) {
+  if (reportingFrequency === 'day') {
+    return daysFromPeriod(startDate, endDate)
+  }
+
+  if (reportingFrequency === 'week') {
+    return weeksFromPeriod(startDate, endDate)
+  }
+
+  return monthsFromPeriod(startDate, endDate)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/lib/create-missing-return-lines.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-lines.js
@@ -12,16 +12,16 @@ async function go (missingReturn, timestamp) {
 }
 
 async function _createReturnLine (line, versionId, reportingFrequency, timestamp) {
-  const { end_date, qty, start_date } = line
+  const { end_date: endDate, qty, start_date: startDate } = line
   const id = generateUUID()
-  const quantity = qty ? qty : null
+  const quantity = qty ?? null
 
   const params = [
     id,
     versionId,
     quantity,
-    start_date,
-    end_date,
+    startDate,
+    endDate,
     reportingFrequency,
     {},
     timestamp,

--- a/src/modules/missing-void-returns/lib/create-missing-return-lines.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-lines.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+const { generateUUID } = require('../../../lib/general.js')
+
+async function go (missingReturn, timestamp) {
+  const { lines, returnRequirement, versionId } = missingReturn
+
+  for (const line of lines) {
+    await _createReturnLine(line, versionId, returnRequirement.reportingFrequency, timestamp)
+  }
+}
+
+async function _createReturnLine (line, versionId, reportingFrequency, timestamp) {
+  const { end_date, qty, start_date } = line
+  const id = generateUUID()
+  const quantity = qty ? qty : null
+
+  const params = [
+    id,
+    versionId,
+    quantity,
+    start_date,
+    end_date,
+    reportingFrequency,
+    {},
+    timestamp,
+    timestamp
+  ]
+  const query = `INSERT INTO "returns".lines (
+  line_id,
+  version_id,
+  quantity,
+  start_date,
+  end_date,
+  time_period,
+  metadata,
+  created_at,
+  updated_at,
+  reading_type,
+  user_unit
+)
+VALUES (
+  $1,
+  $2,
+  $3,
+  $4,
+  $5,
+  $6,
+  $7,
+  $8,
+  $9,
+  'measured',
+  'm³'
+);`
+
+  return db.query(query, params)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/lib/create-missing-return-log.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-log.js
@@ -11,14 +11,8 @@ async function go (missingReturn, timestamp) {
   return _returnLog(missingReturn, points, purposes, timestamp)
 }
 
-function _abstractionPeriodValue(value) {
+function _abstractionPeriodValue (value) {
   return value ? value.toString() : 'null'
-}
-
-function _createReturnLog(returnLogData) {
-  const params = [
-
-  ]
 }
 
 function _metadata (missingReturn, points, purposes) {

--- a/src/modules/missing-void-returns/lib/create-missing-return-log.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-log.js
@@ -1,0 +1,164 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+const FetchPointsPurposes = require('./fetch-points-purposes.js')
+const { formatDateObjectToISO } = require('../../../lib/date-helpers.js')
+const { generateUUID } = require('../../../lib/general.js')
+
+async function go (missingReturn, timestamp) {
+  const { points, purposes } = await FetchPointsPurposes.go(missingReturn.returnRequirement.id)
+
+  return _returnLog(missingReturn, points, purposes, timestamp)
+}
+
+function _abstractionPeriodValue(value) {
+  return value ? value.toString() : 'null'
+}
+
+function _createReturnLog(returnLogData) {
+  const params = [
+
+  ]
+}
+
+function _metadata (missingReturn, points, purposes) {
+  const { returnRequirement } = missingReturn
+
+  return {
+    description: returnRequirement.siteDescription,
+    isCurrent: true,
+    isFinal: false,
+    isSummer: returnRequirement.summer,
+    isTwoPartTariff: returnRequirement.twoPartTariff,
+    isUpload: returnRequirement.multipleUpload,
+    nald: {
+      regionCode: missingReturn.regionId,
+      areaCode: returnRequirement.areaCode,
+      formatId: returnRequirement.reference,
+      periodStartDay: _abstractionPeriodValue(returnRequirement.abstractionPeriod.startDay),
+      periodStartMonth: _abstractionPeriodValue(returnRequirement.abstractionPeriod.startMonth),
+      periodEndDay: _abstractionPeriodValue(returnRequirement.abstractionPeriod.endDay),
+      periodEndMonth: _abstractionPeriodValue(returnRequirement.abstractionPeriod.endMonth)
+    },
+    points: _points(points),
+    purposes: _purposes(purposes),
+    version: 1
+  }
+}
+
+function _points (points) {
+  return points.map((point) => {
+    return {
+      name: point.description,
+      ngr1: point.ngr_1,
+      ngr2: point.ngr_2,
+      ngr3: point.ngr_3,
+      ngr4: point.ngr_4
+    }
+  })
+}
+
+function _purposes (purposes) {
+  return purposes.map((purpose) => {
+    const alias = purpose.purpose_alias
+
+    return {
+      // NOTE: This is a way of only adding the `alias` property if an alias is set. If one is not set, its not just
+      // set to null, instead `alias:` isn't present on the return object
+      ...(alias !== null && { alias }),
+      primary: {
+        code: purpose.primary_legacy_id,
+        description: purpose.primary_description
+      },
+      secondary: {
+        code: purpose.secondary_legacy_id,
+        description: purpose.secondary_description
+      },
+      tertiary: {
+        code: purpose.tertiary_legacy_id,
+        description: purpose.tertiary_description
+      }
+    }
+  })
+}
+
+function _returnId (missingReturn) {
+  const regionCode = missingReturn.regionId
+  const licenceReference = missingReturn.licenceRef
+  const returnReference = missingReturn.returnRequirement.reference
+  const startDateAsString = formatDateObjectToISO(missingReturn.returnCycle.startDate)
+  const endDateAsString = formatDateObjectToISO(missingReturn.returnCycle.endDate)
+
+  return `v1:${regionCode}:${licenceReference}:${returnReference}:${startDateAsString}:${endDateAsString}`
+}
+
+async function _returnLog (missingReturn, points, purposes, timestamp) {
+  const returnId = _returnId(missingReturn)
+  const id = generateUUID()
+
+  const params = [
+    returnId,
+    missingReturn.licenceRef,
+    missingReturn.returnCycle.startDate,
+    missingReturn.returnCycle.endDate,
+    missingReturn.returnRequirement.reportingFrequency,
+    _metadata(missingReturn, points, purposes),
+    timestamp,
+    timestamp,
+    missingReturn.returnRequirement.reference,
+    missingReturn.returnCycle.dueDate,
+    missingReturn.returnCycle.id,
+    id,
+    missingReturn.returnRequirement.id
+  ]
+
+  const query = `INSERT INTO "returns"."returns" (
+  return_id,
+  regime,
+  licence_type,
+  licence_ref,
+  start_date,
+  end_date,
+  returns_frequency,
+  status,
+  "source",
+  metadata,
+  created_at,
+  updated_at,
+  return_requirement,
+  due_date,
+  return_cycle_id,
+  id,
+  return_requirement_id,
+  quarterly
+)
+VALUES (
+  $1,
+  'water',
+  'abstraction',
+  $2,
+  $3,
+  $4,
+  $5,
+  'void',
+  'NALD',
+  $6,
+  $7,
+  $8,
+  $9,
+  $10,
+  $11,
+  $12,
+  $13,
+  FALSE
+);
+  `
+
+  await db.query(query, params)
+
+  return { id, returnId }
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/lib/create-missing-return-submission.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-submission.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+const { generateUUID } = require('../../../lib/general.js')
+
+async function go (returnLog, timestamp) {
+  const id = generateUUID()
+  const { id: returnLogId, returnId } = returnLog
+
+  const params = [
+    id,
+    returnId,
+    {},
+    timestamp,
+    timestamp,
+    returnLogId
+  ]
+
+  const query = `INSERT INTO "returns".versions (
+  version_id,
+  return_id,
+  user_id,
+  user_type,
+  version_number,
+  metadata,
+  created_at,
+  updated_at,
+  nil_return,
+  "current",
+  notes,
+  return_log_id
+)
+VALUES (
+  $1,
+  $2,
+  'imported.from@nald.gov.uk',
+  'system',
+  1,
+  $3,
+  $4,
+  $5,
+  FALSE,
+  TRUE,
+  'Created to allow import of NALD return lines not originally imported because they were dated after licence ended and return log voided. See WATER-5597.',
+  $6
+);`
+
+  await db.query(query, params)
+
+  return id
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
@@ -234,6 +234,23 @@ lines_plus_return_cycles AS (
     ON
       rc.return_cycle_id = lprci.return_cycle_id
 ),
+completed_void_return_logs AS (
+  SELECT
+    r.id
+  FROM
+    "returns"."returns" r
+  INNER JOIN
+    "returns".versions v
+    ON
+      v.return_log_id = r.id
+  INNER JOIN
+    lines_plus_return_cycles lprc
+    ON
+      lprc.licence_ref = r.licence_ref
+      AND lprc.format_id = r.return_requirement
+      AND lprc.return_cycle_start_date = r.start_date
+      AND r.status = 'void'
+),
 combined_results AS (
   SELECT
     (concat_ws(':', lprc.external_id, lprc.return_cycle_id)) AS id,
@@ -272,6 +289,15 @@ combined_results AS (
       AND r.return_requirement = lprc.format_id
       AND r.start_date = lprc.return_cycle_start_date
       AND r.status = 'void'
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        completed_void_return_logs cvrl
+      WHERE
+        cvrl.id = r.id
+    )
 )
 -- By SELECTing from our combined results, it makes it easier to filter and order them. These can be
 -- changed as needed when working with the results.

--- a/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
@@ -305,7 +305,6 @@ SELECT
   *
 FROM
   combined_results cr
-WHERE cr.licence_ref IN ('6/33/40/*S/0070', '01/144')
 ORDER BY
   cr.external_id ASC,
   cr.return_date ASC;

--- a/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
@@ -1,0 +1,291 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  return db.query(`
+WITH raw_ended_licences AS (
+  SELECT
+    nal."FGAC_REGION_CODE" AS region_id,
+    nal."ID" AS licence_id,
+    nal."LIC_NO" AS licence_ref,
+    nal."AREP_AREA_CODE" AS area_code,
+    (CASE
+        WHEN nal."AREP_EIUC_CODE" LIKE '%SWC' THEN TRUE
+        ELSE FALSE
+      END) AS water_undertaker,
+    (CASE
+      WHEN nal."EXPIRY_DATE" = 'null' THEN NULL
+      ELSE to_date(nal."EXPIRY_DATE", 'DD/MM/YYYY')
+    END) AS expired_date,
+    (CASE
+      WHEN nal."LAPSED_DATE" = 'null' THEN NULL
+      ELSE to_date(nal."LAPSED_DATE", 'DD/MM/YYYY')
+    END) AS lapsed_date,
+    (CASE
+      WHEN nal."REV_DATE" = 'null' THEN NULL
+      ELSE to_date(nal."REV_DATE", 'DD/MM/YYYY')
+    END) AS revoked_date
+  FROM
+    "import"."NALD_ABS_LICENCES" nal
+  WHERE
+    (
+      nal."EXPIRY_DATE" <> 'null'
+      OR
+      nal."LAPSED_DATE" <> 'null'
+      OR
+      nal."REV_DATE" <> 'null'
+    )
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        "import"."NALD_RET_VERSIONS" nrv
+      WHERE
+        nrv."FGAC_REGION_CODE" = nal."FGAC_REGION_CODE"
+        AND nrv."AABL_ID" = nal."ID"
+    )
+),
+-- This is an interim step, where we determine the earliest end date for each licence we
+-- extracted, plus make the field names easier to use in subsequent steps
+ended_licences AS (
+  SELECT
+    rel.region_id,
+    rel.licence_id,
+    rel.licence_ref,
+    rel.area_code,
+    rel.water_undertaker,
+    least(rel.expired_date, rel.lapsed_date, rel.revoked_date) AS licence_end_date
+  FROM
+    raw_ended_licences rel
+),
+-- Extract the return versions for each licence
+return_versions AS (
+  SELECT
+    el.region_id,
+    el.licence_id,
+    el.licence_ref,
+    el.area_code,
+    el.water_undertaker,
+    el.licence_end_date,
+    nrv."VERS_NO" AS return_vers_no
+  FROM
+    "import"."NALD_RET_VERSIONS" nrv
+  INNER JOIN
+    ended_licences el
+    ON
+      nrv."FGAC_REGION_CODE" = el.region_id
+      AND nrv."AABL_ID" = el.licence_id
+),
+-- Using the return version information, extract the return requirements (formats in NALD)
+-- for each licence
+return_requirements AS (
+  SELECT
+    rv.region_id,
+    rv.licence_id,
+    rv.licence_ref,
+    rv.area_code,
+    rv.water_undertaker,
+    rv.licence_end_date,
+    nrf."ID" AS format_id,
+    (concat_ws(':', nrf."FGAC_REGION_CODE", nrf."ID")) AS external_id
+  FROM
+    "import"."NALD_RET_FORMATS" nrf
+  INNER JOIN
+    return_versions rv
+    ON
+      rv.region_id = nrf."FGAC_REGION_CODE"
+      AND rv.licence_id = nrf."ARVN_AABL_ID"
+      AND rv.return_vers_no = nrf."ARVN_VERS_NO"
+),
+-- Because the NALD return lines are split between those in the overnight extract and those in the
+-- one-off extract we have to grab return line details from both places, starting with the one-off.
+--
+-- We only grab those that
+-- - have a value
+-- - are linked to the return requirements we extract
+-- - have a return date greater than their licence's end date
+oneoff_return_lines AS (
+  SELECT
+    nrl."FGAC_REGION_CODE",
+    nrl."ARFL_ARTY_ID",
+    nrl."RET_DATE",
+    nrl."RET_QTY"
+  FROM
+    public."NALD_RET_LINES" nrl
+  WHERE
+    nrl."RET_QTY" IS NOT NULL
+    AND nrl."RET_QTY" <> ''
+    AND nrl."RET_QTY" <> 'null'
+    AND nrl."RET_QTY" <> '0'
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        return_requirements rr
+      WHERE
+        rr.region_id = nrl."FGAC_REGION_CODE"
+        AND rr.format_id = nrl."ARFL_ARTY_ID"
+        AND to_date(nrl."RET_DATE", 'DD/MM/YYYY') > rr.licence_end_date
+    )
+),
+-- Does exactly the same as old_return_lines, only for overnight extract lines
+overnight_return_lines AS (
+  SELECT
+    nrl."FGAC_REGION_CODE",
+    nrl."ARFL_ARTY_ID",
+    nrl."RET_DATE",
+    nrl."RET_QTY"
+  FROM
+    "import"."NALD_RET_LINES" nrl
+  WHERE
+    nrl."RET_QTY" IS NOT NULL
+    AND nrl."RET_QTY" <> ''
+    AND nrl."RET_QTY" <> 'null'
+    AND nrl."RET_QTY" <> '0'
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        return_requirements rr
+      WHERE
+        rr.region_id = nrl."FGAC_REGION_CODE"
+        AND rr.format_id = nrl."ARFL_ARTY_ID"
+        AND to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') > rr.licence_end_date
+    )
+),
+-- Combine the return line results into a single result set
+all_lines AS (
+  SELECT
+    oorl."FGAC_REGION_CODE" AS region_id,
+    oorl."ARFL_ARTY_ID" AS format_id,
+    to_date(oorl."RET_DATE", 'DD/MM/YYYY') AS return_date,
+    oorl."RET_QTY" AS return_qty
+  FROM
+    oneoff_return_lines oorl
+  UNION ALL
+  SELECT
+    onrl."FGAC_REGION_CODE" AS region_id,
+    onrl."ARFL_ARTY_ID" AS format_id,
+    to_date(onrl."RET_DATE", 'YYYYMMDDHH24MISS') AS return_date,
+    onrl."RET_QTY" AS return_qty
+  FROM
+    overnight_return_lines onrl
+),
+-- Combine all the return line results with the return requirements so we know which lines
+-- go with which licences
+lines_plus_requirements AS (
+  SELECT
+    al.*,
+    rr.licence_id,
+    rr.licence_ref,
+    rr.area_code,
+    rr.water_undertaker,
+    rr.licence_end_date,
+    rr.external_id,
+    wrr.return_requirement_id,
+    wrr.reporting_frequency,
+    wrr.is_summer AS summer,
+    wrr.abstraction_period_start_day,
+    wrr.abstraction_period_start_month,
+    wrr.abstraction_period_end_day,
+    wrr.abstraction_period_end_month,
+    wrr.return_version_id,
+    wrr.site_description,
+    wrr.two_part_tariff
+  FROM
+    all_lines al
+  INNER JOIN
+    return_requirements rr
+    ON
+      rr.region_id = al.region_id
+      AND rr.format_id = al.format_id
+  LEFT JOIN
+    water.return_requirements wrr
+    ON
+      wrr.external_id = rr.external_id
+),
+lines_plus_return_cycle_ids AS (
+  SELECT
+    lpr.*,
+    (
+      SELECT
+        rc.return_cycle_id
+      FROM
+        "returns".return_cycles rc
+      WHERE
+        rc.is_summer = lpr.summer
+        AND rc.start_date <= lpr.return_date
+        AND rc.end_date >= lpr.return_date
+    ) AS return_cycle_id
+  FROM
+    lines_plus_requirements lpr
+),
+lines_plus_return_cycles AS (
+  SELECT
+    lprci.*,
+    rc.start_date AS return_cycle_start_date,
+    rc.end_date AS return_cycle_end_date,
+    rc.due_date AS return_cycle_due_date
+  FROM
+    lines_plus_return_cycle_ids lprci
+  LEFT JOIN
+    "returns".return_cycles rc
+    ON
+      rc.return_cycle_id = lprci.return_cycle_id
+),
+combined_results AS (
+  SELECT
+    (concat_ws(':', lprc.external_id, lprc.return_cycle_id)) AS id,
+    lprc.region_id,
+    lprc.licence_id,
+    lprc.licence_ref,
+    lprc.area_code,
+    lprc.water_undertaker,
+    lprc.licence_end_date,
+    lprc.external_id,
+    lprc.return_requirement_id,
+    lprc.format_id,
+    lprc.reporting_frequency,
+    lprc.summer,
+    lprc.abstraction_period_start_day,
+    lprc.abstraction_period_start_month,
+    lprc.abstraction_period_end_day,
+    lprc.abstraction_period_end_month,
+    lprc.return_version_id,
+    lprc.site_description,
+    lprc.two_part_tariff,
+    lprc.return_date,
+    lprc.return_qty,
+    lprc.return_cycle_id,
+    lprc.return_cycle_start_date,
+    lprc.return_cycle_end_date,
+    lprc.return_cycle_due_date,
+    r.return_id,
+    r.id AS return_log_id
+  FROM
+    lines_plus_return_cycles lprc
+  LEFT JOIN
+    "returns"."returns" r
+    ON
+      r.licence_ref = lprc.licence_ref
+      AND r.return_requirement = lprc.format_id
+      AND r.start_date = lprc.return_cycle_start_date
+      AND r.status = 'void'
+)
+-- By SELECTing from our combined results, it makes it easier to filter and order them. These can be
+-- changed as needed when working with the results.
+SELECT
+  *
+FROM
+  combined_results cr
+WHERE cr.licence_ref IN ('6/33/40/*S/0070', '01/144')
+ORDER BY
+  cr.external_id ASC,
+  cr.return_date ASC;
+    `)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/lib/fetch-points-purposes.js
+++ b/src/modules/missing-void-returns/lib/fetch-points-purposes.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go (returnRequirementId) {
+  const [points, purposes] = await Promise.all([
+    _points(returnRequirementId),
+    _purposes(returnRequirementId)
+  ])
+
+  return {
+    points,
+    purposes
+  }
+}
+
+async function _points (returnRequirementId) {
+  const params = [returnRequirementId]
+  const query = `SELECT
+  rrp.description,
+  rrp.ngr_1,
+  rrp.ngr_2,
+  rrp.ngr_3,
+  rrp.ngr_4
+FROM
+  water.return_requirement_points rrp
+WHERE
+  rrp.return_requirement_id = $1;
+  `
+
+  return db.query(query, params)
+}
+
+async function _purposes (returnRequirementId) {
+  const params = [returnRequirementId]
+  const query = `SELECT
+  rrp.purpose_alias,
+  pu.description AS tertiary_description,
+  pu.legacy_id AS tertiary_legacy_id,
+  pp.description AS primary_description,
+  pp.legacy_id AS primary_legacy_id,
+  ps.description AS secondary_description,
+  ps.legacy_id AS secondary_legacy_id
+FROM
+  water.return_requirement_purposes rrp
+INNER JOIN
+  water.purposes_uses pu
+  ON pu.purpose_use_id = rrp.purpose_use_id
+INNER JOIN
+  water.purposes_primary pp
+  ON pp.purpose_primary_id = rrp.purpose_primary_id
+INNER JOIN
+  water.purposes_secondary ps
+  ON ps.purpose_secondary_id = rrp.purpose_secondary_id
+WHERE
+  rrp.return_requirement_id = $1;
+  `
+
+  return db.query(query, params)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-void-returns/process.js
+++ b/src/modules/missing-void-returns/process.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CollateMissingVoidReturnLines = require('./lib/collate-missing-void-return-lines.js')
+const CreateMissingReturnLines = require('./lib/create-missing-return-lines.js')
 const CreateMissingReturnLog = require('./lib/create-missing-return-log.js')
 const CreateMissingReturnSubmission = require('./lib/create-missing-return-submission.js')
 const FetchMissingVoidReturnLines = require('./lib/fetch-missing-void-return-lines.js')
@@ -19,6 +20,7 @@ async function go (log = false) {
     const timestamp = timestampForPostgres()
 
     await _createMissingReturnLogs(collatedReturns, timestamp)
+
     await _processReturns(collatedReturns, timestamp)
 
     if (log) {
@@ -49,6 +51,8 @@ async function _createMissingReturnLogs (collatedReturns, timestamp) {
 async function _processReturns (collatedReturns, timestamp) {
   for (const collatedReturn of collatedReturns) {
     collatedReturn.versionId = await CreateMissingReturnSubmission.go(collatedReturn.returnLog, timestamp)
+
+    await CreateMissingReturnLines.go(collatedReturn, timestamp)
   }
 }
 

--- a/src/modules/missing-void-returns/process.js
+++ b/src/modules/missing-void-returns/process.js
@@ -1,12 +1,21 @@
 'use strict'
 
-const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+const CollateMissingVoidReturnLines = require('./lib/collate-missing-void-return-lines.js')
+const CreateMissingReturnLog = require('./lib/create-missing-return-log.js')
+const FetchMissingVoidReturnLines = require('./lib/fetch-missing-void-return-lines.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
 
 async function go (log = false) {
   const messages = []
 
   try {
     const startTime = currentTimeInNanoseconds()
+
+    const missingVoidReturnLines = await FetchMissingVoidReturnLines.go()
+
+    const collatedReturns = CollateMissingVoidReturnLines.go(missingVoidReturnLines)
+
+    await _processMissingReturnLogs(collatedReturns)
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'missing-void-returns: complete', { messages })
@@ -18,6 +27,21 @@ async function go (log = false) {
   }
 
   return messages
+}
+
+async function _processMissingReturnLogs (collatedReturns) {
+  const missingReturns = collatedReturns.filter((collatedReturn) => {
+    return !collatedReturn.returnLog.id
+  })
+
+  const timestamp = timestampForPostgres()
+
+  for (const missingReturn of missingReturns) {
+    const { id, returnId } = await CreateMissingReturnLog.go(missingReturn, timestamp)
+
+    missingReturn.returnLog.id = id
+    missingReturn.returnLog.returnId = returnId
+  }
 }
 
 module.exports = {

--- a/src/modules/missing-void-returns/process.js
+++ b/src/modules/missing-void-returns/process.js
@@ -2,6 +2,7 @@
 
 const CollateMissingVoidReturnLines = require('./lib/collate-missing-void-return-lines.js')
 const CreateMissingReturnLog = require('./lib/create-missing-return-log.js')
+const CreateMissingReturnSubmission = require('./lib/create-missing-return-submission.js')
 const FetchMissingVoidReturnLines = require('./lib/fetch-missing-void-return-lines.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
 
@@ -15,7 +16,10 @@ async function go (log = false) {
 
     const collatedReturns = CollateMissingVoidReturnLines.go(missingVoidReturnLines)
 
-    await _processMissingReturnLogs(collatedReturns)
+    const timestamp = timestampForPostgres()
+
+    await _createMissingReturnLogs(collatedReturns, timestamp)
+    await _processReturns(collatedReturns, timestamp)
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'missing-void-returns: complete', { messages })
@@ -29,18 +33,22 @@ async function go (log = false) {
   return messages
 }
 
-async function _processMissingReturnLogs (collatedReturns) {
+async function _createMissingReturnLogs (collatedReturns, timestamp) {
   const missingReturns = collatedReturns.filter((collatedReturn) => {
     return !collatedReturn.returnLog.id
   })
-
-  const timestamp = timestampForPostgres()
 
   for (const missingReturn of missingReturns) {
     const { id, returnId } = await CreateMissingReturnLog.go(missingReturn, timestamp)
 
     missingReturn.returnLog.id = id
     missingReturn.returnLog.returnId = returnId
+  }
+}
+
+async function _processReturns (collatedReturns, timestamp) {
+  for (const collatedReturn of collatedReturns) {
+    collatedReturn.versionId = await CreateMissingReturnSubmission.go(collatedReturn.returnLog, timestamp)
   }
 }
 

--- a/src/modules/missing-void-returns/process.js
+++ b/src/modules/missing-void-returns/process.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'missing-void-returns: complete', { messages })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('missing-void-returns: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -175,6 +175,14 @@ module.exports = [
     }
   },
   {
+    method: 'POST',
+    path: '/process/missing-void-returns',
+    handler: Controller.missingVoidReturns,
+    config: {
+      auth: false
+    }
+  },
+  {
     method: 'post',
     handler: Controller.partyCrmV2Import,
     path: '/process/party-crm-v2-import',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5597

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences where NALD had a higher value. After looking into them, we found that NALD has return lines with return quantities for dates after a licence has 'ended' (expired, lapsed, or revoked).

When the nightly import was responsible for creating return logs, it would not have generated any after a licence's end date, and any existing ones would have been marked as `VOID` and deleted.

This means that when the return submission data was imported to WRLS, there were no return logs to match them against.

This change will add a 'one-off' step to the import process that will

- identify the licences affected by this
- create `VOID` return logs for the periods where there is submission data
- import the missing NALD submission data to WRLS