### PR TITLE
Handle missing returns clashing with existing

### DIFF
--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -94,8 +94,9 @@ calculated_gaps AS (
       datemultirange(
         daterange(
           rrd.return_version_start_date,
-          rrd.calculated_end_date, '[]')) - COALESCE(lg.logged_ranges, datemultirange()
+          rrd.calculated_end_date, '[]'
         )
+      ) - COALESCE(lg.logged_ranges, datemultirange())
     ) AS gap_multirange
   FROM
     return_requirement_details rrd
@@ -149,12 +150,12 @@ missing_return_requirement_cycles AS (
 missing_return_requirement_periods AS (
   SELECT
     mrrc.*,
-    (GREATEST(mrrc.return_version_start_date, mrrc.return_cycle_start_date)) AS return_period_start_date,
-    (LEAST(mrrc.return_version_end_date, mrrc.return_cycle_end_date)) AS return_period_end_date
+    (GREATEST(mrrc.return_version_start_date, mrrc.return_cycle_start_date, mrrc.gap_start_date)) AS return_period_start_date,
+    (LEAST(mrrc.licence_end_date, mrrc.return_version_end_date, mrrc.return_cycle_end_date, mrrc.gap_end_date)) AS return_period_end_date
   FROM
     missing_return_requirement_cycles mrrc
 ),
-missing_returns AS (
+missing_return_candidates AS (
   SELECT
     mrrp.*,
     (CASE
@@ -174,6 +175,21 @@ missing_returns AS (
     ) AS return_id
   FROM
     missing_return_requirement_periods mrrp
+),
+missing_returns AS (
+  SELECT
+    mrc.*
+  FROM
+    missing_return_candidates mrc
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        "returns"."returns" r
+      WHERE
+        r.return_id = mrc.return_id
+    )
 )
 SELECT
   mr.licence_id,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5594

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

We [Added a new step to import missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186) and thought we were done. But when working on another issue (populating these missing return logs), we found cases where the ones we were creating overlapped with existing ones.

We figured out a [solution for this](https://github.com/DEFRA/water-abstraction-import/pull/1188), which skipped the check of the generated return ID against existing return IDs used in the previous query. We both thought this was an artefact of how we had previously confirmed the gaps, and it was not needed because of the improved query logic.

Turns out, a minor flaw, plus NALD data being the way it is meant we were still generating clashes.

The flaw was that we were not providing the right dates when calculating the return period start and end dates.

The first issue with the NALD data was that some records were missing their return requirement ID. This meant those return logs were not included when the query aggregated the return periods, leading it to believe there was a gap when, in fact, the return logs existed.

We've [added a step to correct those](https://github.com/DEFRA/water-abstraction-import/pull/1189) and populate the missing return requirement IDs.

But we also found there are `VOID` returns, which cover the periods the query thinks are missing. We exclude `VOID` return logs from the period aggregation because they would skew the results.

For example, imagine licence 01/123 has the following return version: 2004-04-01 to [no end date]. The service would have generated return logs for 2004-04-01 to 2005-03-31 (`a`), 2005-04-01 to 2006-03-31 (`b`) and so on. But then a new return version was added starting 2004-06-01. This should have caused NALD and the legacy import to void return log `a`, and create two new ones: 2004-04-01 to 2004-05-31 (`c`) and 2004-06-01 to 2005-03-31 (`d`). Now imagine NALD doesn't generate a form log for `c`, so the legacy import skipped importing it.

We have a gap for 2004-04-01 to 2004-05-31 we want to add a missing return log for. But if we included `VOID` returns in the range aggregation, the gap would be covered by `a`, which means the query wouldn't spot it.

The fact that they are 'void' yet no 'due' or 'completed' return exists for the same period is another issue we'll need to look into. But for now, it's the reason we need to add back into the query the check of the generated return ID against existing return IDs.