### PR TITLE
One-off step to sync imported lines to NALD

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -27,6 +27,7 @@ const LicencesImportProcess = require('./modules/licences-import/process.js')
 const ModLogsImportProcess = require('./modules/mod-logs-import/process.js')
 const PartyCrmV2ImportProcess = require('./modules/party-crm-v2-import/process.js')
 const ReferenceDataImportProcess = require('./modules/reference-data-import/process.js')
+const SyncNaldLinesProcess = require('./modules/sync-nald-lines/process.js')
 
 async function clean (_request, h) {
   CleanProcess.go(true)
@@ -196,6 +197,12 @@ function status (_request, _h) {
   return { status: 'alive' }
 }
 
+async function syncNaldLines (_request, h) {
+  SyncNaldLinesProcess.go(true)
+
+  return h.response().code(204)
+}
+
 async function _tagReference () {
   try {
     const { stdout, stderr } = await exec('git describe --always --tags')
@@ -238,5 +245,6 @@ module.exports = {
   modLogsImport,
   partyCrmV2Import,
   referenceDataImport,
-  status
+  status,
+  syncNaldLines
 }

--- a/src/modules/import-job/lib/sync-nald-lines.js
+++ b/src/modules/import-job/lib/sync-nald-lines.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { currentTimeInNanoseconds, durations } = require('../../../lib/general.js')
+const SyncNaldLinesProcess = require('../../sync-nald-lines/process.js')
+
+const STEP_NAME = 'sync-nald-lines'
+
+async function go () {
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: started`)
+
+  const step = { logTime: new Date(), name: STEP_NAME }
+
+  const startTime = currentTimeInNanoseconds()
+
+  step.messages = await SyncNaldLinesProcess.go(false)
+
+  const { timeTakenSs } = durations(startTime)
+
+  step.duration = timeTakenSs
+
+  global.GlobalNotifier.omg(`import-job.${STEP_NAME}: completed`)
+
+  return step
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/import-job/process.js
+++ b/src/modules/import-job/process.js
@@ -14,6 +14,7 @@ const LicencesImportStep = require('./lib/licences-import.js')
 const ModLogsImportStep = require('./lib/mod-logs-import.js')
 const PartyCrmV2ImportStep = require('./lib/party-crm-v2-import.js')
 const ReferenceDataImportStep = require('./lib/reference-data-import.js')
+const SyncNaldLinesStep = require('./lib/sync-nald-lines.js')
 
 async function go () {
   try {
@@ -58,6 +59,9 @@ async function go () {
     steps.push(step)
 
     step = await CleanReturnLogsStep.go()
+    steps.push(step)
+
+    step = await SyncNaldLinesStep.go()
     steps.push(step)
 
     await CompletionEmail.go(steps)

--- a/src/modules/sync-nald-lines/lib/already-run.js
+++ b/src/modules/sync-nald-lines/lib/already-run.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  const results = await db.query(`SELECT
+  application_state_id
+FROM
+  water.application_state a
+WHERE
+  a."key" = 'sync-nald-lines';
+  `)
+
+  return results.length > 0
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/sync-nald-lines/lib/record-run.js
+++ b/src/modules/sync-nald-lines/lib/record-run.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+const { generateUUID } = require('../../../lib/general.js')
+
+async function go () {
+  const params = [generateUUID(), 'sync-nald-lines', {}]
+  await db.query(`INSERT INTO water.application_state (
+  application_state_id,
+  "key",
+  "data",
+  date_created,
+  date_updated
+)
+VALUES (
+  $1,
+  $2,
+  $3,
+  NOW(),
+  NOW()
+);
+  `, params)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/sync-nald-lines/lib/round-quantities.js
+++ b/src/modules/sync-nald-lines/lib/round-quantities.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go () {
+  await db.query(`UPDATE "returns".lines l
+SET
+  quantity = ROUND(quantity, 6)
+WHERE
+  l.quantity IS NOT NULL
+  AND l.quantity != ROUND(l.quantity, 6);`)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/sync-nald-lines/lib/sync-mismatched-quantities.js
+++ b/src/modules/sync-nald-lines/lib/sync-mismatched-quantities.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const db = require('../../../lib/connectors/db.js')
+
+async function go (regionCode) {
+  const params = [regionCode]
+  const query = `-- Grab all the lines created by the import, past or present for a specific region.
+-- Means the overal step time will be longer, but reduces the risk of a time out
+-- as the query does take some time to run.
+WITH imported_return_lines AS (
+  SELECT
+    r.id AS return_log_id,
+    r.licence_ref,
+    (SPLIT_PART(rr.external_id, ':', 1)) AS region_code,
+    rr.legacy_id::text AS format_id,
+    rr.reporting_frequency,
+    l.line_id,
+    l.start_date,
+    l.end_date,
+    l.quantity
+  FROM
+    "returns".lines l
+  INNER JOIN
+    "returns".versions v
+    ON
+      v.version_id = l.version_id
+  INNER JOIN
+    "returns"."returns" r
+    ON
+      r.id = v.return_log_id
+  INNER JOIN
+    water.return_requirements rr
+    ON
+      rr.return_requirement_id = r.return_requirement_id
+  WHERE
+    v.user_type = 'system'
+    AND v.nil_return = FALSE
+    AND SPLIT_PART(rr.external_id, ':', 1) = $1
+),
+date_bounds AS (
+  -- OPTIMIZATION: Calculate date bounds to trim down the huge NALD source tables
+  SELECT
+    MIN(irl.start_date) AS min_date,
+    MAX(irl.end_date) AS max_date
+  FROM imported_return_lines irl
+),
+old_return_lines AS (
+  SELECT
+    1 AS line_source,
+    nrl."FGAC_REGION_CODE" AS region_code,
+    nrl."ARFL_ARTY_ID" AS format_id,
+    to_date(nrl."ARFL_DATE_FROM", 'DD/MM/YYYY') AS from_date,
+    to_date(nrl."RET_DATE", 'DD/MM/YYYY') AS return_date,
+    nrl."RET_QTY"::decimal AS quantity
+  FROM
+    public."NALD_RET_LINES" nrl
+  INNER JOIN (
+    SELECT DISTINCT region_code, format_id FROM imported_return_lines
+  ) wr ON wr.region_code = nrl."FGAC_REGION_CODE" AND wr.format_id = nrl."ARFL_ARTY_ID"
+  CROSS JOIN date_bounds db
+  WHERE
+    nrl."RET_QTY" IS NOT NULL
+    AND nrl."RET_QTY" <> ''
+    AND nrl."RET_QTY" <> 'null'
+    -- OPTIMIZATION: Filter dates immediately during table read
+    AND to_date(nrl."RET_DATE", 'DD/MM/YYYY') BETWEEN db.min_date AND db.max_date
+),
+extract_return_lines AS (
+  SELECT
+    2 AS line_source,
+    nrl."FGAC_REGION_CODE" AS region_code,
+    nrl."ARFL_ARTY_ID" AS format_id,
+    to_date(nrl."ARFL_DATE_FROM", 'YYYYMMDDHH24MISS') AS from_date,
+    to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') AS return_date,
+    nrl."RET_QTY"::decimal AS quantity
+  FROM
+    "import"."NALD_RET_LINES" nrl
+  INNER JOIN (
+    SELECT DISTINCT region_code, format_id FROM imported_return_lines
+  ) wr ON wr.region_code = nrl."FGAC_REGION_CODE" AND wr.format_id = nrl."ARFL_ARTY_ID"
+  CROSS JOIN date_bounds db
+  WHERE
+    nrl."RET_QTY" IS NOT NULL
+    AND nrl."RET_QTY" <> ''
+    AND nrl."RET_QTY" <> 'null'
+    -- OPTIMIZATION: Filter dates immediately during table read
+    AND to_date(nrl."RET_DATE", 'YYYYMMDDHH24MISS') BETWEEN db.min_date AND db.max_date
+),
+-- This is where we deal with any duplicates in the two data sources. The four fields
+-- we're distinct on give us unique records per dataset. If we do have a dupe across
+-- them, the final order by line_source means we only return one of the records (the
+-- one from the old lines data set)
+--
+-- A note about from_date. We found instances of duplicate NALD lines with the same
+-- region, format ID and return date. The difference between the two lines was the
+-- ARFL_DATE_FROM date. Any NALD reporting of the values will have included both, so
+-- by including from_date in our DISTINCT ON, we ensure we also include both when
+-- we come to sum the NALD lines.
+all_nald_lines AS (
+  SELECT DISTINCT ON (rl.region_code, rl.format_id, rl.return_date, rl.from_date)
+    rl.region_code,
+    rl.format_id,
+    rl.return_date,
+    rl.quantity
+  FROM (
+    SELECT
+      orl.*
+    FROM
+      old_return_lines orl
+    UNION ALL
+    SELECT
+      erl.*
+    FROM
+      extract_return_lines erl
+  ) rl
+  ORDER BY
+    rl.region_code,
+    rl.format_id,
+    rl.return_date,
+    rl.from_date,
+    rl.line_source
+),
+-- In WRLS, a weekly return's lines will just be for a week, a monthly for a month. In
+-- NALD a weekly or a monthly can be represented as daily lines. So, to get the NALD
+-- quantity we have to sum the NALD lines that fall between the WRLS line's start and
+-- end date.
+-- So, we get one result per WRLS line, but the NALD quantity is the sum of the
+-- matching lines. Without the grouping we'd get one result per WRLS and NALD
+-- combination.
+line_quantities AS (
+  SELECT
+    anl.region_code,
+    anl.format_id,
+    irl.line_id,
+    irl.start_date,
+    irl.end_date,
+    irl.quantity,
+    SUM(anl.quantity) AS nald_quantity
+  FROM
+    imported_return_lines irl
+  INNER JOIN
+    all_nald_lines anl
+    ON anl.region_code = irl.region_code
+    AND anl.format_id = irl.format_id
+    AND anl.return_date BETWEEN irl.start_date AND irl.end_date
+  GROUP BY
+    anl.region_code,
+    anl.format_id,
+    irl.line_id,
+    irl.start_date,
+    irl.end_date,
+    irl.quantity
+),
+mismatched_lines AS (
+  SELECT
+    lq.line_id,
+    lq.nald_quantity
+  FROM
+    line_quantities lq
+  WHERE
+    lq.quantity <> lq.nald_quantity
+)
+UPDATE "returns".lines l
+SET
+  quantity = ml.nald_quantity
+FROM
+  mismatched_lines ml
+WHERE
+  ml.line_id = l.line_id;
+  `
+
+  await db.query(query, params)
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/sync-nald-lines/process.js
+++ b/src/modules/sync-nald-lines/process.js
@@ -1,23 +1,52 @@
 'use strict'
 
+const AlreadyRun = require('./lib/already-run.js')
+const RecordRun = require('./lib/record-run.js')
 const RoundQuantities = require('./lib/round-quantities.js')
+const SyncMismatchedQuantities = require('./lib/sync-mismatched-quantities.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
   const messages = []
 
+  let currentRegion
+
   try {
     const startTime = currentTimeInNanoseconds()
+
+    // Checking the lines for mismatches between NALD and WRLS is an intensive process, even if none are found. So,
+    // unlike previous one-off fixes, we literally only want this process to run once.
+    // So, we make use of a now defunct table. On the first run nothing will exist so the process will be allowed to
+    // run. When finished we create a record in the table. On subsequent runs the record existing will cause the process
+    // to be skipped.
+    const hasAlreadyRun = await AlreadyRun.go()
+
+    if (hasAlreadyRun) {
+      global.GlobalNotifier.omg('sync-nald-lines: skipped')
+      messages.push('Skipped because they have already been synced')
+
+      return messages
+    }
 
     // Rounding quantities to 6 decimal places fixes those previously imported that fell foul of JavaScript's issues
     // with floating point numbers. This will avoid them being flagged as a mismatch in the next step.
     await RoundQuantities.go()
 
+    // Sync any mismatches between NALD and imported WRLS lines one region at a time
+    const regions = ['1', '2', '3', '4', '5', '6', '7', '8']
+
+    for (const region of regions) {
+      currentRegion = region
+      await SyncMismatchedQuantities.go(region)
+    }
+
+    await RecordRun.go()
+
     if (log) {
       calculateAndLogTimeTaken(startTime, 'sync-nald-lines: complete')
     }
   } catch (error) {
-    global.GlobalNotifier.omfg('sync-nald-lines: errored', {}, error)
+    global.GlobalNotifier.omfg('sync-nald-lines: errored', { currentRegion }, error)
 
     messages.push(error.message)
   }

--- a/src/modules/sync-nald-lines/process.js
+++ b/src/modules/sync-nald-lines/process.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
+
+async function go (log = false) {
+  const messages = []
+
+  try {
+    const startTime = currentTimeInNanoseconds()
+
+    if (log) {
+      calculateAndLogTimeTaken(startTime, 'sync-nald-lines: complete')
+    }
+  } catch (error) {
+    global.GlobalNotifier.omfg('sync-nald-lines: errored', {}, error)
+
+    messages.push(error.message)
+  }
+
+  return messages
+}
+
+module.exports = {
+  go
+}

--- a/src/modules/sync-nald-lines/process.js
+++ b/src/modules/sync-nald-lines/process.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const RoundQuantities = require('./lib/round-quantities.js')
 const { currentTimeInNanoseconds, calculateAndLogTimeTaken } = require('../../lib/general.js')
 
 async function go (log = false) {
@@ -7,6 +8,10 @@ async function go (log = false) {
 
   try {
     const startTime = currentTimeInNanoseconds()
+
+    // Rounding quantities to 6 decimal places fixes those previously imported that fell foul of JavaScript's issues
+    // with floating point numbers. This will avoid them being flagged as a mismatch in the next step.
+    await RoundQuantities.go()
 
     if (log) {
       calculateAndLogTimeTaken(startTime, 'sync-nald-lines: complete')

--- a/src/routes.js
+++ b/src/routes.js
@@ -189,5 +189,13 @@ module.exports = [
     config: {
       auth: false
     }
+  },
+  {
+    method: 'POST',
+    path: '/process/sync-nald-lines',
+    handler: Controller.syncNaldLines,
+    config: {
+      auth: false
+    }
   }
 ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5738

All the tranche one (T1) 'fixes' we put in place ensured each licence's return log history was complete and aligned with its return version data. Part of this was correcting the return versions to align with the submission data in NALD.

With those in place, we were then able to assign the NALD quantities to their WRLS lines

We've then carried out another comparison of NALD to WRLS. It has highlighted that there are still discrepancies between the two systems.

**Period start for weekly return logs**

This is where the import did not pick up NALD data because it was outside the return log's period.

For example, imagine the return log period is 2008-04-01 to 2009-03-31, and it is weekly. When the fix ran, having determined the return log is missing and added it, now needs to assign NALD return lines to it.

So, it looked for all NALD data between 2009-04-01 to 2010-03-31. But with weekly, you have to consider _all_ days in the week. In WRLS, if a week's Saturday falls inside the return log's period, then that is the return log it is assigned to.

The first Saturday in this example is 2009-04-04. This means all returns data between 2009-03-29 to 2009-04-04 is included in that first week's total, even if some of the days are outside the period.

This wouldn't be a problem if NALD returns data was held consistently. Instead, when 'weekly', the end date is not always consistent (it can be Friday or Saturday). More commonly, it won't be held as a week. Instead, the data may be daily or monthly.

This means our first tranche of fixes missed NALD return lines for weekly returns if they were dated before the start of the associated return log.

**Duplicates in old and extract data**

The nightly NALD data extract we receive does not include older return lines. It caused problems for the FME job due to the volume of data being exported if they were all included. Therefore, it was decided to extract them only from a specific date.

We therefore asked the FME team to provide us with a one-off extract of the excluded lines.

When the import fixes run, they search both datasets for NALD return lines. What we failed to consider is whether there is any crossover between the two. Unfortunately, there is, which means the import has processed duplicate return lines, leading to double the NALD quantity being recorded in WRLS.

**JavaScript decimals**

The comparison has also shown that we've overlooked how JavaScript handles decimals, again! (See [WATER-5394](https://eaflood.atlassian.net/browse/WATER-5394), for a detailed explanation of this)

This has resulted in minor differences between NALD and WRLS quantities. for example, WRLS `262.98400000000004` vs NALD `262.984`.

The example is taken from a licence, which has a weekly return for 2000-04-01 to 2001-03-31. For one week in May, NALD has the following daily entries

- 36.804
- 38.488
- 40.864
- 40.768
- 41.112
- 32.432
- 32.516

The total is 262.984, unless your JavaScript!

-----

So, this change adds a new step to sync the lines we created based on NALD with the NALD data. Any lines created as a result of a submission in WRLS are excluded.

[WATER-5394]: https://eaflood.atlassian.net/browse/WATER-5394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ