### PR TITLE
Include lics with no end date in missing rtn logs

### DIFF
--- a/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
+++ b/src/modules/missing-return-logs/lib/fetch-missing-return-logs.js
@@ -34,7 +34,9 @@ return_version_details AS (
   WHERE
     rv.status = 'current'
     AND rv.quarterly_returns = FALSE
-    AND rv.start_date <= ld.licence_end_date
+    AND (
+      ld.licence_end_date IS NULL OR rv.start_date <= ld.licence_end_date
+    )
     AND (
       rv.reason IS NULL
       OR rv.reason NOT IN (


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5594

We have been investigating the differences between NALD and WRLS returns data. We have found some discrepancies after doing a comparison for 2014 between the two services, down to the return requirement (reference) level

One was that we observed several licences with missing return logs.

We [Added a new step to import missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186), and then [corrected the query](https://github.com/DEFRA/water-abstraction-import/pull/1188) after spotting a flaw in how the missing return logs were being determined.

In testing, we've found another issue with the query.

If a return version starts after a licence ends, we wouldn't generate return logs even in the service proper. So these would not be considered 'gaps' to be filled in. Therefore, our query excluded any return versions with a start date on or after the licence end date.

The flaw with the query is that it was also excluding all return versions linked to licences with no end date.

This change corrects the query.