### PR TITLE
Add new step to void return logs older than lic.

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -31,6 +31,7 @@ const MissingVoidReturnsProcess = require('./modules/missing-void-returns/proces
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
 const MissingReturnSubmissionsProcess = require('./modules/missing-return-submissions/process.js')
+const VoidReturnLogsProcess = require('./modules/void-return-logs/process.js')
 
 async function clean (_request, h) {
   CleanProcess.go(true)
@@ -220,6 +221,12 @@ async function referenceDataImport (_request, h) {
   return h.response().code(204)
 }
 
+async function voidReturnLogs (_request, h) {
+  VoidReturnLogsProcess.go(true)
+
+  return h.response().code(204)
+}
+
 function status (_request, _h) {
   return { status: 'alive' }
 }
@@ -270,5 +277,6 @@ module.exports = {
   missingVoidReturns,
   partyCrmV2Import,
   referenceDataImport,
-  status
+  status,
+  voidReturnLogs
 }

--- a/src/modules/import-job/lib/void-return-logs.js
+++ b/src/modules/import-job/lib/void-return-logs.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const VoidReturnLogsProcess = require('../../void-return-logs/process.js')
+
+const STEP_NAME = 'void-return-logs'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await VoidReturnLogsProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -18,6 +18,7 @@ const MissingReturnSubmissionsStep = require('./lib/missing-return-submissions.j
 const MissingVoidReturnsStep = require('./lib/missing-void-returns.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
 const ReferenceDataImportStep = require('./lib/reference-data-import.js')
+const VoidReturnLogsStep = require('./lib/void-return-logs.js')
 
 async function go () {
   try {
@@ -62,6 +63,9 @@ async function go () {
     steps.push(step)
 
     step = await MissingReturnLogDataStep.go()
+    steps.push(step)
+
+    step = await VoidReturnLogsStep.go()
     steps.push(step)
 
     step = await MissingVoidReturnsStep.go()

--- a/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/collate-missing-void-return-lines.js
@@ -82,8 +82,9 @@ function _processLines (missingVoidReturnLines) {
         dueDate
       },
       returnLog: {
-        id: missingVoidReturnLine.return_log_id,
-        returnId: missingVoidReturnLine.return_id
+        id: missingVoidReturnLine.existing_return_log_id,
+        returnId: missingVoidReturnLine.existing_return_id,
+        newReturnId: missingVoidReturnLine.new_return_id
       }
     }
   }

--- a/src/modules/missing-void-returns/lib/create-missing-return-log.js
+++ b/src/modules/missing-void-returns/lib/create-missing-return-log.js
@@ -2,7 +2,6 @@
 
 const db = require('../../../lib/connectors/db.js')
 const FetchPointsPurposes = require('./fetch-points-purposes.js')
-const { formatDateObjectToISO } = require('../../../lib/date-helpers.js')
 const { generateUUID } = require('../../../lib/general.js')
 
 async function go (missingReturn, timestamp) {
@@ -88,22 +87,11 @@ function _returnsFrequency (reportingFrequency) {
   return reportingFrequency
 }
 
-function _returnId (missingReturn) {
-  const regionCode = missingReturn.regionId
-  const licenceReference = missingReturn.licenceRef
-  const returnReference = missingReturn.returnRequirement.reference
-  const startDateAsString = formatDateObjectToISO(missingReturn.returnCycle.startDate)
-  const endDateAsString = formatDateObjectToISO(missingReturn.returnCycle.endDate)
-
-  return `v1:${regionCode}:${licenceReference}:${returnReference}:${startDateAsString}:${endDateAsString}`
-}
-
 async function _returnLog (missingReturn, points, purposes, timestamp) {
-  const returnId = _returnId(missingReturn)
   const id = generateUUID()
 
   const params = [
-    returnId,
+    missingReturn.returnLog.newReturnId,
     missingReturn.licenceRef,
     missingReturn.returnCycle.startDate,
     missingReturn.returnCycle.endDate,
@@ -162,7 +150,7 @@ VALUES (
 
   await db.query(query, params)
 
-  return { id, returnId }
+  return { id, returnId: missingReturn.returnLog.newReturnId }
 }
 
 module.exports = {

--- a/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
@@ -205,6 +205,8 @@ lines_plus_requirements AS (
     ON
       wrr.external_id = rr.external_id
 ),
+-- Identify the return cycle for each of our lines, needed to create a void return log if
+-- one doesn't exist
 lines_plus_return_cycle_ids AS (
   SELECT
     lpr.*,
@@ -221,6 +223,8 @@ lines_plus_return_cycle_ids AS (
   FROM
     lines_plus_requirements lpr
 ),
+-- Extract the start, end and due dates from the return cycle so we have them if we need
+-- to create a void return log
 lines_plus_return_cycles AS (
   SELECT
     lprci.*,
@@ -234,6 +238,10 @@ lines_plus_return_cycles AS (
     ON
       rc.return_cycle_id = lprci.return_cycle_id
 ),
+-- Identify previously completed void return logs so we can exclude them from our results. This allows us to rerun the
+-- step repeatedly
+-- Note to future self. The difference between this and the WHERE clause in combined_results is the JOIN to
+-- returns.versions!
 completed_void_return_logs AS (
   SELECT
     r.id

--- a/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
+++ b/src/modules/missing-void-returns/lib/fetch-missing-void-return-lines.js
@@ -3,8 +3,7 @@
 const db = require('../../../lib/connectors/db.js')
 
 async function go () {
-  return db.query(`
-WITH raw_ended_licences AS (
+  return db.query(`WITH raw_ended_licences AS (
   SELECT
     nal."FGAC_REGION_CODE" AS region_id,
     nal."ID" AS licence_id,
@@ -240,7 +239,7 @@ lines_plus_return_cycles AS (
 ),
 -- Identify previously completed void return logs so we can exclude them from our results. This allows us to rerun the
 -- step repeatedly
--- Note to future self. The difference between this and the WHERE clause in combined_results is the JOIN to
+-- Note to future self. The difference between this and the WHERE clause in lines_with_existing_returns is the JOIN to
 -- returns.versions!
 completed_void_return_logs AS (
   SELECT
@@ -259,35 +258,30 @@ completed_void_return_logs AS (
       AND lprc.return_cycle_start_date = r.start_date
       AND r.status = 'void'
 ),
-combined_results AS (
+-- Combine the lines we've got with existing incomplete VOID return logs. This tells us which lines can be assigned
+-- to an existing VOID return log, and which ones need one creating.
+-- We also generate an ID we can use to group the lines ready for assigning, and where a new return log is needed,
+-- what its return ID will be
+lines_with_existing_returns AS (
   SELECT
+    lprc.*,
     (concat_ws(':', lprc.external_id, lprc.return_cycle_id)) AS id,
-    lprc.region_id,
-    lprc.licence_id,
-    lprc.licence_ref,
-    lprc.area_code,
-    lprc.water_undertaker,
-    lprc.licence_end_date,
-    lprc.external_id,
-    lprc.return_requirement_id,
-    lprc.format_id,
-    lprc.reporting_frequency,
-    lprc.summer,
-    lprc.abstraction_period_start_day,
-    lprc.abstraction_period_start_month,
-    lprc.abstraction_period_end_day,
-    lprc.abstraction_period_end_month,
-    lprc.return_version_id,
-    lprc.site_description,
-    lprc.two_part_tariff,
-    lprc.return_date,
-    lprc.return_qty,
-    lprc.return_cycle_id,
-    lprc.return_cycle_start_date,
-    lprc.return_cycle_end_date,
-    lprc.return_cycle_due_date,
-    r.return_id,
-    r.id AS return_log_id
+    r.return_id AS existing_return_id,
+    r.id AS existing_return_log_id,
+    (CASE
+      WHEN r.id IS NOT NULL THEN
+        NULL
+      ELSE
+        concat_ws(
+          ':',
+          'v1',
+          lprc.region_id,
+          lprc.licence_ref,
+          lprc.format_id,
+          to_char(lprc.return_cycle_start_date, 'YYYY-MM-DD'),
+          to_char(lprc.return_cycle_end_date, 'YYYY-MM-DD')
+        )
+    END) AS new_return_id
   FROM
     lines_plus_return_cycles lprc
   LEFT JOIN
@@ -305,6 +299,51 @@ combined_results AS (
         completed_void_return_logs cvrl
       WHERE
         cvrl.id = r.id
+    )
+),
+-- Other than showing what we are actualy returning for processing, this step also filters out any proposed new
+-- return logs that have an existing match. This should not be the case, but we'd rather exclude them than throw
+-- an error and stop the rest from being processed.
+combined_results AS (
+  SELECT
+    lwer.id,
+    lwer.region_id,
+    lwer.licence_id,
+    lwer.licence_ref,
+    lwer.area_code,
+    lwer.water_undertaker,
+    lwer.licence_end_date,
+    lwer.external_id,
+    lwer.return_requirement_id,
+    lwer.format_id,
+    lwer.reporting_frequency,
+    lwer.summer,
+    lwer.abstraction_period_start_day,
+    lwer.abstraction_period_start_month,
+    lwer.abstraction_period_end_day,
+    lwer.abstraction_period_end_month,
+    lwer.return_version_id,
+    lwer.site_description,
+    lwer.two_part_tariff,
+    lwer.return_date,
+    lwer.return_qty,
+    lwer.return_cycle_id,
+    lwer.return_cycle_start_date,
+    lwer.return_cycle_end_date,
+    lwer.return_cycle_due_date,
+    lwer.existing_return_id,
+    lwer.existing_return_log_id,
+    lwer.new_return_id
+  FROM
+    lines_with_existing_returns lwer
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        "returns"."returns" r
+      WHERE
+        r.return_id = lwer.new_return_id
     )
 )
 -- By SELECTing from our combined results, it makes it easier to filter and order them. These can be

--- a/src/modules/void-return-logs/process.js
+++ b/src/modules/void-return-logs/process.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'void-return-logs: complete', { messages })
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('void-return-logs: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/void-return-logs/process.js
+++ b/src/modules/void-return-logs/process.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const db = require('../../lib/connectors/db.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
@@ -7,6 +8,8 @@ async function go (log = false) {
 
   try {
     const startTime = currentTimeInNanoseconds()
+
+    await _voidReturnLogs()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'void-return-logs: complete', { messages })
@@ -18,6 +21,82 @@ async function go (log = false) {
   }
 
   return messages
+}
+
+async function _voidReturnLogs () {
+  const query = `WITH all_licences AS (
+  SELECT
+    l.licence_id,
+    l.licence_ref,
+    r.nald_region_id,
+    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date
+  FROM
+    water.licences l
+  INNER JOIN
+    water.regions r
+    ON r.region_id = l.region_id
+),
+ended_licences_with_return_versions AS (
+  SELECT
+    al.*
+  FROM
+    all_licences al
+  WHERE
+    al.licence_end_date IS NOT NULL
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        water.return_versions rv
+      WHERE
+        rv.licence_id = al.licence_id
+    )
+),
+need_voiding_return_logs AS (
+  SELECT
+    r.id AS return_log_id,
+    r.return_id,
+    r.start_date AS return_log_start_date,
+    r.end_date AS return_log_end_date,
+    r.status AS return_log_status,
+    r.created_at AS return_log_created_at,
+    elwrv.licence_id
+  FROM
+    "returns"."returns" r
+  INNER JOIN
+    ended_licences_with_return_versions elwrv
+    ON
+      elwrv.licence_ref = r.licence_ref
+  WHERE
+    r.status <> 'void'
+    AND r.end_date > elwrv.licence_end_date
+
+),
+combined_results AS (
+  SELECT
+    elwrv.*,
+    nvrl.return_log_start_date,
+    nvrl.return_log_end_date,
+    nvrl.return_log_status,
+    nvrl.return_log_id,
+    nvrl.return_id,
+    nvrl.return_log_created_at
+  FROM
+    ended_licences_with_return_versions elwrv
+  INNER JOIN
+    need_voiding_return_logs nvrl
+    ON nvrl.licence_id = elwrv.licence_id
+)
+UPDATE "returns"."returns" r
+SET
+  status = 'void',
+  updated_at = NOW()
+FROM
+  combined_results cr
+WHERE
+  r.id = cr.return_log_id;`
+
+  return db.query(query)
 }
 
 module.exports = {

--- a/src/routes.js
+++ b/src/routes.js
@@ -229,5 +229,13 @@ module.exports = [
     config: {
       auth: false
     }
+  },
+  {
+    method: 'POST',
+    path: '/process/void-return-logs',
+    handler: Controller.voidReturnLogs,
+    config: {
+      auth: false
+    }
   }
 ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5687

While working on fixes for discrepancies between NALD and WRLS return data, we encountered an issue when running the import in certain environments. After investigating, we found it was due to those environments containing return logs we didn't expect to exist.

Specifically, we were trying to [create the missing VOID return logs](https://github.com/DEFRA/water-abstraction-import/pull/1184) when we encountered errors because of duplicate return IDs.

We were not expecting any non-void return logs to remain after the licence ended, but they were present in those environments. We then checked whether this was a testing issue or also present in production, and confirmed that it was present in production as well.

Return logs that are 'due' or 'complete' with an end date later than the licence they are linked to should have a status of 'void'. Ordinarily, when a licence is ended, a process is triggered that voids the existing return logs and creates new ones (for the period from the return cycle start date to the licence end date).

Based on the record dates, this just appears to be something the legacy import process (when it handled return logs) wasn't picking up.

This change will add a 'one-off' step to the import process that will

- identify the return logs that should be voided
- update their status to `void`

With these return logs marked as void, the two previous steps we added ([Add new step to import missing return logs](https://github.com/DEFRA/water-abstraction-import/pull/1186) and [Add new step to import missing submission data](https://github.com/DEFRA/water-abstraction-import/pull/1191)) will fill in any gaps and ensure the appropriate NALD submission lines are assigned.