### PR TITLE
Ignore quarterly rtn versions in missing rtn logs

### DIFF
--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -11,6 +11,7 @@ async function go () {
     water.return_versions rv
   WHERE
     rv.status = 'current'
+    AND rv.quarterly_returns = false
     AND (
       rv.reason IS NULL
       OR rv.reason NOT IN (
@@ -51,6 +52,7 @@ licences_with_return_versions AS (
       WHERE
         rv.licence_id = l.licence_id
         AND rv.status = 'current'
+        AND rv.quarterly_returns = false
         AND (
           rv.reason IS NULL
           OR rv.reason NOT IN (


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5594

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

We [added a new step to import these missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186). But double-checking prod, there is a risk that quarterly return versions may be incorrectly identified as missing because their return periods do not align with the return cycle they are linked to. to.

For now, as these were all created using the new jobs we built, we're assuming none of them has missing return logs, so we'll exclude them from the on-off step.

We'll check specifically for these after this first tranche of discrepancies has been resolved.