### PR TITLE
One-off step 2 remove void rtn logs with no req id 

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -8,6 +8,7 @@ const db = require('./lib/connectors/db.js')
 const PermitJson = require('./lib/permit-json/permit-json.js')
 
 const CleanProcess = require('./modules/clean/process.js')
+const CleanReturnLogsProcess = require('./modules/clean-return-logs/process.js')
 const CompletionEmailProcess = require('./modules/completion-email/process.js')
 const EndDateCheckProcess = require('./modules/end-date-check/process.js')
 const EndDateTriggerProcess = require('./modules/end-date-trigger/process.js')
@@ -29,6 +30,12 @@ const ReferenceDataImportProcess = require('./modules/reference-data-import/proc
 
 async function clean (_request, h) {
   CleanProcess.go(true)
+
+  return h.response().code(204)
+}
+
+async function cleanReturnLogs (_request, h) {
+  CleanReturnLogsProcess.go(true)
 
   return h.response().code(204)
 }
@@ -211,6 +218,7 @@ async function _commitHash () {
 
 module.exports = {
   clean,
+  cleanReturnLogs,
   completionEmail,
   endDateCheck,
   endDateTrigger,

--- a/src/modules/clean-return-logs/process.js
+++ b/src/modules/clean-return-logs/process.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const db = require('../../lib/connectors/db.js')
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'clean-return-logs: complete')
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('clean-return-logs: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/clean-return-logs/process.js
+++ b/src/modules/clean-return-logs/process.js
@@ -9,6 +9,8 @@ async function go (log = false) {
   try {
     const startTime = currentTimeInNanoseconds()
 
+    await _clean()
+
     if (log) {
       calculateAndLogTimeTaken(startTime, 'clean-return-logs: complete')
     }
@@ -19,6 +21,100 @@ async function go (log = false) {
   }
 
   return messages
+}
+
+async function _clean () {
+  await db.query(`WITH no_return_requirement_logs AS (
+  SELECT
+    r.*
+  FROM
+    "returns"."returns" r
+  WHERE
+    r.return_requirement_id IS NULL
+),
+can_be_fixed_return_logs AS (
+  SELECT
+    nrrl.id
+  FROM
+    no_return_requirement_logs nrrl
+  INNER JOIN
+    water.licences l
+    ON
+      l.licence_ref = nrrl.licence_ref
+  INNER JOIN
+    water.return_versions rv
+    ON
+      rv.licence_id = l.licence_id
+  INNER JOIN
+    water.return_requirements rr
+    ON
+      rr.return_version_id = rv.return_version_id
+      AND rr.legacy_id::text = nrrl.return_requirement
+),
+deleted_licence_return_logs AS (
+  SELECT
+    nrrl.id
+  FROM
+    no_return_requirement_logs nrrl
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        water.licences l
+      WHERE
+        nrrl.licence_ref = l.licence_ref
+    )
+),
+combined_results AS (
+  SELECT
+    nrrl.id,
+    nrrl.return_id,
+    nrrl.licence_ref,
+    nrrl.start_date,
+    nrrl.end_date,
+    nrrl.received_date,
+    nrrl.status,
+    nrrl."source",
+    nrrl.created_at,
+    nrrl.return_requirement,
+    (CASE
+      WHEN cbfrl.id IS NOT NULL THEN
+        'can be fixed'
+      WHEN dlrl.id IS NOT NULL THEN
+        'licence deleted'
+      ELSE
+        'rtn req deleted'
+    END) AS reason_missing,
+    v.version_id,
+    v.user_id AS submitted_by,
+    v.nil_return
+  FROM
+    no_return_requirement_logs nrrl
+  LEFT JOIN
+    deleted_licence_return_logs dlrl
+    ON
+      dlrl.id = nrrl.id
+  LEFT JOIN
+    can_be_fixed_return_logs cbfrl
+    ON
+      cbfrl.id = nrrl.id
+  LEFT JOIN
+    "returns".versions v
+    ON
+      v.return_log_id = nrrl.id
+),
+no_submissions AS (
+  SELECT
+    cr.*
+  FROM
+    combined_results cr
+  WHERE
+    cr.version_id IS NULL
+)
+DELETE FROM "returns"."returns" r
+WHERE r.id IN (SELECT ns.id FROM no_submissions ns);
+  `)
 }
 
 module.exports = {

--- a/src/modules/import-job/lib/clean-return-logs.js
+++ b/src/modules/import-job/lib/clean-return-logs.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const CleanReturnLogsProcess = require('../../clean/process.js')
+
+const STEP_NAME = 'clean-return-logs'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await CleanReturnLogsProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -2,6 +2,7 @@
 
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 const CleanStep = require('./lib/clean.js')
+const CleanReturnLogsStep = require('./lib/clean-return-logs.js')
 const CompletionEmail = require('../completion-email/process.js')
 const EndDateCheckStep = require('./lib/end-date-check.js')
 const EndDateTriggerStep = require('./lib/end-date-trigger.js')
@@ -54,6 +55,9 @@ async function go () {
     steps.push(step)
 
     step = await EndDateTriggerStep.go()
+    steps.push(step)
+
+    step = await CleanReturnLogsStep.go()
     steps.push(step)
 
     await CompletionEmail.go(steps)

--- a/src/routes.js
+++ b/src/routes.js
@@ -80,6 +80,14 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/process/clean-return-logs',
+    handler: Controller.cleanReturnLogs,
+    config: {
+      auth: false
+    }
+  },
+  {
+    method: 'POST',
     path: '/process/completion-email',
     handler: Controller.completionEmail,
     config: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5676

In [Add voiding returns with deleted rtn reqs to step](https://github.com/DEFRA/water-abstraction-import/pull/1197), we added a step to mark as 'void' any return log where no matching return requirement could be found. This is because the return requirement was either deleted in NALD and subsequently deleted in WRLS. Or the licence itself has been deleted in NALD.

This shouldn't happen any more; we have protections in place for deleted licences with return submissions, and return versions and their requirements are handled by the service, not NALD.

With them now marked as 'void', it is easier to see the ones that have no return submission and safely delete them.

This change adds a one-off step to do that.