### PR TITLE
Update to consider future lic. versions as current 

### DIFF
--- a/src/lib/permit-json/fetch-current-version.js
+++ b/src/lib/permit-json/fetch-current-version.js
@@ -95,7 +95,6 @@ async function _currentLicenceVersion (id, regionCode) {
         AND (l."EXPIRY_DATE" = 'null' OR to_date(l."EXPIRY_DATE", 'DD/MM/YYYY') > NOW())
         AND (l."LAPSED_DATE" = 'null' OR to_date(l."LAPSED_DATE", 'DD/MM/YYYY') > NOW())
         AND (l."REV_DATE" = 'null' OR to_date(l."REV_DATE", 'DD/MM/YYYY') > NOW())
-        AND (v."EFF_ST_DATE"='null' OR to_date(v."EFF_ST_DATE", 'DD/MM/YYYY') <= NOW())
       )
     ORDER BY
       "ISSUE_NO" DESC,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5624

An issue was reported (see [[WATER-5613](https://eaflood.atlassian.net/browse/WATER-5613)](https://eaflood.atlassian.net/browse/WATER-5613)) in which a licensee reported they could no longer see one of their licences in the external UI. The licence was not 'ended', so it was 'live' and should have been visible.

When we investigated, we found it was because of the `isCurrent:` property set in the `crm.document_header` record's `metadata` field.

For this licence, the import set it to false because the 'current' licence version started in the future. When the current date matched the licence version's start date, the licence would have become visible again.

This is a scenario, though rare, that we have had to deal with when migrating legacy functionality that the previous team had overlooked or decided to handle differently.

The fact that NALD considers the latest licence version to always be the 'CURR' one, even if it starts in the future, should mean the legacy import also considers it the 'current' licence version.

So, this change amends the logic that determines what the 'current' NALD licence version is, which in turn will ensure the flag remains `isCurrent: true` in the `crm.document_header` record's `metadata` field.

[WATER-5613]: https://eaflood.atlassian.net/browse/WATER-5613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ