### PR TITLE
Add new step to import missing return logs

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -25,6 +25,7 @@ const LicenceNoStartDateImportProcess = require('./modules/licence-no-start-date
 const LicencePermitImportProcess = require('./modules/licence-permit-import/process.js')
 const LicencesImportProcess = require('./modules/licences-import/process.js')
 const LinkToModLogsProcess = require('./modules/link-to-mod-logs/process.js')
+const MissingReturnLogsProcess = require('./modules/missing-return-logs/process.js')
 const MissingVoidReturnsProcess = require('./modules/missing-void-returns/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
@@ -174,6 +175,12 @@ async function linkToModLogs (_request, h) {
   return h.response().code(204)
 }
 
+async function missingReturnLogs (_request, h) {
+  MissingReturnLogsProcess.go(true)
+
+  return h.response().code(204)
+}
+
 async function missingVoidReturns (_request, h) {
   MissingVoidReturnsProcess.go(true)
 
@@ -243,6 +250,7 @@ module.exports = {
   licencePermitImport,
   licencesImport,
   linkToModLogs,
+  missingReturnLogs,
   missingVoidReturns,
   partyCrmV2Import,
   referenceDataImport,

--- a/src/modules/import-job/lib/missing-return-logs.js
+++ b/src/modules/import-job/lib/missing-return-logs.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const MissingReturnLogsProcess = require('../../missing-return-logs/process.js')
+
+const STEP_NAME = 'missing-return-logs'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await MissingReturnLogsProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -12,6 +12,7 @@ const FlagDeletedDocumentsStep = require('./lib/flag-deleted-documents.js')
 const LicenceDataImportStep = require('./lib/licence-data-import.js')
 const LicencesImportStep = require('./lib/licences-import.js')
 const LinkToModLogsStep = require('./lib/link-to-mod-logs.js')
+const MissingReturnLogsStep = require('./lib/missing-return-logs.js')
 const MissingVoidReturnsStep = require('./lib/missing-void-returns.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
 const ReferenceDataImportStep = require('./lib/reference-data-import.js')
@@ -62,6 +63,9 @@ async function go () {
     steps.push(step)
 
     step = await ExtendReturnVersionsStep.go()
+    steps.push(step)
+
+    step = await MissingReturnLogsStep.go()
     steps.push(step)
 
     await CompletionEmail.go(steps)

--- a/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
@@ -1,0 +1,63 @@
+'use strict'
+
+function go (missingReturnLogs) {
+  const missingReturns = _processReturnLogs(missingReturnLogs)
+
+  return Object.values(missingReturns)
+}
+
+function _processReturnLogs (missingReturnLogs) {
+  const missingReturns = {}
+
+  for (const missingReturnLog of missingReturnLogs) {
+    const { return_cycle_id: returnCycleId, return_requirement_id: returnRequirementId } = missingReturnLog
+
+    const returnCycle = {
+      dueDate: new Date(missingReturnLog.return_cycle_due_date),
+      endDate: new Date(missingReturnLog.return_cycle_end_date),
+      id: returnCycleId,
+      startDate: new Date(missingReturnLog.return_cycle_start_date)
+    }
+
+    if (missingReturns[returnRequirementId]) {
+      missingReturns[returnRequirementId].returnCycles.push(returnCycle)
+
+      continue
+    }
+
+    missingReturns[returnRequirementId] = {
+      licence: {
+        endDate: missingReturnLog.licence_end_date ? new Date(missingReturnLog.licence_end_date) : null,
+        id: missingReturnLog.licence_id,
+        licenceRef: missingReturnLog.licence_ref,
+      },
+      returnVersion: {
+        endDate: missingReturnLog.return_version_end_date ? new Date(missingReturnLog.return_version_end_date) : null,
+        id: missingReturnLog.return_version_id,
+        startDate: new Date(missingReturnLog.return_version_start_date)
+      },
+      abstractionPeriod: {
+        startDay: missingReturnLog.abstraction_period_start_day,
+        startMonth: missingReturnLog.abstraction_period_start_month,
+        endDay: missingReturnLog.abstraction_period_end_day,
+        endMonth: missingReturnLog.abstraction_period_end_month
+      },
+      areaCode: missingReturnLog.area_code,
+      multipleUpload: missingReturnLog.water_undertaker,
+      reference: missingReturnLog.legacy_id,
+      reportingFrequency: missingReturnLog.reporting_frequency,
+      returnRequirementId: returnRequirementId,
+      siteDescription: missingReturnLog.site_description,
+      summer: missingReturnLog.summer,
+      twoPartTariff: missingReturnLog.two_part_tariff,
+      regionId: missingReturnLog.region_id,
+      returnCycles: [returnCycle]
+    }
+  }
+
+  return missingReturns
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
@@ -10,17 +10,18 @@ function _processReturnLogs (missingReturnLogs) {
   const missingReturns = {}
 
   for (const missingReturnLog of missingReturnLogs) {
-    const { return_cycle_id: returnCycleId, return_requirement_id: returnRequirementId } = missingReturnLog
+    const { return_requirement_id: returnRequirementId } = missingReturnLog
 
-    const returnCycle = {
-      dueDate: new Date(missingReturnLog.return_cycle_due_date),
-      endDate: new Date(missingReturnLog.return_cycle_end_date),
-      id: returnCycleId,
-      startDate: new Date(missingReturnLog.return_cycle_start_date)
+    const returnLog = {
+      dueDate: new Date(missingReturnLog.return_period_due_date),
+      endDate: new Date(missingReturnLog.return_period_end_date),
+      returnCycleId: missingReturnLog.return_cycle_id,
+      returnId: missingReturnLog.return_id,
+      startDate: new Date(missingReturnLog.return_period_start_date)
     }
 
     if (missingReturns[returnRequirementId]) {
-      missingReturns[returnRequirementId].returnCycles.push(returnCycle)
+      missingReturns[returnRequirementId].returnLogs.push(returnLog)
 
       continue
     }
@@ -51,7 +52,7 @@ function _processReturnLogs (missingReturnLogs) {
       summer: missingReturnLog.summer,
       twoPartTariff: missingReturnLog.two_part_tariff,
       regionId: missingReturnLog.region_id,
-      returnCycles: [returnCycle]
+      returnLogs: [returnLog]
     }
   }
 

--- a/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/collate-missing-return-logs.js
@@ -30,7 +30,7 @@ function _processReturnLogs (missingReturnLogs) {
       licence: {
         endDate: missingReturnLog.licence_end_date ? new Date(missingReturnLog.licence_end_date) : null,
         id: missingReturnLog.licence_id,
-        licenceRef: missingReturnLog.licence_ref,
+        licenceRef: missingReturnLog.licence_ref
       },
       returnVersion: {
         endDate: missingReturnLog.return_version_end_date ? new Date(missingReturnLog.return_version_end_date) : null,
@@ -47,7 +47,7 @@ function _processReturnLogs (missingReturnLogs) {
       multipleUpload: missingReturnLog.water_undertaker,
       reference: missingReturnLog.legacy_id,
       reportingFrequency: missingReturnLog.reporting_frequency,
-      returnRequirementId: returnRequirementId,
+      returnRequirementId,
       siteDescription: missingReturnLog.site_description,
       summer: missingReturnLog.summer,
       twoPartTariff: missingReturnLog.two_part_tariff,

--- a/src/modules/missing-return-logs/lib/create-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/create-missing-return-logs.js
@@ -8,8 +8,8 @@ const { generateUUID } = require('../../../lib/general.js')
 async function go (missingReturn, timestamp) {
   const { points, purposes } = await FetchPointsPurposes.go(missingReturn.returnRequirementId)
 
-  for (const returnCycle of missingReturn.returnCycles) {
-    await _returnLog(missingReturn, returnCycle, points, purposes, timestamp)
+  for (const returnLog of missingReturn.returnLogs) {
+    await _createReturnLog(missingReturn, returnLog, points, purposes, timestamp)
   }
 }
 
@@ -76,33 +76,21 @@ function _purposes (purposes) {
   })
 }
 
-function _returnId (missingReturn, returnPeriod) {
-  const regionCode = missingReturn.regionId
-  const licenceReference = missingReturn.licenceRef
-  const returnReference = missingReturn.reference
-  const startDateAsString = formatDateObjectToISO(returnPeriod.startDate)
-  const endDateAsString = formatDateObjectToISO(returnPeriod.endDate)
-
-  return `v1:${regionCode}:${licenceReference}:${returnReference}:${startDateAsString}:${endDateAsString}`
-}
-
-async function _returnLog (missingReturn, returnCycle, points, purposes, timestamp) {
-  const returnPeriod = _returnPeriod(missingReturn, returnCycle)
-  const returnId = _returnId(missingReturn, returnPeriod)
+async function _createReturnLog (missingReturn, returnLog, points, purposes, timestamp) {
   const id = generateUUID()
 
   const params = [
-    returnId,
+    returnLog.returnId,
     missingReturn.licence.licenceRef,
-    returnPeriod.startDate,
-    returnPeriod.endDate,
+    returnLog.startDate,
+    returnLog.endDate,
     missingReturn.reportingFrequency,
     _metadata(missingReturn, points, purposes),
     timestamp,
     timestamp,
     missingReturn.reference,
-    returnPeriod.dueDate,
-    returnCycle.id,
+    returnLog.dueDate,
+    returnLog.returnCycleId,
     id,
     missingReturn.returnRequirementId
   ]
@@ -150,34 +138,6 @@ VALUES (
   `
 
   return db.query(query, params)
-}
-
-function _returnPeriod (missingReturn, returnCycle) {
-  // We use .filter() to remove any null timestamps, as Math.min() assumes a value of `0` for these
-  const startDates = [
-    missingReturn.returnVersion.startDate,
-    returnCycle.startDate
-  ].filter(Boolean)
-
-  const latestStartDate = Math.max(...startDates)
-
-  const endDates = [
-    missingReturn.licence.endDate,
-    missingReturn.returnVersion.endDate,
-    returnCycle.endDate
-  ].filter(Boolean)
-
-  const earliestEndDate = Math.min(...endDates)
-
-  const dueDate = new Date(earliestEndDate)
-
-  dueDate.setDate(dueDate.getDate() + 28)
-
-  return {
-    startDate: new Date(latestStartDate),
-    endDate: new Date(earliestEndDate),
-    dueDate
-  }
 }
 
 module.exports = {

--- a/src/modules/missing-return-logs/lib/create-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/create-missing-return-logs.js
@@ -76,6 +76,18 @@ function _purposes (purposes) {
   })
 }
 
+function _returnsFrequency (reportingFrequency) {
+  if (reportingFrequency === 'year' || reportingFrequency === 'quarter') {
+    return 'month'
+  }
+
+  if (reportingFrequency === 'fortnight') {
+    return 'week'
+  }
+
+  return reportingFrequency
+}
+
 async function _createReturnLog (missingReturn, returnLog, points, purposes, timestamp) {
   const id = generateUUID()
 
@@ -84,7 +96,7 @@ async function _createReturnLog (missingReturn, returnLog, points, purposes, tim
     missingReturn.licence.licenceRef,
     returnLog.startDate,
     returnLog.endDate,
-    missingReturn.reportingFrequency,
+    _returnsFrequency(missingReturn.reportingFrequency),
     _metadata(missingReturn, points, purposes),
     timestamp,
     timestamp,

--- a/src/modules/missing-return-logs/lib/create-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/create-missing-return-logs.js
@@ -2,7 +2,6 @@
 
 const db = require('../../../lib/connectors/db.js')
 const FetchPointsPurposes = require('../../missing-void-returns/lib/fetch-points-purposes.js')
-const { formatDateObjectToISO } = require('../../../lib/date-helpers.js')
 const { generateUUID } = require('../../../lib/general.js')
 
 async function go (missingReturn, timestamp) {

--- a/src/modules/missing-return-logs/lib/create-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/create-missing-return-logs.js
@@ -1,0 +1,185 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+const FetchPointsPurposes = require('../../missing-void-returns/lib/fetch-points-purposes.js')
+const { formatDateObjectToISO } = require('../../../lib/date-helpers.js')
+const { generateUUID } = require('../../../lib/general.js')
+
+async function go (missingReturn, timestamp) {
+  const { points, purposes } = await FetchPointsPurposes.go(missingReturn.returnRequirementId)
+
+  for (const returnCycle of missingReturn.returnCycles) {
+    await _returnLog(missingReturn, returnCycle, points, purposes, timestamp)
+  }
+}
+
+function _abstractionPeriodValue (value) {
+  return value ? value.toString() : 'null'
+}
+
+function _metadata (missingReturn, points, purposes) {
+  return {
+    description: missingReturn.siteDescription,
+    isCurrent: true,
+    isFinal: false,
+    isSummer: missingReturn.summer,
+    isTwoPartTariff: missingReturn.twoPartTariff,
+    isUpload: missingReturn.multipleUpload,
+    nald: {
+      regionCode: missingReturn.regionId,
+      areaCode: missingReturn.areaCode,
+      formatId: missingReturn.reference,
+      periodStartDay: _abstractionPeriodValue(missingReturn.abstractionPeriod.startDay),
+      periodStartMonth: _abstractionPeriodValue(missingReturn.abstractionPeriod.startMonth),
+      periodEndDay: _abstractionPeriodValue(missingReturn.abstractionPeriod.endDay),
+      periodEndMonth: _abstractionPeriodValue(missingReturn.abstractionPeriod.endMonth)
+    },
+    points: _points(points),
+    purposes: _purposes(purposes),
+    version: 1
+  }
+}
+
+function _points (points) {
+  return points.map((point) => {
+    return {
+      name: point.description,
+      ngr1: point.ngr_1,
+      ngr2: point.ngr_2,
+      ngr3: point.ngr_3,
+      ngr4: point.ngr_4
+    }
+  })
+}
+
+function _purposes (purposes) {
+  return purposes.map((purpose) => {
+    const alias = purpose.purpose_alias
+
+    return {
+      // NOTE: This is a way of only adding the `alias` property if an alias is set. If one is not set, its not just
+      // set to null, instead `alias:` isn't present on the return object
+      ...(alias !== null && { alias }),
+      primary: {
+        code: purpose.primary_legacy_id,
+        description: purpose.primary_description
+      },
+      secondary: {
+        code: purpose.secondary_legacy_id,
+        description: purpose.secondary_description
+      },
+      tertiary: {
+        code: purpose.tertiary_legacy_id,
+        description: purpose.tertiary_description
+      }
+    }
+  })
+}
+
+function _returnId (missingReturn, returnPeriod) {
+  const regionCode = missingReturn.regionId
+  const licenceReference = missingReturn.licenceRef
+  const returnReference = missingReturn.reference
+  const startDateAsString = formatDateObjectToISO(returnPeriod.startDate)
+  const endDateAsString = formatDateObjectToISO(returnPeriod.endDate)
+
+  return `v1:${regionCode}:${licenceReference}:${returnReference}:${startDateAsString}:${endDateAsString}`
+}
+
+async function _returnLog (missingReturn, returnCycle, points, purposes, timestamp) {
+  const returnPeriod = _returnPeriod(missingReturn, returnCycle)
+  const returnId = _returnId(missingReturn, returnPeriod)
+  const id = generateUUID()
+
+  const params = [
+    returnId,
+    missingReturn.licence.licenceRef,
+    returnPeriod.startDate,
+    returnPeriod.endDate,
+    missingReturn.reportingFrequency,
+    _metadata(missingReturn, points, purposes),
+    timestamp,
+    timestamp,
+    missingReturn.reference,
+    returnPeriod.dueDate,
+    returnCycle.id,
+    id,
+    missingReturn.returnRequirementId
+  ]
+
+  const query = `INSERT INTO "returns"."returns" (
+  return_id,
+  regime,
+  licence_type,
+  licence_ref,
+  start_date,
+  end_date,
+  returns_frequency,
+  status,
+  "source",
+  metadata,
+  created_at,
+  updated_at,
+  return_requirement,
+  due_date,
+  return_cycle_id,
+  id,
+  return_requirement_id,
+  quarterly
+)
+VALUES (
+  $1,
+  'water',
+  'abstraction',
+  $2,
+  $3,
+  $4,
+  $5,
+  'due',
+  'NALD',
+  $6,
+  $7,
+  $8,
+  $9,
+  $10,
+  $11,
+  $12,
+  $13,
+  FALSE
+);
+  `
+
+  return db.query(query, params)
+}
+
+function _returnPeriod (missingReturn, returnCycle) {
+  // We use .filter() to remove any null timestamps, as Math.min() assumes a value of `0` for these
+  const startDates = [
+    missingReturn.returnVersion.startDate,
+    returnCycle.startDate
+  ].filter(Boolean)
+
+  const latestStartDate = Math.max(...startDates)
+
+  const endDates = [
+    missingReturn.licence.endDate,
+    missingReturn.returnVersion.endDate,
+    returnCycle.endDate
+  ].filter(Boolean)
+
+  const earliestEndDate = Math.min(...endDates)
+
+  const dueDate = new Date(earliestEndDate)
+
+  dueDate.setDate(dueDate.getDate() + 28)
+
+  return {
+    startDate: new Date(latestStartDate),
+    endDate: new Date(earliestEndDate),
+    dueDate
+  }
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -1,0 +1,182 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  return db.query(`WITH return_version_periods AS (
+  SELECT
+    rv.licence_id,
+    MAX(COALESCE(rv.end_date, CURRENT_DATE)) AS latest_end_date
+  FROM
+    water.return_versions rv
+  WHERE
+    rv.status = 'current'
+    AND (
+      rv.reason IS NULL
+      OR rv.reason NOT IN (
+        'abstraction-below-100-cubic-metres-per-day',
+        'licence-conditions-do-not-require-returns',
+        'returns-exception',
+        'temporary-trade'
+      )
+    )
+  GROUP BY
+    rv.licence_id
+),
+licences_with_return_versions AS (
+  SELECT
+    l.licence_id,
+    l.licence_ref,
+    l.is_water_undertaker AS water_undertaker,
+    l.regions->>'historicalAreaCode' AS area_code,
+    r.nald_region_id AS region_id,
+    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date,
+    LEAST(l.expired_date, l.lapsed_date, l.revoked_date, rvp.latest_end_date) AS calculated_end_date
+  FROM
+    water.licences l
+  INNER JOIN
+    water.regions r
+    ON
+      r.region_id = l.region_id
+  INNER JOIN
+    return_version_periods rvp
+    ON
+      rvp.licence_id= l.licence_id
+  WHERE
+    EXISTS (
+      SELECT
+        1
+      FROM
+        water.return_versions rv
+      WHERE
+        rv.licence_id = l.licence_id
+        AND rv.status = 'current'
+        AND (
+          rv.reason IS NULL
+          OR rv.reason NOT IN (
+            'abstraction-below-100-cubic-metres-per-day',
+            'licence-conditions-do-not-require-returns',
+            'returns-exception',
+            'temporary-trade'
+          )
+        )
+    )
+),
+return_version_history AS (
+  SELECT
+    lwrv.*,
+    rv.return_version_id,
+    rv.start_date AS return_version_start_date,
+    rv.end_date AS return_version_end_date,
+    (CASE
+      WHEN rv.end_date IS NULL THEN lwrv.calculated_end_date
+      ELSE rv.end_date
+    END) AS calculated_return_version_end_date
+  FROM
+    water.return_versions rv
+  INNER JOIN
+    licences_with_return_versions lwrv
+    ON
+      lwrv.licence_id = rv.licence_id
+  WHERE
+    rv.status = 'current'
+    AND (
+      rv.reason IS NULL
+      OR rv.reason NOT IN (
+        'abstraction-below-100-cubic-metres-per-day',
+        'licence-conditions-do-not-require-returns',
+        'returns-exception',
+        'temporary-trade'
+      )
+    )
+),
+return_requirement_history AS (
+  SELECT
+    rvh.*,
+    rr.return_requirement_id,
+    rr.legacy_id,
+    rr.reporting_frequency,
+    rr.is_summer AS summer,
+    rr.abstraction_period_start_day,
+    rr.abstraction_period_start_month,
+    rr.abstraction_period_end_day,
+    rr.abstraction_period_end_month,
+    rr.site_description,
+    rr.two_part_tariff
+  FROM
+    water.return_requirements rr
+  INNER JOIN
+    return_version_history rvh
+    ON
+      rvh.return_version_id = rr.return_version_id
+),
+returns_history AS (
+  SELECT
+    rrh.*,
+    rc.return_cycle_id,
+    rc.start_date AS return_cycle_start_date,
+    rc.end_date AS return_cycle_end_date,
+    rc.due_date AS return_cycle_due_date
+  FROM
+    return_requirement_history rrh
+  INNER JOIN
+    "returns".return_cycles rc
+    ON
+      rc.is_summer = rrh.summer
+      AND rc.start_date <= rrh.calculated_return_version_end_date
+      AND rc.end_date >= rrh.return_version_start_date
+),
+returns_history_misses AS (
+  SELECT
+    rh.*
+  FROM
+    returns_history rh
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        "returns"."returns" r
+      WHERE
+        r.return_cycle_id = rh.return_cycle_id
+        AND r.return_requirement_id = rh.return_requirement_id
+    )
+)
+SELECT
+  rhm.licence_id,
+  rhm.licence_ref,
+  rhm.water_undertaker,
+  rhm.area_code,
+  rhm.region_id,
+  rhm.licence_end_date,
+  rhm.calculated_end_date,
+  rhm.return_version_id,
+  rhm.return_version_start_date,
+  rhm.return_version_end_date,
+  rhm.return_requirement_id,
+  rhm.legacy_id,
+  rhm.reporting_frequency,
+  rhm.summer,
+  rhm.abstraction_period_start_day,
+  rhm.abstraction_period_start_month,
+  rhm.abstraction_period_end_day,
+  rhm.abstraction_period_end_month,
+  rhm.site_description,
+  rhm.two_part_tariff,
+  rhm.return_cycle_id,
+  rhm.return_cycle_start_date,
+  rhm.return_cycle_end_date,
+  rhm.return_cycle_due_date
+FROM
+  returns_history_misses rhm
+ORDER BY
+  rhm.licence_id,
+  rhm.return_version_id,
+  rhm.return_requirement_id,
+  rhm.return_cycle_start_date DESC;
+  `)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -116,7 +116,9 @@ returns_history AS (
     rc.return_cycle_id,
     rc.start_date AS return_cycle_start_date,
     rc.end_date AS return_cycle_end_date,
-    rc.due_date AS return_cycle_due_date
+    rc.due_date AS return_cycle_due_date,
+    GREATEST(rrh.return_version_start_date, rc.start_date) AS return_period_start_date,
+    LEAST(rrh.licence_end_date, rrh.return_version_end_date, rc.end_date) AS return_period_end_date
   FROM
     return_requirement_history rrh
   INNER JOIN
@@ -126,11 +128,32 @@ returns_history AS (
       AND rc.start_date <= rrh.calculated_return_version_end_date
       AND rc.end_date >= rrh.return_version_start_date
 ),
-returns_history_misses AS (
+returns_candidates AS (
   SELECT
-    rh.*
+    rh.*,
+    (CASE
+      WHEN rh.return_cycle_due_date IS NULL THEN
+        NULL
+      ELSE
+        rh.return_period_end_date + INTERVAL '28 day'
+    END) AS return_period_due_date,
+    concat_ws(
+      ':',
+      'v1',
+      rh.region_id,
+      rh.licence_ref,
+      rh.legacy_id,
+      to_char(rh.return_period_start_date, 'YYYY-MM-DD'),
+      to_char(rh.return_period_end_date, 'YYYY-MM-DD')
+    ) AS return_id
   FROM
     returns_history rh
+),
+returns_candidate_misses AS (
+  SELECT
+    rc.*
+  FROM
+    returns_candidates rc
   WHERE
     NOT EXISTS (
       SELECT
@@ -138,42 +161,45 @@ returns_history_misses AS (
       FROM
         "returns"."returns" r
       WHERE
-        r.return_cycle_id = rh.return_cycle_id
-        AND r.return_requirement_id = rh.return_requirement_id
+        r.return_id = rc.return_id
     )
 )
 SELECT
-  rhm.licence_id,
-  rhm.licence_ref,
-  rhm.water_undertaker,
-  rhm.area_code,
-  rhm.region_id,
-  rhm.licence_end_date,
-  rhm.calculated_end_date,
-  rhm.return_version_id,
-  rhm.return_version_start_date,
-  rhm.return_version_end_date,
-  rhm.return_requirement_id,
-  rhm.legacy_id,
-  rhm.reporting_frequency,
-  rhm.summer,
-  rhm.abstraction_period_start_day,
-  rhm.abstraction_period_start_month,
-  rhm.abstraction_period_end_day,
-  rhm.abstraction_period_end_month,
-  rhm.site_description,
-  rhm.two_part_tariff,
-  rhm.return_cycle_id,
-  rhm.return_cycle_start_date,
-  rhm.return_cycle_end_date,
-  rhm.return_cycle_due_date
+  rcm.licence_id,
+  rcm.licence_ref,
+  rcm.water_undertaker,
+  rcm.area_code,
+  rcm.region_id,
+  rcm.licence_end_date,
+  rcm.calculated_end_date,
+  rcm.return_version_id,
+  rcm.return_version_start_date,
+  rcm.return_version_end_date,
+  rcm.return_requirement_id,
+  rcm.legacy_id,
+  rcm.reporting_frequency,
+  rcm.summer,
+  rcm.abstraction_period_start_day,
+  rcm.abstraction_period_start_month,
+  rcm.abstraction_period_end_day,
+  rcm.abstraction_period_end_month,
+  rcm.site_description,
+  rcm.two_part_tariff,
+  rcm.return_cycle_id,
+  rcm.return_cycle_start_date,
+  rcm.return_cycle_end_date,
+  rcm.return_cycle_due_date,
+  rcm.return_period_start_date,
+  rcm.return_period_end_date,
+  rcm.return_period_due_date,
+  rcm.return_id
 FROM
-  returns_history_misses rhm
+  returns_candidate_misses rcm
 ORDER BY
-  rhm.licence_id,
-  rhm.return_version_id,
-  rhm.return_requirement_id,
-  rhm.return_cycle_start_date DESC;
+  rcm.licence_id,
+  rcm.return_version_id,
+  rcm.return_requirement_id,
+  rcm.return_cycle_start_date DESC;
   `)
 }
 

--- a/src/modules/missing-return-logs/process.js
+++ b/src/modules/missing-return-logs/process.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'missing-return-logs: complete', { messages })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('missing-return-logs: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-return-logs/process.js
+++ b/src/modules/missing-return-logs/process.js
@@ -1,12 +1,23 @@
 'use strict'
 
-const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+const CollateMissingReturnLogs = require('./lib/collate-missing-return-logs.js')
+const CreateMissingReturnLogs = require('./lib/create-missing-return-logs.js')
+const FetchMissingReturnLogs = require('./lib/fetch-missing-return-logs.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
 
 async function go (log = false) {
   const messages = []
 
   try {
     const startTime = currentTimeInNanoseconds()
+
+    const missingReturnLogs = await FetchMissingReturnLogs.go()
+
+    const collatedMissingReturnLogs = CollateMissingReturnLogs.go(missingReturnLogs)
+
+    const timestamp = timestampForPostgres()
+
+    await _createMissingReturnLogs(collatedMissingReturnLogs, timestamp)
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'missing-return-logs: complete', { messages })
@@ -18,6 +29,12 @@ async function go (log = false) {
   }
 
   return messages
+}
+
+async function _createMissingReturnLogs (collatedMissingReturnLogs, timestamp) {
+  for (const collatedMissingReturnLog of collatedMissingReturnLogs) {
+    await CreateMissingReturnLogs.go(collatedMissingReturnLog, timestamp)
+  }
 }
 
 module.exports = {

--- a/src/modules/missing-void-returns/lib/create-missing-return-log.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-log.js
@@ -76,6 +76,18 @@ function _purposes (purposes) {
   })
 }
 
+function _returnsFrequency (reportingFrequency) {
+  if (reportingFrequency === 'year' || reportingFrequency === 'quarter') {
+    return 'month'
+  }
+
+  if (reportingFrequency === 'fortnight') {
+    return 'week'
+  }
+
+  return reportingFrequency
+}
+
 function _returnId (missingReturn) {
   const regionCode = missingReturn.regionId
   const licenceReference = missingReturn.licenceRef
@@ -95,7 +107,7 @@ async function _returnLog (missingReturn, points, purposes, timestamp) {
     missingReturn.licenceRef,
     missingReturn.returnCycle.startDate,
     missingReturn.returnCycle.endDate,
-    missingReturn.returnRequirement.reportingFrequency,
+    _returnsFrequency(missingReturn.returnRequirement.reportingFrequency),
     _metadata(missingReturn, points, purposes),
     timestamp,
     timestamp,

--- a/src/routes.js
+++ b/src/routes.js
@@ -184,6 +184,14 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/process/missing-return-logs',
+    handler: Controller.missingReturnLogs,
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: 'POST',
     path: '/process/missing-void-returns',
     handler: Controller.missingVoidReturns,
     config: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5594

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

The return logs for a licence in WRLS should cover the same period as the return versions. What we found was that the original import process would 'skip' creating a return log if it could not find a matching 'NALD_RET_FORM_LOGS'.

For example, licence `01/123` first return version starts 1993-10-21. But its first return log has a start date of 1998-04-01. When we check its NALD form logs, the first is dated 1999-01-01 to 1999-12-31.

The import would attempt to generate a WRLS return log for 1998-04-01 to 1999-03-31. Based on the logic above, this will match with the first form log in NALD (1999-01-01 falls between 1998-04-01 to 1999-03-31), so the import would create a return log and move to the next.

But the return logs it wants to generate between 1993-10-21 and 1998-03-31 don't match a NALD form log, hence no WRLS return log is created.

This change will add a 'one-off' step to the import process that will

- identify the licences affected by this
- create 'DUE' return logs for the missing period