### PR TITLE
Correct query in missing-return-logs step 

### DIFF
--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -3,85 +3,38 @@
 const db = require('../../../lib/connectors/db.js')
 
 async function go () {
-  return db.query(`WITH return_version_periods AS (
-  SELECT
-    rv.licence_id,
-    MAX(COALESCE(rv.end_date, CURRENT_DATE)) AS latest_end_date
-  FROM
-    water.return_versions rv
-  WHERE
-    rv.status = 'current'
-    AND rv.quarterly_returns = false
-    AND (
-      rv.reason IS NULL
-      OR rv.reason NOT IN (
-        'abstraction-below-100-cubic-metres-per-day',
-        'licence-conditions-do-not-require-returns',
-        'returns-exception',
-        'temporary-trade'
-      )
-    )
-  GROUP BY
-    rv.licence_id
-),
-licences_with_return_versions AS (
+  return db.query(`WITH licence_details AS (
   SELECT
     l.licence_id,
     l.licence_ref,
     l.is_water_undertaker AS water_undertaker,
     l.regions->>'historicalAreaCode' AS area_code,
     r.nald_region_id AS region_id,
-    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date,
-    LEAST(l.expired_date, l.lapsed_date, l.revoked_date, rvp.latest_end_date) AS calculated_end_date
+    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date
   FROM
     water.licences l
   INNER JOIN
     water.regions r
     ON
       r.region_id = l.region_id
-  INNER JOIN
-    return_version_periods rvp
-    ON
-      rvp.licence_id= l.licence_id
-  WHERE
-    EXISTS (
-      SELECT
-        1
-      FROM
-        water.return_versions rv
-      WHERE
-        rv.licence_id = l.licence_id
-        AND rv.status = 'current'
-        AND rv.quarterly_returns = false
-        AND (
-          rv.reason IS NULL
-          OR rv.reason NOT IN (
-            'abstraction-below-100-cubic-metres-per-day',
-            'licence-conditions-do-not-require-returns',
-            'returns-exception',
-            'temporary-trade'
-          )
-        )
-    )
 ),
-return_version_history AS (
+return_version_details AS (
   SELECT
-    lwrv.*,
+    ld.*,
     rv.return_version_id,
     rv.start_date AS return_version_start_date,
     rv.end_date AS return_version_end_date,
-    (CASE
-      WHEN rv.end_date IS NULL THEN lwrv.calculated_end_date
-      ELSE rv.end_date
-    END) AS calculated_return_version_end_date
+    LEAST(rv.end_date, ld.licence_end_date, CURRENT_DATE) AS calculated_end_date
   FROM
     water.return_versions rv
   INNER JOIN
-    licences_with_return_versions lwrv
+    licence_details ld
     ON
-      lwrv.licence_id = rv.licence_id
+      ld.licence_id = rv.licence_id
   WHERE
     rv.status = 'current'
+    AND rv.quarterly_returns = FALSE
+    AND rv.start_date <= ld.licence_end_date
     AND (
       rv.reason IS NULL
       OR rv.reason NOT IN (
@@ -92,9 +45,9 @@ return_version_history AS (
       )
     )
 ),
-return_requirement_history AS (
+return_requirement_details AS (
   SELECT
-    rvh.*,
+    rvd.*,
     rr.return_requirement_id,
     rr.legacy_id,
     rr.reporting_frequency,
@@ -108,100 +61,156 @@ return_requirement_history AS (
   FROM
     water.return_requirements rr
   INNER JOIN
-    return_version_history rvh
+    return_version_details rvd
     ON
-      rvh.return_version_id = rr.return_version_id
+      rvd.return_version_id = rr.return_version_id
 ),
-returns_history AS (
+log_aggregates AS (
+    -- Step 1: Combine all log ranges for each version into a single multirange
   SELECT
-    rrh.*,
+    r.return_requirement_id,
+    range_agg(daterange(r.start_date, r.end_date, '[]')) AS logged_ranges
+  FROM
+    "returns"."returns" r
+  WHERE
+    r.status <> 'void'
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        return_requirement_details rrd
+      WHERE
+        rrd.return_requirement_id = r.return_requirement_id
+    )
+  GROUP BY
+    r.return_requirement_id
+),
+calculated_gaps AS (
+  -- Step 2: Subtract the logged multirange from the master version range
+  SELECT
+    rrd.return_requirement_id,
+    -- The '-' operator subtracts the logs multirange from the version range
+    (
+      datemultirange(
+        daterange(
+          rrd.return_version_start_date,
+          rrd.calculated_end_date, '[]')) - COALESCE(lg.logged_ranges, datemultirange()
+        )
+    ) AS gap_multirange
+  FROM
+    return_requirement_details rrd
+  LEFT JOIN
+    log_aggregates lg
+    ON
+      rrd.return_requirement_id = lg.return_requirement_id
+),
+missing_periods AS (
+  SELECT
+    cg.return_requirement_id,
+    lower(gap_range) AS gap_start_date,
+    (upper(gap_range) - INTERVAL '1 day')::date AS gap_end_date
+  FROM
+    calculated_gaps cg,
+    unnest(cg.gap_multirange) AS gap_range
+  WHERE NOT
+    isempty(gap_range)
+  ORDER BY
+    cg.return_requirement_id,
+    gap_start_date
+),
+missing_return_requirement_gaps AS (
+  SELECT
+    rrd.*,
+    mp.gap_start_date,
+    mp.gap_end_date
+  FROM
+    return_requirement_details rrd
+  INNER JOIN
+    missing_periods mp
+    ON
+      mp.return_requirement_id = rrd.return_requirement_id
+),
+missing_return_requirement_cycles AS (
+  SELECT
+    mrrg.*,
     rc.return_cycle_id,
     rc.start_date AS return_cycle_start_date,
     rc.end_date AS return_cycle_end_date,
-    rc.due_date AS return_cycle_due_date,
-    GREATEST(rrh.return_version_start_date, rc.start_date) AS return_period_start_date,
-    LEAST(rrh.licence_end_date, rrh.return_version_end_date, rc.end_date) AS return_period_end_date
+    rc.due_date AS return_cycle_due_date
   FROM
-    return_requirement_history rrh
+    missing_return_requirement_gaps mrrg
   INNER JOIN
     "returns".return_cycles rc
     ON
-      rc.is_summer = rrh.summer
-      AND rc.start_date <= rrh.calculated_return_version_end_date
-      AND rc.end_date >= rrh.return_version_start_date
+      rc.is_summer = mrrg.summer
+      AND rc.start_date <= mrrg.gap_end_date
+      AND rc.end_date >= mrrg.gap_start_date
 ),
-returns_candidates AS (
+missing_return_requirement_periods AS (
   SELECT
-    rh.*,
+    mrrc.*,
+    (GREATEST(mrrc.return_version_start_date, mrrc.return_cycle_start_date)) AS return_period_start_date,
+    (LEAST(mrrc.return_version_end_date, mrrc.return_cycle_end_date)) AS return_period_end_date
+  FROM
+    missing_return_requirement_cycles mrrc
+),
+missing_returns AS (
+  SELECT
+    mrrp.*,
     (CASE
-      WHEN rh.return_cycle_due_date IS NULL THEN
+      WHEN mrrp.return_cycle_due_date IS NULL THEN
         NULL
       ELSE
-        rh.return_period_end_date + INTERVAL '28 day'
+        (mrrp.return_period_end_date + INTERVAL '28 day')::date
     END) AS return_period_due_date,
     concat_ws(
       ':',
       'v1',
-      rh.region_id,
-      rh.licence_ref,
-      rh.legacy_id,
-      to_char(rh.return_period_start_date, 'YYYY-MM-DD'),
-      to_char(rh.return_period_end_date, 'YYYY-MM-DD')
+      mrrp.region_id,
+      mrrp.licence_ref,
+      mrrp.legacy_id,
+      to_char(mrrp.return_period_start_date, 'YYYY-MM-DD'),
+      to_char(mrrp.return_period_end_date, 'YYYY-MM-DD')
     ) AS return_id
   FROM
-    returns_history rh
-),
-returns_candidate_misses AS (
-  SELECT
-    rc.*
-  FROM
-    returns_candidates rc
-  WHERE
-    NOT EXISTS (
-      SELECT
-        1
-      FROM
-        "returns"."returns" r
-      WHERE
-        r.return_id = rc.return_id
-    )
+    missing_return_requirement_periods mrrp
 )
 SELECT
-  rcm.licence_id,
-  rcm.licence_ref,
-  rcm.water_undertaker,
-  rcm.area_code,
-  rcm.region_id,
-  rcm.licence_end_date,
-  rcm.calculated_end_date,
-  rcm.return_version_id,
-  rcm.return_version_start_date,
-  rcm.return_version_end_date,
-  rcm.return_requirement_id,
-  rcm.legacy_id,
-  rcm.reporting_frequency,
-  rcm.summer,
-  rcm.abstraction_period_start_day,
-  rcm.abstraction_period_start_month,
-  rcm.abstraction_period_end_day,
-  rcm.abstraction_period_end_month,
-  rcm.site_description,
-  rcm.two_part_tariff,
-  rcm.return_cycle_id,
-  rcm.return_cycle_start_date,
-  rcm.return_cycle_end_date,
-  rcm.return_cycle_due_date,
-  rcm.return_period_start_date,
-  rcm.return_period_end_date,
-  rcm.return_period_due_date,
-  rcm.return_id
+  mr.licence_id,
+  mr.licence_ref,
+  mr.region_id,
+  mr.water_undertaker,
+  mr.area_code,
+  mr.licence_end_date,
+  mr.return_version_id,
+  mr.return_version_start_date,
+  mr.return_version_end_date,
+  mr.calculated_end_date,
+  mr.return_requirement_id,
+  mr.legacy_id,
+  mr.reporting_frequency,
+  mr.summer,
+  mr.abstraction_period_start_day,
+  mr.abstraction_period_start_month,
+  mr.abstraction_period_end_day,
+  mr.abstraction_period_end_month,
+  mr.site_description,
+  mr.two_part_tariff,
+  mr.gap_start_date,
+  mr.gap_end_date,
+  mr.return_cycle_id,
+  mr.return_cycle_start_date,
+  mr.return_cycle_end_date,
+  mr.return_cycle_due_date,
+  mr.return_period_start_date,
+  mr.return_period_end_date,
+  mr.return_period_due_date,
+  mr.return_id
 FROM
-  returns_candidate_misses rcm
+  missing_returns mr
 ORDER BY
-  rcm.licence_id,
-  rcm.return_version_id,
-  rcm.return_requirement_id,
-  rcm.return_cycle_start_date DESC;
+  mr.licence_ref ASC,
+  mr.return_requirement_id;
   `)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5594

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

We [Added a new step to import missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186) and thought we were done. But when working on another issue (populating these missing return logs), we found cases where the ones we were creating overlapped with existing ones.

For example, the query we implemented believed licence 01/123 was missing a return log for 1 April 2008 to 31 March 2009. In reality, the year was covered by two return logs: 1 April 2008 to 31 October 2008, and 1 November 2008 to 31 March 2009. Why the old legacy import created two is another question (in fairness, this smacks of someone correcting a record in NALD when they should have added a replacement).

This meant we needed to come back and rethink our `FetchMissingReturnLogs` query.

With the help of Google Gemini, we've managed to rewrite the query with one that now handles this situation, whilst still able to spot the gaps. It characterised it as:

> the classic "gaps and islands" style problem, but with a twist: you are comparing a master period (`return_versions`) against a set of child periods (`return_logs`) to find the missing pieces.

It introduced us to PostgreSQL's [range_agg() function](https://www.postgresql.org/docs/current/functions-aggregate.html) and [daterange](https://www.postgresql.org/docs/current/rangetypes.html). Having worked out for each licence the date range each of its return requirements covers (taking into account licence end dates), we could aggregate the periods covered by the return logs for those return requirements.

By subtracting the aggregated return log periods from the return requirement period, PostgreSQL gives us the 'gaps' as an array. We can then unnest those for each return requirement to identify the gaps that need to be covered.

Doing it this way means our example above is handled, as it sees that 1 April 2008 to 31 March 2009 is covered by existing return logs. Yet it still finds where we do have gaps (we really checked this time!)

So, this change updates the Fetch with a better query.