### PR TITLE
Update updated_at in nald-sync-lines step

### DIFF
--- a/src/modules/sync-nald-lines/lib/sync-mismatched-quantities.js
+++ b/src/modules/sync-nald-lines/lib/sync-mismatched-quantities.js
@@ -162,7 +162,8 @@ mismatched_lines AS (
 )
 UPDATE "returns".lines l
 SET
-  quantity = ml.nald_quantity
+  quantity = ml.nald_quantity,
+  updated_at = NOW()
 FROM
   mismatched_lines ml
 WHERE


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5738

We added the [One-off step to sync imported lines to NALD](https://github.com/DEFRA/water-abstraction-import/issues/1212).

This ensures that the lines imported into WRLS from NALD match the quantities in NALD.

But we've remembered that the downstream RDP service relies on records `updated_at/date_updated` fields to change for it to trigger an update on their side (they use deltas rather than a full refresh).

So, we ensure the `updated_at` field is updated when we sync the quantities to NALD.