### PR TITLE
Add cooldown option to dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  versioning-strategy: lockfile-only
-- package-ecosystem: "github-actions"
-  # Workflow files stored in the default location of `.github/workflows`
-  directory: "/"
-  schedule:
-    interval: "daily"
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 7
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
+  - package-ecosystem: 'github-actions'
+    cooldown:
+      default-days: 7
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5681

Update `.github/dependabot.yml`. Set cooldown to 7 (days) for both the npm and github-actions ecosystems.