### PR TITLE
Add new step to fixup return logs missing data 

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -25,6 +25,7 @@ const LicenceNoStartDateImportProcess = require('./modules/licence-no-start-date
 const LicencePermitImportProcess = require('./modules/licence-permit-import/process.js')
 const LicencesImportProcess = require('./modules/licences-import/process.js')
 const LinkToModLogsProcess = require('./modules/link-to-mod-logs/process.js')
+const MissingReturnLogDataProcess = require('./modules/missing-return-log-data/process.js')
 const MissingReturnLogsProcess = require('./modules/missing-return-logs/process.js')
 const MissingVoidReturnsProcess = require('./modules/missing-void-returns/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
@@ -175,6 +176,12 @@ async function linkToModLogs (_request, h) {
   return h.response().code(204)
 }
 
+async function missingReturnLogData (_request, h) {
+  MissingReturnLogDataProcess.go(true)
+
+  return h.response().code(204)
+}
+
 async function missingReturnLogs (_request, h) {
   MissingReturnLogsProcess.go(true)
 
@@ -250,6 +257,7 @@ module.exports = {
   licencePermitImport,
   licencesImport,
   linkToModLogs,
+  missingReturnLogData,
   missingReturnLogs,
   missingVoidReturns,
   partyCrmV2Import,

--- a/src/modules/import-job/lib/missing-return-log-data.js
+++ b/src/modules/import-job/lib/missing-return-log-data.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const MissingReturnLogDataProcess = require('../..//missing-return-log-data/process.js')
+
+const STEP_NAME = 'missing-return-log-data'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await MissingReturnLogDataProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -12,6 +12,7 @@ const FlagDeletedDocumentsStep = require('./lib/flag-deleted-documents.js')
 const LicenceDataImportStep = require('./lib/licence-data-import.js')
 const LicencesImportStep = require('./lib/licences-import.js')
 const LinkToModLogsStep = require('./lib/link-to-mod-logs.js')
+const MissingReturnLogDataStep = require('./lib/missing-return-log-data.js')
 const MissingReturnLogsStep = require('./lib/missing-return-logs.js')
 const MissingVoidReturnsStep = require('./lib/missing-void-returns.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
@@ -57,6 +58,9 @@ async function go () {
     steps.push(step)
 
     step = await EndDateTriggerStep.go()
+    steps.push(step)
+
+    step = await MissingReturnLogDataStep.go()
     steps.push(step)
 
     step = await MissingVoidReturnsStep.go()

--- a/src/modules/missing-return-log-data/process.js
+++ b/src/modules/missing-return-log-data/process.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    const timestamp = timestampForPostgres()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'missing-return-log-data: complete', { messages })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('missing-return-log-data: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/missing-return-log-data/process.js
+++ b/src/modules/missing-return-log-data/process.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { currentTimeInNanoseconds, calculateAndLogTimeTaken, timestampForPostgres } = require('../../lib/general.js')
+const db = require('../../lib/connectors/db.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
   const messages = []
@@ -8,7 +9,8 @@ async function go (log = false) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    const timestamp = timestampForPostgres()
+    await _missingReturnRequirementId()
+    await _missingReturnCycleId()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'missing-return-log-data: complete', { messages })
@@ -20,6 +22,75 @@ async function go (log = false) {
   }
 
   return messages
+}
+
+async function _missingReturnCycleId () {
+  const query = `WITH missing_cycle_returns AS (
+  SELECT
+    r.id,
+    rc.return_cycle_id
+  FROM
+    "returns"."returns" r
+  INNER JOIN
+    water.return_requirements rr
+    ON
+      rr.return_requirement_id = r.return_requirement_id
+  INNER JOIN
+    "returns".return_cycles rc
+    ON
+      rc.is_summer = rr.is_summer
+      AND rc.start_date <= r.end_date
+      AND rc.end_date >= r.start_date
+  WHERE
+    r.return_cycle_id IS NULL
+)
+UPDATE "returns"."returns" r
+SET
+  return_cycle_id = mcr.return_cycle_id,
+  updated_at = NOW()
+FROM
+  missing_cycle_returns mcr
+WHERE
+  r.id = mcr.id;
+  `
+
+  return db.query(query)
+}
+
+async function _missingReturnRequirementId () {
+  const query = `WITH missing_requirement_returns AS (
+  SELECT
+    r.id,
+    rr.return_requirement_id
+  FROM
+    "returns"."returns" r
+  INNER JOIN
+    water.licences l
+    ON
+      l.licence_ref = r.licence_ref
+  INNER JOIN
+    water.return_versions rv
+    ON
+      rv.licence_id = l.licence_id
+  INNER JOIN
+    water.return_requirements rr
+    ON
+      rr.return_version_id = rv.return_version_id
+      AND rr.legacy_id::text = r.return_requirement
+  WHERE
+    r.return_requirement_id IS NULL
+)
+UPDATE "returns"."returns" r
+SET
+  return_requirement_id = mrr.return_requirement_id,
+  updated_at = NOW()
+FROM
+  missing_requirement_returns mrr
+WHERE
+  r.id = mrr.id;
+  `
+
+  return db.query(query)
 }
 
 module.exports = {

--- a/src/routes.js
+++ b/src/routes.js
@@ -184,6 +184,14 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/process/missing-return-log-data',
+    handler: Controller.missingReturnLogData,
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: 'POST',
     path: '/process/missing-return-logs',
     handler: Controller.missingReturnLogs,
     config: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5667

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

We [Added a new step to import missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186) and thought we were done. We've had to make some adjustments to that step as we've learnt more, and our latest finding is that there are some return logs missing

- A return cycle ID
- A return requirement ID

All return logs should have these fields populated, and we can only speculate that something in the legacy return log import mechanism caused them to become blank.

But for our missing return logs step to work as expected, we need these fields populated.

To populate the return cycle ID, we need to access the return requirement to know whether we are dealing with the summer or winter return log.

So, we start by populating any missing return requirement IDs. Then we populate any missing return cycle IDs.