### PR TITLE
Check return logs when deleting licences

### DIFF
--- a/src/modules/clean/lib/deleted-licence-data.js
+++ b/src/modules/clean/lib/deleted-licence-data.js
@@ -12,14 +12,6 @@ async function go () {
   await _modLogs()
 }
 
-async function _modLogs () {
-  // Delete any mod logs linked to deleted NALD licence versions
-  await db.query(`
-    DELETE FROM public.mod_logs ml
-      WHERE NOT EXISTS (SELECT 1 FROM public.licence_versions lv WHERE ml.licence_version_id = lv.id);
-  `)
-}
-
 async function _licenceMonitoringStations () {
   // Delete any soft deleted licence monitoring stations linked to deleted NALD licence version purpose conditions
   await db.query(`
@@ -148,6 +140,14 @@ async function _licenceVersions () {
     DELETE FROM public.licence_versions lv
       WHERE NOT EXISTS (SELECT 1 FROM nald_licence_versions nlv WHERE lv.external_id = nlv.nald_id)
       AND NOT EXISTS (SELECT 1 FROM public.licence_version_purposes lvp WHERE lvp.licence_version_id = lv.id);
+  `)
+}
+
+async function _modLogs () {
+  // Delete any mod logs linked to deleted NALD licence versions
+  await db.query(`
+    DELETE FROM public.mod_logs ml
+      WHERE NOT EXISTS (SELECT 1 FROM public.licence_versions lv WHERE ml.licence_version_id = lv.id);
   `)
 }
 

--- a/src/modules/clean/lib/deleted-licences.js
+++ b/src/modules/clean/lib/deleted-licences.js
@@ -24,7 +24,7 @@ licences_to_remove AS (
   FROM public.licences l
   WHERE NOT EXISTS (SELECT 1 FROM nald_lics nal WHERE nal."LIC_NO" = l.licence_ref)
   AND NOT EXISTS (SELECT 1 FROM public.bill_licences bl WHERE bl.licence_id = l.id)
-  AND NOT EXISTS (SELECT 1 FROM public.return_versions rv WHERE rv.licence_id = l.id)
+  AND NOT EXISTS (SELECT 1 FROM public.return_logs rl WHERE rl.licence_ref = l.licence_ref AND rl.status <> 'due')
   AND NOT EXISTS (SELECT 1 FROM public.licence_document_headers ldh WHERE ldh.licence_ref = l.licence_ref AND ldh.company_entity_id IS NOT NULL)
 )
 `

--- a/src/modules/clean/lib/deleted-licences.js
+++ b/src/modules/clean/lib/deleted-licences.js
@@ -46,6 +46,7 @@ async function go () {
   await _returnRequirementPurposes()
   await _returnRequirements()
   await _returnVersions()
+  await _returnLogs()
   await _modLogs()
   await _chargeReferences()
   await _billingVolumes()
@@ -53,6 +54,17 @@ async function go () {
   await _chargeVersions()
   await _licenceDocuments()
   await _licences()
+}
+
+async function _returnLogs() {
+  // Delete any return logs linked to deleted NALD licences
+  await db.query(`
+    ${LICENCES_TO_REMOVE_QUERY}
+    DELETE FROM public.return_logs rl
+    WHERE
+      rl.licence_ref IN (SELECT ltr.licence_ref FROM licences_to_remove ltr)
+      AND rl.status = 'due';
+  `)
 }
 
 async function _billingBatchChargeVersionYears () {

--- a/src/modules/clean/lib/deleted-licences.js
+++ b/src/modules/clean/lib/deleted-licences.js
@@ -56,17 +56,6 @@ async function go () {
   await _licences()
 }
 
-async function _returnLogs() {
-  // Delete any return logs linked to deleted NALD licences
-  await db.query(`
-    ${LICENCES_TO_REMOVE_QUERY}
-    DELETE FROM public.return_logs rl
-    WHERE
-      rl.licence_ref IN (SELECT ltr.licence_ref FROM licences_to_remove ltr)
-      AND rl.status = 'due';
-  `)
-}
-
 async function _billingBatchChargeVersionYears () {
   // Delete any billing batch charge version years linked to charge versions linked to deleted NALD licences
   await db.query(`
@@ -283,6 +272,17 @@ async function _permitLicences () {
     ${LICENCES_TO_REMOVE_QUERY}
     DELETE FROM public.permit_licences pl
     WHERE pl.licence_ref IN (SELECT ltr.licence_ref FROM licences_to_remove ltr);
+  `)
+}
+
+async function _returnLogs () {
+  // Delete any return logs linked to deleted NALD licences
+  await db.query(`
+    ${LICENCES_TO_REMOVE_QUERY}
+    DELETE FROM public.return_logs rl
+    WHERE
+      rl.licence_ref IN (SELECT ltr.licence_ref FROM licences_to_remove ltr)
+      AND rl.status = 'due';
   `)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5677

A long time back, we realised that many of the data issues we faced between NALD and WRLS were due to the fact that users can delete pretty much anything in NALD, but the overnight import only creates or edits. Stuff that was deleted in NALD would remain in WRLS.

We went through a process of 'cleaning' WRLS, and ensuring it remains clean each time the import is run (see [[WATER-4662](https://eaflood.atlassian.net/browse/WATER-4662)](https://eaflood.atlassian.net/browse/WATER-4662)).

There are, however, scenarios where we should not delete data, especially licences. For example, if a licence has been included in a bill run, we cannot delete it from WRLS. Another scenario we outlined was if a licence has a completed return log. We thought this scenario was covered, but a series of return logs with no matching licence made us think otherwise (see [WATER-5676](https://eaflood.atlassian.net/browse/WATER-5676) for more details).

After checking and testing the 'clean' step, we can now see what might have happened.

Yes, it isn't checking the return logs directly. Instead, it checks whether a return version exists. We believe it's because we are treating this as a proxy for whether any return logs will exist.

However, this assumes the return versions and their data would be deleted if there are return logs with a status other than 'due'. But instead, it uses the same `LICENCES_TO_REMOVE_QUERY` statement, which means that as long as a licence has a return version, it can never be deleted.

In the case that led us to double-check the step, the return versions _did not_ exist, allowing the clean step to remove the licences and leave the return logs.

We're making things clearer and more explicit with this change by checking the return logs directly rather than using the return versions as a proxy.

We also ensure we 'clean' the return logs where it is safe to do so to avoid any future confusion.

[WATER-4662]: https://eaflood.atlassian.net/browse/WATER-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WATER-5676]: https://eaflood.atlassian.net/browse/WATER-5676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ