### PR TITLE
Add voiding returns with deleted rtn reqs to step

### DIFF
--- a/src/modules/void-return-logs/lib/void-where-end-after-licence-ends.js
+++ b/src/modules/void-return-logs/lib/void-where-end-after-licence-ends.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  const query = `WITH all_licences AS (
+  SELECT
+    l.licence_id,
+    l.licence_ref,
+    r.nald_region_id,
+    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date
+  FROM
+    water.licences l
+  INNER JOIN
+    water.regions r
+    ON r.region_id = l.region_id
+),
+ended_licences_with_return_versions AS (
+  SELECT
+    al.*
+  FROM
+    all_licences al
+  WHERE
+    al.licence_end_date IS NOT NULL
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        water.return_versions rv
+      WHERE
+        rv.licence_id = al.licence_id
+    )
+),
+need_voiding_return_logs AS (
+  SELECT
+    r.id AS return_log_id,
+    r.return_id,
+    r.start_date AS return_log_start_date,
+    r.end_date AS return_log_end_date,
+    r.status AS return_log_status,
+    r.created_at AS return_log_created_at,
+    elwrv.licence_id
+  FROM
+    "returns"."returns" r
+  INNER JOIN
+    ended_licences_with_return_versions elwrv
+    ON
+      elwrv.licence_ref = r.licence_ref
+  WHERE
+    r.status <> 'void'
+    AND r.end_date > elwrv.licence_end_date
+
+),
+combined_results AS (
+  SELECT
+    elwrv.*,
+    nvrl.return_log_start_date,
+    nvrl.return_log_end_date,
+    nvrl.return_log_status,
+    nvrl.return_log_id,
+    nvrl.return_id,
+    nvrl.return_log_created_at
+  FROM
+    ended_licences_with_return_versions elwrv
+  INNER JOIN
+    need_voiding_return_logs nvrl
+    ON nvrl.licence_id = elwrv.licence_id
+)
+UPDATE "returns"."returns" r
+SET
+  status = 'void',
+  updated_at = NOW()
+FROM
+  combined_results cr
+WHERE
+  r.id = cr.return_log_id;`
+
+  await db.query(query)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/void-return-logs/lib/void-where-return-requirement-deleted.js
+++ b/src/modules/void-return-logs/lib/void-where-return-requirement-deleted.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  const query = `UPDATE "returns"."returns" r
+SET
+  status = 'void',
+  updated_at = NOW()
+WHERE
+  r.return_requirement_id IS NULL
+  AND r.status <> 'void';
+  `
+
+  await db.query(query)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/void-return-logs/process.js
+++ b/src/modules/void-return-logs/process.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const db = require('../../lib/connectors/db.js')
+const VoidWhereEndAfterLicenceEnds = require('./lib/void-where-end-after-licence-ends.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
@@ -9,7 +9,7 @@ async function go (log = false) {
   try {
     const startTime = currentTimeInNanoseconds()
 
-    await _voidReturnLogs()
+    await VoidWhereEndAfterLicenceEnds.go()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'void-return-logs: complete', { messages })
@@ -21,82 +21,6 @@ async function go (log = false) {
   }
 
   return messages
-}
-
-async function _voidReturnLogs () {
-  const query = `WITH all_licences AS (
-  SELECT
-    l.licence_id,
-    l.licence_ref,
-    r.nald_region_id,
-    LEAST(l.expired_date, l.lapsed_date, l.revoked_date) AS licence_end_date
-  FROM
-    water.licences l
-  INNER JOIN
-    water.regions r
-    ON r.region_id = l.region_id
-),
-ended_licences_with_return_versions AS (
-  SELECT
-    al.*
-  FROM
-    all_licences al
-  WHERE
-    al.licence_end_date IS NOT NULL
-    AND EXISTS (
-      SELECT
-        1
-      FROM
-        water.return_versions rv
-      WHERE
-        rv.licence_id = al.licence_id
-    )
-),
-need_voiding_return_logs AS (
-  SELECT
-    r.id AS return_log_id,
-    r.return_id,
-    r.start_date AS return_log_start_date,
-    r.end_date AS return_log_end_date,
-    r.status AS return_log_status,
-    r.created_at AS return_log_created_at,
-    elwrv.licence_id
-  FROM
-    "returns"."returns" r
-  INNER JOIN
-    ended_licences_with_return_versions elwrv
-    ON
-      elwrv.licence_ref = r.licence_ref
-  WHERE
-    r.status <> 'void'
-    AND r.end_date > elwrv.licence_end_date
-
-),
-combined_results AS (
-  SELECT
-    elwrv.*,
-    nvrl.return_log_start_date,
-    nvrl.return_log_end_date,
-    nvrl.return_log_status,
-    nvrl.return_log_id,
-    nvrl.return_id,
-    nvrl.return_log_created_at
-  FROM
-    ended_licences_with_return_versions elwrv
-  INNER JOIN
-    need_voiding_return_logs nvrl
-    ON nvrl.licence_id = elwrv.licence_id
-)
-UPDATE "returns"."returns" r
-SET
-  status = 'void',
-  updated_at = NOW()
-FROM
-  combined_results cr
-WHERE
-  r.id = cr.return_log_id;`
-
-  return db.query(query)
 }
 
 module.exports = {

--- a/src/modules/void-return-logs/process.js
+++ b/src/modules/void-return-logs/process.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const VoidWhereEndAfterLicenceEnds = require('./lib/void-where-end-after-licence-ends.js')
+const VoidWhereReturnRequirementDeleted = require('./lib/void-where-return-requirement-deleted.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
@@ -10,6 +11,7 @@ async function go (log = false) {
     const startTime = currentTimeInNanoseconds()
 
     await VoidWhereEndAfterLicenceEnds.go()
+    await VoidWhereReturnRequirementDeleted.go()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'void-return-logs: complete', { messages })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5690

In a previous change, we added a step to [fixup return logs missing return requirement IDs](https://github.com/DEFRA/water-abstraction-import/pull/1189).

This wasn't something we expected, and the new step fixes the ones where the return requirement still exists.

For the rest, either just the return requirement was deleted, or the licence and everything linked to it.

Either way, if the return requirement no longer exists, it is because it was either replaced or incorrect, and the return logs linked to it need to be voided. This ensures they are not included in reports of _actual_ abstraction.

We've already [added a step for voiding invalid return logs](https://github.com/DEFRA/water-abstraction-import/pull/1195). In this change, we will expand it to include return logs linked to deleted return requirements.